### PR TITLE
Add `/config` shortlink

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -4,3 +4,4 @@
 /v0.21          /blog/astro-021-release/  301
 /releases/:v    https://github.com/withastro/astro/releases/tag/astro@:v  301
 /issues         https://github.com/withastro/astro/issues/new/choose
+/config         https://docs.astro.build/reference/configuration-reference 301


### PR DESCRIPTION
Adds shortlink for https://astro.build/config

This will be paired with https://github.com/withastro/astro/pull/2803 to make finding the Astro configuration reference much easier.