### PR TITLE
fix: hero image extension missmatch in "introducing astro" blog post

### DIFF
--- a/src/pages/blog/introducing-astro.md
+++ b/src/pages/blog/introducing-astro.md
@@ -11,7 +11,7 @@ authors:
 description: | 
   We're excited to announce Astro as a new way to build static websites and deliver lightning-fast performance without sacrificing a modern developer experience.
 publishDate: 'June 8, 2021'
-heroImage: '/social.jpg'
+heroImage: '/social.png'
 permalink: 'https://astro.build/blog/introducing-astro'
 lang: 'en'
 ---


### PR DESCRIPTION
fix a little image extension mismatch in "the introducing astro" blog post 🚀

### before:
![image](https://user-images.githubusercontent.com/46791833/165836939-3e7a511f-06ef-40f2-85a9-71906cc13564.png)

### after:
![image](https://user-images.githubusercontent.com/46791833/165837151-01e3799a-e0ef-46fa-9fde-dd65f06a695b.png)
