### PR TITLE
Load careers data from markdown files similar to blog posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1410,7 +1410,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1897,25 +1896,6 @@
       "integrity": "sha512-Ok3w+Pc9SNdNVEEJUUx9OvNZHwFyoKS0N+ceytfUB3wh/HxhRkOEc9dO8KR9AjfpFI82/Wg258GRDs1/8SFgKQ==",
       "dev": true,
       "hasInstallScript": true,
-      "dependencies": {
-        "esbuild-android-arm64": "0.13.7",
-        "esbuild-darwin-64": "0.13.7",
-        "esbuild-darwin-arm64": "0.13.7",
-        "esbuild-freebsd-64": "0.13.7",
-        "esbuild-freebsd-arm64": "0.13.7",
-        "esbuild-linux-32": "0.13.7",
-        "esbuild-linux-64": "0.13.7",
-        "esbuild-linux-arm": "0.13.7",
-        "esbuild-linux-arm64": "0.13.7",
-        "esbuild-linux-mips64le": "0.13.7",
-        "esbuild-linux-ppc64le": "0.13.7",
-        "esbuild-netbsd-64": "0.13.7",
-        "esbuild-openbsd-64": "0.13.7",
-        "esbuild-sunos-64": "0.13.7",
-        "esbuild-windows-32": "0.13.7",
-        "esbuild-windows-64": "0.13.7",
-        "esbuild-windows-arm64": "0.13.7"
-      },
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5087,9 +5067,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
       "integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.3.2"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -5751,25 +5728,6 @@
       "integrity": "sha512-ofwgH4ITPXhkMo2AM39oXpSe5KIyWjxicdqYVy+tLa1lMgxzPCKwaepcrSRtYbgTUMXwquxB1C3xQYpUNaPAFA==",
       "dev": true,
       "hasInstallScript": true,
