### PR TITLE
Remove `noreferrer`

### DIFF
--- a/src/components/showcase/ShowcaseCard.astro
+++ b/src/components/showcase/ShowcaseCard.astro
@@ -24,7 +24,7 @@ const placeholder = await generatePlaceholder(site.image.src)
 ---
 
 <article onload="console.log('loaded')" class={clsx("relative flex flex-col rounded-lg overflow-hidden shadow-md bg-white aspect-w-16 aspect-h-9", site.highlight && "sm:col-span-2 sm:row-span-2")}>
-    <a {...site.url} target="_blank" alt={site.title} rel="noopener noreferrer">
+    <a {...site.url} target="_blank" alt={site.title} rel="noopener">
         <span class="sr-only">{site.title}</span>
 
         <picture class="w-full h-full">


### PR DESCRIPTION
As discussed on Discord [in #general](https://ptb.discord.com/channels/830184174198718474/830184175176122389/962105868516741163) it would be nice to give Astro credit where credit is due and show when traffic comes from Astro! Right now traffic to the pages in the showcase list looks like "Direct traffic" in analytics tools.

I looked around and couldn't find any implications for this, but I'm happy to reconsider if this is here for a reason.

Fun fact: we could also technically remove `noopener` since all links with `target="_blank"` automatically gets `rel="noopener"`, but it's probably best to keep it in case we ever want to remove `target="_blank"`.