### PR TITLE
Disabling the hero background grid animation for Firefox

### DIFF
--- a/src/components/landing/Grid.astro
+++ b/src/components/landing/Grid.astro
@@ -56,6 +56,12 @@ const { class: className } = Astro.props;
     animation: move var(--time) infinite linear;
 }
 
+@-moz-document url-prefix() {
+    .line {
+        animation-play-state: paused;
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .line {
         animation-play-state: paused;

--- a/src/components/landing/Grid.astro
+++ b/src/components/landing/Grid.astro
@@ -56,7 +56,8 @@ const { class: className } = Astro.props;
     animation: move var(--time) infinite linear;
 }
 
-@-moz-document url-prefix() {
+/* Firefox tweaks */
+@supports (-moz-appearance: none) {
     .line {
         animation-play-state: paused;
     }


### PR DESCRIPTION
Firefox really chokes on the background grid animation, possibly related to [this](https://bugzilla.mozilla.org/show_bug.cgi?id=739176) older Gecko issue

Let's just disable the animation in Firefox, I'd hate to change the design here - the transforms and blur filters don't seem to be a problem without the animation