-      "dependencies": {
-        "esbuild-android-arm64": "0.14.5",
-        "esbuild-darwin-64": "0.14.5",
-        "esbuild-darwin-arm64": "0.14.5",
-        "esbuild-freebsd-64": "0.14.5",
-        "esbuild-freebsd-arm64": "0.14.5",
-        "esbuild-linux-32": "0.14.5",
-        "esbuild-linux-64": "0.14.5",
-        "esbuild-linux-arm": "0.14.5",
-        "esbuild-linux-arm64": "0.14.5",
-        "esbuild-linux-mips64le": "0.14.5",
-        "esbuild-linux-ppc64le": "0.14.5",
-        "esbuild-netbsd-64": "0.14.5",
-        "esbuild-openbsd-64": "0.14.5",
-        "esbuild-sunos-64": "0.14.5",
-        "esbuild-windows-32": "0.14.5",
-        "esbuild-windows-64": "0.14.5",
-        "esbuild-windows-arm64": "0.14.5"
-      },
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6347,7 +6305,6 @@
       "dev": true,
       "dependencies": {
         "esbuild": "^0.13.2",
-        "fsevents": "~2.3.2",
         "postcss": "^8.3.8",
         "resolve": "^1.20.0",
         "rollup": "^2.57.0"

--- a/src/careers/design-lead.md
+++ b/src/careers/design-lead.md
@@ -1,0 +1,10 @@
+---
+title: 'Design Lead'
+description: 'Full Time • Remote • United States, Canada'
+publishDate: 'January 12, 2022'
+department: 'Design'
+salary: '$$-$$$'
+lang: 'en'
+---
+
+More details coming soon...To apply or just learn more, reach out to jobs@astro.build.

--- a/src/careers/index.ts
+++ b/src/careers/index.ts
@@ -1,0 +1,31 @@
+import { parse, isBefore } from 'date-fns';
+
+export async function getAllRoles() {
+  const files = await import.meta.glob("./**/*.md");
+  const roles = (
+    await Promise.all(
+      Object.values(files).map((importFile: any, index) =>
+        importFile().then((res) => {
+          const { title, salary, status, description, publishDate, department } = res.frontmatter;
+          const href = Object.keys(files)
+            [index].replace(/^\./, "/careers")
+                .replace(/\.md$/, "");
+          return {
+            title,
+            salary,
+            status,
+            description,
+            department,
+            publishDate: parse(publishDate, "MMMM d, yyyy", new Date()),
+            href,
+          };
+        })
+      )
+    )
+  ).sort((a, b) => {
+    if (isBefore(a.publishDate, b.publishDate)) return 1;
+    if (isBefore(b.publishDate, a.publishDate)) return -1;
+    return 0;
+  });
+  return roles;
+}

--- a/src/careers/software-engineer-devtools.md
+++ b/src/careers/software-engineer-devtools.md
@@ -1,0 +1,10 @@
+---
+title: 'Software Engineer - Devtools'
+description: 'Full Time • Remote • United States, Canada'
+publishDate: 'January 12, 2022'
+department: 'Engineering'
+salary: '$$$'
+lang: 'en'
+---
+
+More details coming soon...To apply or just learn more, reach out to jobs@astro.build.

--- a/src/careers/software-engineer-frontend.md
+++ b/src/careers/software-engineer-frontend.md
@@ -1,0 +1,10 @@
+---
+title: 'Software Engineer - Frontend'
+description: 'Full Time • Remote • United States, Canada'
+publishDate: 'January 12, 2022'
+department: 'Engineering'
+salary: '$$$'
+lang: 'en'
+---
+
+More details coming soon...To apply or just learn more, reach out to jobs@astro.build.

--- a/src/careers/software-engineer-full-stack.md
+++ b/src/careers/software-engineer-full-stack.md
@@ -1,0 +1,10 @@
+---
+title: 'Software Engineer - Full Stack'
+description: 'Full Time • Remote • United States, Canada'
+publishDate: 'January 12, 2022'
+department: 'Engineering'
+salary: '$$$'
+lang: 'en'
+---
+
+More details coming soon...To apply or just learn more, reach out to jobs@astro.build.

--- a/src/components/careers/Card.astro
+++ b/src/components/careers/Card.astro
@@ -1,14 +1,23 @@
 ---
+import DateTime from '../../components/Date.astro';
 import { smartypants } from 'smartypants';
 
-const { career = {}, variant = 'summary' } = Astro.props;
+const { role = {}, variant = 'summary' } = Astro.props;
 const Title = variant === 'summary' ? 'h2' : 'h1';
 ---
 
 <div class="wrapper">
-    <Title class="title text-gradient">{smartypants(career.title, 1)}</Title>
+    <Title class="title text-gradient">{smartypants(role.title, 1)}</Title>
     <div class="description">
-        <p>{career.description}</p>
+        <p>{role.description}</p>
+    </div>
+    <div class="salary">
+        <h3>Salary</h3>
+        <p>{role.salary}</p>
+    </div>
+    <div class="date">
+        <h3>Listed on</h3>
+        <p><DateTime value={role.publishDate} /></p>
     </div>
 </div>
 
@@ -43,25 +52,14 @@ h2.title {
     max-width: 48ch;
     color: #999;
 }
-.post > div {
-    margin-top: 2em;
-}
-.authors {
+.salary {
     flex-grow: 2;
     width: 100%;
 }
 @media (min-width: 52rem) {
-    .authors {
+    .salary {
         width: initial;
     }
-}
-.authors ul {
-    display: flex;
-    flex-flow: column nowrap;
-    list-style: none;
-}
-.authors ul > li + li {
-    margin-top: 0.5rem;
 }
 .date {
     flex-grow: 1;
@@ -76,11 +74,11 @@ h3 {
     text-transform: uppercase;
     letter-spacing: 1px;
 }
-.date, .authors {
-    margin-top: 2rem;
+.date, .salary {
+    margin-top: 2em;
     font-size: var(--size-400);
 }
-:is(.date, .authors) p {
+:is(.date, .salary) p {
     margin: 0;
     font-size: inherit;
     height: 2rem;

--- a/src/components/careers/Outro.astro
+++ b/src/components/careers/Outro.astro
@@ -1,0 +1,53 @@
+---
+import { Sprite } from 'astro-icon';
+
+const { tweet: { title, href } } = Astro.props;
+---
+
+<section class="outro">
+    <div class="container">
+        <div class="content">
+            <a class="return" href="/careers">
+                <Sprite pack="mdi" name="arrow-left" size="32" aria-hidden="true" />
+                <span>Return to Careers</span>
+            </a>
+            <a class="share-on-twitter" title="Share on Twitter" href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(href)}&via=astrodotbuild`}>
+                <Sprite pack="mdi" name="twitter" size="16" />
+                <span>Share</span>
+            </a>
+        </div>
+    </div>
+</section>
+
+<style>
+    .outro {
+        padding: 8rem 0 2rem;
+        width: 100%;
+    }
+    .content {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        max-width: 48rem;
+        padding: 0;
+        margin: 0 auto;
+    }
+    .return {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: var(--size-600);
+        font-family: var(--font-display);
+        color: var(--color-purple);
+        gap: 0.25em;
+    }
+    .share-on-twitter {
+        background: var(--color-blue);
+        color: white;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.25em 0.5em;
+        gap: 0.25em;
+    }
+</style>

--- a/src/layouts/Role.astro
+++ b/src/layouts/Role.astro
@@ -1,0 +1,85 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import BaseLayout from '../components/BaseLayout.astro';
+import Nav from '../components/Nav.astro';
+import Wrapper from '../components/Wrapper.astro';
+import Footer from '../components/Footer.astro';
+import Card from '../components/careers/Card.astro';
+import Outro from '../components/careers/Outro.astro';
+import Panel from '../components/Panel.astro';
+
+let { content: { title, salary, publishDate, description, department } } = Astro.props;
+const { canonicalURL } = Astro.request;
+const meta = {
+	title: `${title} | Astro`,
+	description,
+	canonicalURL
+}
+---
+
+<html lang="en">
+
+<head>
+	<BaseHead {...meta} />
+	<style>
+		:root {
+			scroll-padding-top: 10rem;
+			background: var(--color-tan);
+		}
+		:global(#content) {
+			min-height: 100vh;
+			padding: 4rem 0;
+		}
+		#article {
+			max-width: 48rem;
+			padding-bottom: 2rem;
+			display: flex;
+			flex-flow: column nowrap;
+			font-family: var(--font-body);
+			font-size: var(--size-500);
+			line-height: 1.3;
+			color: var(--color-midnight);
+			z-index: 1;
+		}
+		:where(#article > :global(* + *)) {
+			margin-top: 1em;
+		}
+		#article :is(h2):not([class]) {
+			margin-top: 3em;
+		}
+		#article > :global(.note:last-child) {
+			margin-top: 8rem;
+		}
+		.hero {
+			display: flex;
+			flex-flow: row wrap;
+			padding: 3rem 0 2rem;
+			max-width: 100%;
+		}
+	</style>
+</head>
+
+<body>
+	<BaseLayout wrapper={Wrapper}>
+		<Nav slot="nav" />
+
+		<Panel size="md" background="white linear-gradient(180deg, #E5DAEE 0%, rgba(255, 255, 255, 0) 24rem)">
+			<div id="article">
+				<header class="hero">
+					<Card role={{ title, salary, description, department, publishDate }} variant="hero" />
+				</header>
+
+				<hr>
+
+				<slot />
+
+				<Outro tweet={{ title, href: canonicalURL.toString() }} />
+			</div>
+		</Panel>
+
+
+		<Footer slot="footer" />
+	</BaseLayout>
+</body>
+
+</html>

--- a/src/pages/careers/[...slug].astro
+++ b/src/pages/careers/[...slug].astro
@@ -1,0 +1,22 @@
+---
+import Role from '../../layouts/Role.astro';
+import { getAllRoles } from '../../careers';
+
+export async function getStaticPaths() {
+    const roles = await getAllRoles();
+
+    return roles.map((r) => {
+        return {
+            params: { slug: r.href.replace('/careers/', '') },
+            props: { role: r },
+        }
+    });
+}
+
+const role = Astro.props.role;
+const { default: Content } = await import(`/src/careers/${role.href.replace('/careers/', '')}.md`);
+---
+
+<Role content={role}>
+	<Content />
+</Role>

--- a/src/pages/careers/index.astro
+++ b/src/pages/careers/index.astro
@@ -1,6 +1,6 @@
 ---
-import Page from '../layouts/Page.astro';
-import Card from '../components/careers/Card.astro';
+import Page from '../../layouts/Page.astro';
+import Card from '../../components/careers/Card.astro';
 
 const posts = [{
   href: 'mailto:jobs@astro.build',

--- a/src/pages/careers/index.astro
+++ b/src/pages/careers/index.astro
@@ -1,24 +1,26 @@
 ---
 import Page from '../../layouts/Page.astro';
 import Card from '../../components/careers/Card.astro';
+import { getAllRoles } from '../../careers';
 
-const posts = [{
-  href: 'mailto:jobs@astro.build',
-  title: 'Software Engineer - Devtools / Astro Core',
-  description: 'Full Time • Remote • United States, Canada'
-},  {
-  href: 'mailto:jobs@astro.build',
-  title: 'Software Engineer - Frontend',
-  description: 'Full Time • Remote • United States, Canada'
-}, {
-  href: 'mailto:jobs@astro.build',
-  title: 'Software Engineer - Full Stack',
-  description: 'Full Time • Remote • United States, Canada'
-}, {
-  href: 'mailto:jobs@astro.build',
-  title: 'Design Lead',
-  description: 'Full Time • Remote • United States, Canada'
-}]
+const roles = await getAllRoles();
+
+//   href: 'mailto:jobs@astro.build',
+//   title: 'Software Engineer - Devtools / Astro Core',
+//   description: 'Full Time • Remote • United States, Canada'
+// },  {
+//   href: 'mailto:jobs@astro.build',
+//   title: 'Software Engineer - Frontend',
+//   description: 'Full Time • Remote • United States, Canada'
+// }, {
+//   href: 'mailto:jobs@astro.build',
+//   title: 'Software Engineer - Full Stack',
+//   description: 'Full Time • Remote • United States, Canada'
+// }, {
+//   href: 'mailto:jobs@astro.build',
+//   title: 'Design Lead',
+//   description: 'Full Time • Remote • United States, Canada'
+// }]
 ---
 
 <Page title="Careers">
@@ -31,12 +33,12 @@ const posts = [{
         <p>Join Astro and help make the web accessible to everyone. We are currently hiring for the following positions. To apply or just learn more, reach out to <a href="mailto:jobs@astro.build">jobs@astro.build.</a></p>
     </section>
 
-    <ul role="list" class="posts">
-        {posts.map(post => {
+    <ul role="list" class="roles">
+        {roles.map(role => {
             return (
-                <li class="post">
-                    <a class="overlay" href={post.href}></a>
-                    <Card career={post} variant="summary" />
+                <li class="role">
+                    <a class="overlay" href={role.href}></a>
+                    <Card role={role} variant="summary" />
                 </li>
             )
         })}
@@ -64,7 +66,7 @@ const posts = [{
         --fill: var(--gradient-pop-1);
         font-size: var(--size-900);
     }
-    .posts {
+    .roles {
         width: 100%;
         max-width: 64rem;
         padding: 2rem;
@@ -76,10 +78,10 @@ const posts = [{
         line-height: 1.3;
         color: var(--color-midnight);
     }
-    .post + .post {
+    .role + .role {
         margin-top: 1rem;
     }
-    .post {
+    .role {
         position: relative;
         display: flex;
         flex-flow: row wrap;
@@ -94,14 +96,14 @@ const posts = [{
         line-height: 1.3;
         color: var(--color-midnight);
     }
-    .post:hover,
-    .post:focus-within {
+    .role:hover,
+    .role:focus-within {
         background: linear-gradient(to top, var(--color-dawn), white);
     }
-    :is(.post:hover, .post:focus-within) .title {
+    :is(.role:hover, .role:focus-within) .title {
         --fill: var(--gradient-pop-1);
     }
-    .post :global(a) {
+    .role :global(a) {
         z-index: 1;
     }
     .overlay {


### PR DESCRIPTION
I submitted this already but it broke the build so I started over with a new fork and branch and it built locally just fine so I am submitting this PR in hopes that it will deploy a preview successfully. I thought it would be helpful to pull in Career Data from Markdown files so that when the job details are ready to post, all someone would have to do is update those files. Based on job posting requirements in the discord I added salary to the front matter. 

Here is a screenshot of the updated careers page:
<img width="1077" alt="Screen Shot 2022-01-18 at 1 57 42 PM" src="https://user-images.githubusercontent.com/6471857/150017529-9e869d29-711e-4e46-9b84-6f881857e960.png">

And another for an individual role:
<img width="1066" alt="Screen Shot 2022-01-18 at 1 58 01 PM" src="https://user-images.githubusercontent.com/6471857/150017560-848e46b7-70f2-4a06-b34c-05829f3f9bf3.png">

It would make sense as the organization grows to separate the career pages by department so I also set up a department prop.

I'd be happy to make any changes necessary. Thanks! 