### PR TITLE
migrating blog posts to use @tailwindcss/typography

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ packages:
       uvu: 0.5.3
     dev: true
 
-  /@astrojs/language-server/0.13.2:
-    resolution: {integrity: sha512-4YM4hM02ILvvsSQljAlwLY7OWymlhbikY7O/gsZqELVGMXixemA6dI3GTr2K6duU4ktPBJ3JexuU/OFyb5jvtQ==}
+  /@astrojs/language-server/0.13.3:
+    resolution: {integrity: sha512-i+m49XGg52LBDsi+zT5Wo9uhundfWHdA2uzC0xMn5AOmQXXzlDgSo29/SFRsHx3shT3kZ5Uf/Jkm6BNed/bs3g==}
     hasBin: true
     dependencies:
       '@astrojs/svelte-language-integration': 0.1.2_typescript@4.6.3
@@ -133,8 +133,8 @@ packages:
   /@astrojs/svelte-language-integration/0.1.2_typescript@4.6.3:
     resolution: {integrity: sha512-O6LYL9igYSzxCxDHYWUqEquuuUlMG0UL1SliZ7rF/vx9GwU71TCpsRe4iHZ0bcemM5ju9ihoTzGCmLXzYrNw0g==}
     dependencies:
-      svelte: 3.46.4
-      svelte2tsx: 0.5.6_svelte@3.46.4+typescript@4.6.3
+      svelte: 3.46.5
+      svelte2tsx: 0.5.6_svelte@3.46.5+typescript@4.6.3
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -732,7 +732,7 @@ packages:
     hasBin: true
     dependencies:
       '@astrojs/compiler': 0.13.1
-      '@astrojs/language-server': 0.13.2
+      '@astrojs/language-server': 0.13.3
       '@astrojs/markdown-remark': 0.7.0
       '@astrojs/prism': 0.4.1
       '@astrojs/webapi': 0.11.0
@@ -766,7 +766,7 @@ packages:
       parse5: 6.0.1
       path-to-regexp: 6.2.0
       postcss: 8.4.12
-      postcss-load-config: 3.1.3
+      postcss-load-config: 3.1.4_postcss@8.4.12
       preferred-pm: 3.0.3
       prismjs: 1.27.0
       prompts: 2.4.2
@@ -785,7 +785,7 @@ packages:
       strip-ansi: 7.0.1
       supports-esm: 1.0.0
       tsconfig-resolver: 3.0.1
-      vite: 2.8.6
+      vite: 2.9.0
       yargs-parser: 21.0.1
       zod: 3.14.3
     transitivePeerDependencies:
@@ -810,7 +810,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.20.2
-      caniuse-lite: 1.0.30001320
+      caniuse-lite: 1.0.30001323
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -911,8 +911,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001320
-      electron-to-chromium: 1.4.96
+      caniuse-lite: 1.0.30001323
+      electron-to-chromium: 1.4.103
       escalade: 3.1.1
       node-releases: 2.0.2
       picocolors: 1.0.0
@@ -972,8 +972,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite/1.0.30001320:
-    resolution: {integrity: sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA==}
+  /caniuse-lite/1.0.30001323:
+    resolution: {integrity: sha512-e4BF2RlCVELKx8+RmklSEIVub1TWrmdhvA5kEUueummz1XyySW0DVk+3x9HyhU9MuWTa2BhqLgEuEmUwASAdCA==}
     dev: true
 
   /ccount/2.0.1:
@@ -1213,16 +1213,6 @@ packages:
       which: 2.0.2
     dev: true
 
-  /css-select/4.2.1:
-    resolution: {integrity: sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==}
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 5.1.0
-      domhandler: 4.3.1
-      domutils: 2.8.0
-      nth-check: 2.0.1
-    dev: true
-
   /css-select/4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
     dependencies:
@@ -1239,11 +1229,6 @@ packages:
     dependencies:
       mdn-data: 2.0.14
       source-map: 0.6.1
-    dev: true
-
-  /css-what/5.1.0:
-    resolution: {integrity: sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==}
-    engines: {node: '>= 6'}
     dev: true
 
   /css-what/6.0.1:
@@ -1450,8 +1435,8 @@ packages:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
     dev: true
 
