### PR TITLE
Fix typo in URL for an integreration item ("astro-infinity")

### DIFF
--- a/src/data/integrations.json
+++ b/src/data/integrations.json
@@ -18,7 +18,7 @@
             "text": "View on NPM"
         },
         "url": {
-            "href": "https://github.com/alterdorange/astro-infinity",
+            "href": "https://github.com/alteredorange/astro-infinity",
             "text": "View homepage"
         },
         "downloads": 479,


### PR DESCRIPTION
This is a simple PR to fix a minor typo (missing letter) in URL for the "astro-infinity" integration, which currently leads to GitHub 404 page on click. The typo was introduced in https://github.com/withastro/astro.build/commit/6e7f41bd2f3ccd121318047e1045f6e43ae69a84.