### PR TITLE
Adding redirect for Astro.resolve() migration docs

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,7 +1,8 @@
 # Netlify Redirects
-/chat           https://discord.gg/grF4GTXXYm
-/play/*         https://play.astro.build/play/:splat  200
-/v0.21          /blog/astro-021-release/  301
-/releases/:v    https://github.com/withastro/astro/releases/tag/astro@:v  301
-/issues         https://github.com/withastro/astro/issues/new/choose
-/config         https://docs.astro.build/reference/configuration-reference 301
+/chat                   https://discord.gg/grF4GTXXYm
+/play/*                 https://play.astro.build/play/:splat  200
+/v0.21                  /blog/astro-021-release/  301
+/releases/:v            https://github.com/withastro/astro/releases/tag/astro@:v  301
+/issues                 https://github.com/withastro/astro/issues/new/choose
+/config                 https://docs.astro.build/reference/configuration-reference 301
+/deprecated/resolve     https://docs.astro.build/en/migrate/#deprecated-astroresolve 301


### PR DESCRIPTION
[Related PR](https://github.com/withastro/astro/pull/2856) using the redirect for `Astro.resolve()` deprecation warnings 