-  /electron-to-chromium/1.4.96:
-    resolution: {integrity: sha512-DPNjvNGPabv6FcyjzLAN4C0psN/GgD9rSGvMTuv81SeXG/EX3mCz0wiw9N1tUEnfQXYCJi3H8M0oFPRziZh7rw==}
+  /electron-to-chromium/1.4.103:
+    resolution: {integrity: sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==}
     dev: true
 
   /emmet/2.3.6:
@@ -1500,8 +1485,8 @@ packages:
       is-arrayish: 0.2.1
     dev: true
 
-  /es-abstract/1.19.1:
-    resolution: {integrity: sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==}
+  /es-abstract/1.19.2:
+    resolution: {integrity: sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -1552,8 +1537,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-android-64/0.14.29:
+    resolution: {integrity: sha512-tJuaN33SVZyiHxRaVTo1pwW+rn3qetJX/SRuc/83rrKYtyZG0XfsQ1ao1nEudIt9w37ZSNXR236xEfm2C43sbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-android-arm64/0.14.25:
     resolution: {integrity: sha512-4jv5xPjM/qNm27T5j3ZEck0PvjgQtoMHnz4FzwF5zNP56PvY2CT0WStcAIl6jNlsuDdN63rk2HRBIsO6xFbcFw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.14.29:
+    resolution: {integrity: sha512-D74dCv6yYnMTlofVy1JKiLM5JdVSQd60/rQfJSDP9qvRAI0laPXIG/IXY1RG6jobmFMUfL38PbFnCqyI/6fPXg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -1570,8 +1573,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-darwin-64/0.14.29:
+    resolution: {integrity: sha512-+CJaRvfTkzs9t+CjGa0Oa28WoXa7EeLutQhxus+fFcu0MHhsBhlmeWHac3Cc/Sf/xPi1b2ccDFfzGYJCfV0RrA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-darwin-arm64/0.14.25:
     resolution: {integrity: sha512-oTcDgdm0MDVEmw2DWu8BV68pYuImpFgvWREPErBZmNA4MYKGuBRaCiJqq6jZmBR1x+3y1DWCjez+5uLtuAm6mw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.14.29:
+    resolution: {integrity: sha512-5Wgz/+zK+8X2ZW7vIbwoZ613Vfr4A8HmIs1XdzRmdC1kG0n5EG5fvKk/jUxhNlrYPx1gSY7XadQ3l4xAManPSw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -1588,8 +1609,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-freebsd-64/0.14.29:
+    resolution: {integrity: sha512-VTfS7Bm9QA12JK1YXF8+WyYOfvD7WMpbArtDj6bGJ5Sy5xp01c/q70Arkn596aGcGj0TvQRplaaCIrfBG1Wdtg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-freebsd-arm64/0.14.25:
     resolution: {integrity: sha512-+ZVWud2HKh+Ob6k/qiJWjBtUg4KmJGGmbvEXXW1SNKS7hW7HU+Zq2ZCcE1akFxOPkVB+EhOty/sSek30tkCYug==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.14.29:
+    resolution: {integrity: sha512-WP5L4ejwLWWvd3Fo2J5mlXvG3zQHaw5N1KxFGnUc4+2ZFZknP0ST63i0IQhpJLgEJwnQpXv2uZlU1iWZjFqEIg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -1606,8 +1645,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-32/0.14.29:
+    resolution: {integrity: sha512-4myeOvFmQBWdI2U1dEBe2DCSpaZyjdQtmjUY11Zu2eQg4ynqLb8Y5mNjNU9UN063aVsCYYfbs8jbken/PjyidA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-64/0.14.25:
     resolution: {integrity: sha512-+aKHdHZmX9qwVlQmu5xYXh7GsBFf4TWrePgeJTalhXHOG7NNuUwoHmketGiZEoNsWyyqwH9rE5BC+iwcLY30Ug==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.14.29:
+    resolution: {integrity: sha512-iaEuLhssReAKE7HMwxwFJFn7D/EXEs43fFy5CJeA4DGmU6JHh0qVJD2p/UP46DvUXLRKXsXw0i+kv5TdJ1w5pg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1624,8 +1681,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-arm/0.14.29:
+    resolution: {integrity: sha512-OXa9D9QL1hwrAnYYAHt/cXAuSCmoSqYfTW/0CEY0LgJNyTxJKtqc5mlwjAZAvgyjmha0auS/sQ0bXfGf2wAokQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-arm64/0.14.25:
     resolution: {integrity: sha512-UxfenPx/wSZx55gScCImPtXekvZQLI2GW3qe5dtlmU7luiqhp5GWPzGeQEbD3yN3xg/pHc671m5bma5Ns7lBHw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.14.29:
+    resolution: {integrity: sha512-KYf7s8wDfUy+kjKymW3twyGT14OABjGHRkm9gPJ0z4BuvqljfOOUbq9qT3JYFnZJHOgkr29atT//hcdD0Pi7Mw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -1642,8 +1717,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-mips64le/0.14.29:
+    resolution: {integrity: sha512-05jPtWQMsZ1aMGfHOvnR5KrTvigPbU35BtuItSSWLI2sJu5VrM8Pr9Owym4wPvA4153DFcOJ1EPN/2ujcDt54g==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-ppc64le/0.14.25:
     resolution: {integrity: sha512-0dR6Csl6Zas3g4p9ULckEl8Mo8IInJh33VCJ3eaV1hj9+MHGdmDOakYMN8MZP9/5nl+NU/0ygpd14cWgy8uqRw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.14.29:
+    resolution: {integrity: sha512-FYhBqn4Ir9xG+f6B5VIQVbRuM4S6qwy29dDNYFPoxLRnwTEKToIYIUESN1qHyUmIbfO0YB4phG2JDV2JDN9Kgw==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1660,8 +1753,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-riscv64/0.14.29:
+    resolution: {integrity: sha512-eqZMqPehkb4nZcffnuOpXJQdGURGd6GXQ4ZsDHSWyIUaA+V4FpMBe+5zMPtXRD2N4BtyzVvnBko6K8IWWr36ew==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-s390x/0.14.25:
     resolution: {integrity: sha512-YI2d5V6nTE73ZnhEKQD7MtsPs1EtUZJ3obS21oxQxGbbRw1G+PtJKjNyur+3t6nzHP9oTg6GHQ3S3hOLLmbDIQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.14.29:
+    resolution: {integrity: sha512-o7EYajF1rC/4ho7kpSG3gENVx0o2SsHm7cJ5fvewWB/TEczWU7teDgusGSujxCYcMottE3zqa423VTglNTYhjg==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -1678,8 +1789,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-netbsd-64/0.14.29:
+    resolution: {integrity: sha512-/esN6tb6OBSot6+JxgeOZeBk6P8V/WdR3GKBFeFpSqhgw4wx7xWUqPrdx4XNpBVO7X4Ipw9SAqgBrWHlXfddww==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-openbsd-64/0.14.25:
     resolution: {integrity: sha512-QgFJ37A15D7NIXBTYEqz29+uw3nNBOIyog+3kFidANn6kjw0GHZ0lEYQn+cwjyzu94WobR+fes7cTl/ZYlHb1A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.14.29:
+    resolution: {integrity: sha512-jUTdDzhEKrD0pLpjmk0UxwlfNJNg/D50vdwhrVcW/D26Vg0hVbthMfb19PJMatzclbK7cmgk1Nu0eNS+abzoHw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -1696,8 +1825,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-sunos-64/0.14.29:
+    resolution: {integrity: sha512-EfhQN/XO+TBHTbkxwsxwA7EfiTHFe+MNDfxcf0nj97moCppD9JHPq48MLtOaDcuvrTYOcrMdJVeqmmeQ7doTcg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-32/0.14.25:
     resolution: {integrity: sha512-HGAxVUofl3iUIz9W10Y9XKtD0bNsK9fBXv1D55N/ljNvkrAYcGB8YCm0v7DjlwtyS6ws3dkdQyXadbxkbzaKOA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32/0.14.29:
+    resolution: {integrity: sha512-uoyb0YAJ6uWH4PYuYjfGNjvgLlb5t6b3zIaGmpWPOjgpr1Nb3SJtQiK4YCPGhONgfg2v6DcJgSbOteuKXhwqAw==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -1714,8 +1861,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-windows-64/0.14.29:
+    resolution: {integrity: sha512-X9cW/Wl95QjsH8WUyr3NqbmfdU72jCp71cH3pwPvI4CgBM2IeOUDdbt6oIGljPu2bf5eGDIo8K3Y3vvXCCTd8A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-arm64/0.14.25:
     resolution: {integrity: sha512-4ype9ERiI45rSh+R8qUoBtaj6kJvUOI7oVLhKqPEpcF4Pa5PpT3hm/mXAyotJHREkHpM87PAJcA442mLnbtlNA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.14.29:
+    resolution: {integrity: sha512-+O/PI+68fbUZPpl3eXhqGHTGK7DjLcexNnyJqtLZXOFwoAjaXlS5UBCvVcR3o2va+AqZTj8o6URaz8D2K+yfQQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -1749,6 +1914,34 @@ packages:
       esbuild-windows-32: 0.14.25
       esbuild-windows-64: 0.14.25
       esbuild-windows-arm64: 0.14.25
+    dev: true
+
+  /esbuild/0.14.29:
+    resolution: {integrity: sha512-SQS8cO8xFEqevYlrHt6exIhK853Me4nZ4aMW6ieysInLa0FMAL+AKs87HYNRtR2YWRcEIqoXAHh+Ytt5/66qpg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      esbuild-android-64: 0.14.29
+      esbuild-android-arm64: 0.14.29
+      esbuild-darwin-64: 0.14.29
+      esbuild-darwin-arm64: 0.14.29
+      esbuild-freebsd-64: 0.14.29
+      esbuild-freebsd-arm64: 0.14.29
+      esbuild-linux-32: 0.14.29
+      esbuild-linux-64: 0.14.29
+      esbuild-linux-arm: 0.14.29
+      esbuild-linux-arm64: 0.14.29
+      esbuild-linux-mips64le: 0.14.29
+      esbuild-linux-ppc64le: 0.14.29
+      esbuild-linux-riscv64: 0.14.29
+      esbuild-linux-s390x: 0.14.29
+      esbuild-netbsd-64: 0.14.29
+      esbuild-openbsd-64: 0.14.29
+      esbuild-sunos-64: 0.14.29
+      esbuild-windows-32: 0.14.29
+      esbuild-windows-64: 0.14.29
+      esbuild-windows-arm64: 0.14.29
     dev: true
 
   /escalade/3.1.1:
@@ -2540,7 +2733,7 @@ packages:
     dependencies:
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
-      es-abstract: 1.19.1
+      es-abstract: 1.19.2
       foreach: 2.0.5
       has-tostringtag: 1.0.0
     dev: true
@@ -3775,16 +3968,20 @@ packages:
       postcss: 8.4.12
     dev: true
 
-  /postcss-load-config/3.1.3:
-    resolution: {integrity: sha512-5EYgaM9auHGtO//ljHH+v/aC/TQ5LHXtL7bQajNAUBKUVKiYE8rYpFms7+V26D9FncaGe2zwCoPQsFKb5zF/Hw==}
+  /postcss-load-config/3.1.4_postcss@8.4.12:
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
+      postcss: '>=8.0.9'
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
+      postcss:
+        optional: true
       ts-node:
         optional: true
     dependencies:
       lilconfig: 2.0.5
+      postcss: 8.4.12
       yaml: 1.10.2
     dev: true
 
@@ -3795,11 +3992,11 @@ packages:
       postcss: ^8.2.14
     dependencies:
       postcss: 8.4.12
-      postcss-selector-parser: 6.0.9
+      postcss-selector-parser: 6.0.10
     dev: true
 
-  /postcss-selector-parser/6.0.9:
-    resolution: {integrity: sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==}
+  /postcss-selector-parser/6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
     dependencies:
       cssesc: 3.0.0
@@ -4504,7 +4701,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
-      es-abstract: 1.19.1
+      es-abstract: 1.19.2
     dev: true
 
   /string.prototype.trimend/1.0.4:
@@ -4640,12 +4837,12 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /svelte/3.46.4:
-    resolution: {integrity: sha512-qKJzw6DpA33CIa+C/rGp4AUdSfii0DOTCzj/2YpSKKayw5WGSS624Et9L1nU1k2OVRS9vaENQXp2CVZNU+xvIg==}
+  /svelte/3.46.5:
+    resolution: {integrity: sha512-T4txpIgYEGTkpFY2KQoqvtDmapu/suHMx0GN2zAImdJ7liEdG29P0XpjcNHnOEU1a4lLJn1WXxreobBSIGdcbQ==}
     engines: {node: '>= 8'}
     dev: true
 
-  /svelte2tsx/0.5.6_svelte@3.46.4+typescript@4.6.3:
+  /svelte2tsx/0.5.6_svelte@3.46.5+typescript@4.6.3:
     resolution: {integrity: sha512-B4WZUtoTdVD+F73H1RQEH3Hrv7m2/ahThmAUkjT5CTWRigQaJqYQpSjisCH1Pzfi9B37YikDnAi4u4uxwYM+iw==}
     peerDependencies:
       svelte: ^3.24
@@ -4653,7 +4850,7 @@ packages:
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 3.46.4
+      svelte: 3.46.5
       typescript: 4.6.3
     dev: true
 
@@ -4664,7 +4861,7 @@ packages:
     dependencies:
       '@trysound/sax': 0.2.0
       commander: 7.2.0
-      css-select: 4.2.1
+      css-select: 4.3.0
       css-tree: 1.1.3
       csso: 4.2.0
       picocolors: 1.0.0
@@ -4698,9 +4895,9 @@ packages:
       object-hash: 2.2.0
       postcss: 8.4.12
       postcss-js: 4.0.0_postcss@8.4.12
-      postcss-load-config: 3.1.3
+      postcss-load-config: 3.1.4_postcss@8.4.12
       postcss-nested: 5.0.6_postcss@8.4.12
-      postcss-selector-parser: 6.0.9
+      postcss-selector-parser: 6.0.10
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
       resolve: 1.22.0
@@ -4790,7 +4987,7 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
     dependencies:
-      esbuild: 0.14.25
+      esbuild: 0.14.29
     dev: true
 
   /tunnel-agent/0.6.0:
@@ -4988,8 +5185,8 @@ packages:
       unist-util-stringify-position: 3.0.2
       vfile-message: 3.1.2
 
-  /vite/2.8.6:
-    resolution: {integrity: sha512-e4H0QpludOVKkmOsRyqQ7LTcMUDF3mcgyNU4lmi0B5JUbe0ZxeBBl8VoZ8Y6Rfn9eFKYtdXNPcYK97ZwH+K2ug==}
+  /vite/2.9.0:
+    resolution: {integrity: sha512-5NAnNqzPmZzJvrswZGeTS2JHrBGIzIWJA2hBTTMYuoBVEMh0xwE0b5yyIXFxf7F07hrK4ugX2LJ7q6t7iIbd4Q==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     peerDependencies:
@@ -5004,7 +5201,7 @@ packages:
       stylus:
         optional: true
     dependencies:
-      esbuild: 0.14.25
+      esbuild: 0.14.29
       postcss: 8.4.12
       resolve: 1.22.0
       rollup: 2.70.1
@@ -5127,7 +5324,7 @@ packages:
     dependencies:
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
-      es-abstract: 1.19.1
+      es-abstract: 1.19.2
       foreach: 2.0.5
       has-tostringtag: 1.0.0
       is-typed-array: 1.1.8

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -36,6 +36,7 @@ h4,
 h5,
 h6 {
 	line-height: 1.11;
+	font-weight: bold;
 }
 
 * {

--- a/src/components/ChecklistItem.astro
+++ b/src/components/ChecklistItem.astro
@@ -19,12 +19,15 @@ const wrapperProps = href ? { href, target: '_blank', rel: 'noopener noreferrer'
 a {
     display: inline-flex;
     align-items: center;
-    color: inherit;
+    color: var(--color-dusk);
     text-decoration: none;
 }
 .marker {
     transition: transform 200ms cubic-bezier(0.23, 1, 0.320, 1);
     transition-property: transform, background, color;
+}
+a:is(:hover, :focus) {
+    color: var(--color-purple);
 }
 a:is(:hover, :focus) .marker {
     color: var(--color-dawn);

--- a/src/components/Mention.astro
+++ b/src/components/Mention.astro
@@ -8,7 +8,7 @@ if (!mention) {
 }
 ---
 
-<span class="mention">
+<span class="mention not-prose">
     <a href={mention.twitter} title={`Follow ${mention.name} on Twitter`}>
         <img aria-hidden="true" alt={mention.name} src={mention.avatar} loading="lazy">
         <span>{mention.name}</span>

--- a/src/components/Panel.astro
+++ b/src/components/Panel.astro
@@ -6,8 +6,8 @@ if (offset !== 0) {
 }
 ---
 
-<div class="astro-container px-2" style={style}>
-    <article class={`panel elevation-${elevation} size-${size} ${className}`} style={`--background: ${background};`}>
+<div class="container" style={style}>
+    <article class={`panel shadow-${elevation} elevation-${elevation} size-${size} ${className}`} style={`--background: ${background};`}>
         {Astro.slots.title && <div class="title">
             <slot name="title" />
         </div>}

--- a/src/components/blocks/ProseBlock.astro
+++ b/src/components/blocks/ProseBlock.astro
@@ -1,3 +1,11 @@
-<section class="prose mx-auto">
+---
+export interface Props {
+    class?: string;
+}
+
+const { class: className = '' } = Astro.props as Props
+---
+
+<section class=`prose mx-auto ${className}`>
     <slot />
 </section>

--- a/src/components/blog/Card.astro
+++ b/src/components/blog/Card.astro
@@ -45,6 +45,7 @@ const Title = variant === 'summary' ? 'h2' : 'h1';
     flex-grow: 1;
     width: 100%;
     line-height: 1.1;
+    font-weight: bold;
 }
 h1.title {
     font-size: var(--size-800);

--- a/src/components/blog/Outro.astro
+++ b/src/components/blog/Outro.astro
@@ -7,7 +7,7 @@ const { tweet: { title, href } } = Astro.props;
 <section class="outro">
     <div class="astro-container container">
         <div class="content">
-            <a class="return" href="/blog">
+            <a class="return subtle" href="/blog">
                 <Sprite pack="mdi" name="arrow-left" size="32" aria-hidden="true" />
                 <span>Return to Blog</span>
             </a>

--- a/src/components/landing/Performance.astro
+++ b/src/components/landing/Performance.astro
@@ -41,7 +41,7 @@ const tweet = {
                         <h5 id="tti-after" class="after">Using Astro: 2.3<abbr title="seconds">s</abbr></h5>
                     </div> -->
                     
-                    <p>Real world data from <a href={tweet.href}>@t3dotgg on Twitter</a></p>
+                    <p>Real world data from <a href={tweet.href} class="link">@t3dotgg on Twitter</a></p>
                 </div>
             </Panel>
         </aside>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -35,7 +35,6 @@ const { wrapper: Wrapper = Fragment, meta, container = false, routeId } = Astro.
     </script>
   </head>
   <body>
-    <Sprite.Provider>
         <slot name="banner" />
 
         <SkipLink />
@@ -49,7 +48,6 @@ const { wrapper: Wrapper = Fragment, meta, container = false, routeId } = Astro.
         </Wrapper>
 
         <slot name="footer" />
-    </Sprite.Provider>
 
     <script type="module" hoist>
         import "/src/scripts/defer.ts";

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -50,6 +50,7 @@ const { wrapper: Wrapper = Fragment, meta, container = false, routeId } = Astro.
 
         <slot name="footer" />
     </Sprite.Provider>
+
     <script type="module" hoist>
         import "/src/scripts/defer.ts";
     </script>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -35,6 +35,7 @@ const { wrapper: Wrapper = Fragment, meta, container = false, routeId } = Astro.
     </script>
   </head>
   <body>
+    <Sprite.Provider>
         <slot name="banner" />
 
         <SkipLink />
@@ -48,7 +49,7 @@ const { wrapper: Wrapper = Fragment, meta, container = false, routeId } = Astro.
         </Wrapper>
 
         <slot name="footer" />
-
+    </Sprite.Provider>
     <script type="module" hoist>
         import "/src/scripts/defer.ts";
     </script>

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -112,6 +112,9 @@ const meta = {
 		display: flex;
 		flex-wrap: wrap;
 	}
+	#article a {
+		color: var(--color-blue);
+	}
 
 	#article :is(h2, h3, h4, h5, h6) a::before {
 		content: "#";

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -1,7 +1,10 @@
 ---
-import Layout from './Page.astro';
+import Layout from './Content.astro';
+import ProseBlock from '../components/blocks/ProseBlock.astro';
 import Card from '../components/blog/Card.astro';
 import Outro from '../components/blog/Outro.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
 import Panel from '../components/Panel.astro';
 
 export interface Props {
@@ -25,194 +28,35 @@ const meta = {
 ---
 
 <Layout meta={meta}>
-	<Panel size="md" elevation="sm" class="post-header" background="var(--color-white)">
-		<Card post={{ title, description, authors, publishDate }} variant="hero" />
-	</Panel>
+    <Nav slot="nav" />
 
-	<div id="article">
+    <ProseBlock class="blogpost">
+		<Panel size="lg" elevation="md" class="not-prose mb-16 lg:mb-24" background="white">
+			<Card post={{ title, description, authors, publishDate }} variant="hero" />
+		</Panel>
+
 		<slot />
 
 		<Outro tweet={{ title, href: Astro.request.canonicalURL.toString() }} />
-	</div>
+	</ProseBlock>
+
+    <Footer slot="footer" />
 </Layout>
 
-<style global>
-
-	.post-header {
-		margin: 1rem auto 3rem;
-	}
-	@media (min-width: 40rem) {
-		.post-header {
-			margin: 4rem auto;
-			padding: 0;
-		}
-	}
-	#article {
-		max-width: 48rem;
-		display: flex;
-		flex-flow: column nowrap;
-		font-family: var(--font-body);
-		font-size: var(--size-500);
-		line-height: 1.3;
-		color: var(--color-midnight);
-		z-index: 1;
-	}
-	#article > * + * {
-		margin-top: 1em;
-	}
-	#article :is(h1, h2, h3, h4, h5, h6) {
-		font-family: var(--font-display);
-		line-height: 1.1;
-		margin-bottom: 1.25rem;
-		color: var(--color-dusk);
-	}
-	#article hr {
-		border-color: var(--color-dusk);
-		border-style: dashed;
-	    margin-top: 2em;
-		padding: 0;
-	}
-	#article h1 {
-		--fill: var(--gradient-pop-1);
-		font-size: 3rem;
-		font-size: var(--size-800);
-	}
-	#article h2 {
-		font-size: 2rem;
-		font-size: var(--size-600);
-		margin-top: 2em;
-		margin-bottom: -0.25em;
-	}
-	#article > .note:last-child {
-		margin-top: 8rem;
-	}
-	#article code {
-		font-family: var(--font-mono);
-		font-weight: 400;
-		white-space: pre-wrap;
-		word-break: break-word;
-	}
-	#article code:not([class]) {
-		font-size: 0.85em;
-		color: #9b19fe;
-	}
-	#article code:not([class])::before {
-		content: "`";
-	}
-	#article code:not([class])::after {
-		content: "`";
-	}
-	#article img {
-		max-width: 100%;
-	}
-	#article :is(h2, h3, h4, h5, h6) a {
-		font: inherit;
-		color: inherit;
-		text-decoration: none !important;
-		display: flex;
-		flex-wrap: wrap;
-	}
-	:where(#article a) {
-		color: var(--color-blue);
+<style>
+	.blogpost :global(h1) {
+		@apply text-2xl;
 	}
 
-	#article :is(h2, h3, h4, h5, h6) a::before {
-		content: "#";
-		width: 1em;
-		margin-left: 0.25em;
-		color: inherit;
-		opacity: 0;
-		transition: opacity 200ms cubic-bezier(0.23, 1, 0.32, 1);
-		order: 999;
+	.blogpost :global(h2) {
+		@apply text-lg lg:text-xl;
 	}
 
-	#article :is(h2, h3, h4, h5, h6) a:is(:active, :visited, :hover, :focus) {
-		color: var(--color-dusk);
+	.blogpost :global(h3, h4) {
+		@apply text-lg;
 	}
 
-	#article :is(h2, h3, h4, h5, h6) a:active::before,
-	#article :is(h2, h3, h4, h5, h6) a:hover::before,
-	#article :is(h2, h3, h4, h5, h6) a:focus::before {
-		opacity: 0.6 !important;
-	}
-
-	#article :is(strong, b) {
-		font-family: inherit;
-		font-weight: 600;
-	}
-
-	#article :is(em, i) {
-		font-weight: 400;
-	}
-
-	#article :is(ul:not([role="list"]), ol:not([role="list"])) {
-		padding-left: 1.5em;
-	}
-
-	#article :where(ul:not([role="list"])) {
-		list-style-type: square;
-	}
-
-	#article :where(ul:not([role="list"]) > li + li) {
-		margin-top: 0.25em;
-	}
-
-	#article ::marker {
-		color: rgba(var(--color-midnight-rgb), 0.5);
-	}
-
-	#article pre > code:not([class*="language"]) {
-		background-color: transparent;
-		padding: 0;
-		margin: 0;
-		border-radius: 0;
-		color: inherit;
-	}
-
-	#article pre > code {
-		font-size: 1em;
-	}
-
-	#article pre {
-		position: relative;
-		--padding-block: 1rem;
-		--padding-inline: 2rem;
-		padding: var(--padding-block) var(--padding-inline);
-		padding-right: calc(var(--padding-inline) * 2);
-		margin-left: calc(var(--padding-inline) * -1);
-		margin-right: calc(var(--padding-inline) * -1);
-		font-family: var(--font-mono);
-
-		line-height: 1.5;
-		font-size: 0.85em;
-		overflow-y: hidden;
-		overflow-x: auto;
-	}
-
-	#article pre {
-		background: linear-gradient(to bottom, var(--color-midnight), #1f1638);
-		color: var(--color-white);
-	}
-
-	#article table {
-		width: 100%;
-		padding: var(--padding-block) 0;
-		margin: 0;
-		border-collapse: collapse;
-	}
-
-	/* Zebra striping */
-	#article tr:nth-of-type(odd) {
-		background: var(--theme-bg-hover);
-	}
-	#article th {
-		background: var(--color-black);
-		color: var(--theme-color);
-		font-weight: bold;
-	}
-	#article td,
-	#article th {
-		padding: 6px;
-		text-align: left;
+	.blogpost .not-prose {
+		@apply sm:ml-0 sm:mr-0;
 	}
 </style>

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -112,7 +112,7 @@ const meta = {
 		display: flex;
 		flex-wrap: wrap;
 	}
-	#article a {
+	:where(#article a) {
 		color: var(--color-blue);
 	}
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -89,7 +89,7 @@ const meta = {
 			</Fragment>
 
 			<Checklist cols={4}>
-				<ChecklistItem href="https://astro.new/framework-react">
+				<ChecklistItem class="link link--subtle" href="https://astro.new/framework-react">
 					<Sprite role="img" name="frameworks/react" size={24} slot="icon" />
 					React
 				</ChecklistItem>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -11,16 +11,17 @@
 	h5,
 	h6 {
 		line-height: 1.11;
+		font-weight: bold;
 	}
 
-	a:not(:is(.btn, .pill)),
+	:where(a),
 	.link {
 		@apply text-blue transition-colors duration-150 ease-in-out;
 	}
 
 	a.subtle,
 	.link.link--subtle {
-		@apply text-inherit hover:no-underline hover:text-blue;
+		@apply text-inherit hover:no-underline hover:text-purple;
 	}
 
 	.btn {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -106,7 +106,13 @@ module.exports = {
 							':focus-visible': {
 								outline: '2px dashed var(--color-blue)',
 							},
+							':target': {
+								scrollMargin: '6rem 0 0'
+							},
 							...headings,
+							code: {
+								fontWeight: 400,
+							},
 							a: {
 								textDecoration: 'none',
 								fontWeight: 400,
@@ -118,19 +124,17 @@ module.exports = {
 									color: 'var(--tw-prose-code)',
 								},
 							},
+							'.astro-code': {
+								background: 'linear-gradient(to bottom,var(--color-midnight),#1f1638)',
+								color: theme('colors.white'),
+								margin: '0 -1rem',
+								fontSize: '0.75em',
+								'> code': {
+									whiteSpace: 'pre-wrap',
+									wordBreak: 'break-word'
+								}
+							}
 						},
-					},
-					sm: {
-						...headings,
-					},
-					md: {
-						...headings,
-					},
-					lg: {
-						...headings,
-					},
-					xl: {
-						...headings,
 					},
 				}
 			},


### PR DESCRIPTION
This updates the blog post pages to use tailwind, including the `@tailwindcss/typography` as a starting point with styles modified to better match our existing designs