### PR TITLE
Updates astro components to import TS files with a .js extension

### DIFF
--- a/src/components/Author.astro
+++ b/src/components/Author.astro
@@ -1,6 +1,6 @@
 ---
 import { Sprite } from 'astro-icon';
-import { mentions } from '../mentions.ts';
+import { mentions } from '../mentions.js';
 const { name } = Astro.props;
 
 const author = mentions[name];

--- a/src/components/Drawer.astro
+++ b/src/components/Drawer.astro
@@ -65,5 +65,5 @@ const { id } = Astro.props as Props;
 </style>
 
 <script>
-    import './Drawer.ts';
+    import './Drawer.js';
 </script>

--- a/src/components/FlyoutMenu.astro
+++ b/src/components/FlyoutMenu.astro
@@ -39,7 +39,7 @@ const hasDescriptions = items.some(({ description }) => !!description);
 </details>
 
 <script>
-    import './FlyoutMenu.ts';
+    import './FlyoutMenu.js';
 </script>
 
 <style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,7 @@
 import Quote from './landing/Quote.astro';
 import Grid from './landing/Grid.astro';
 import Community from './landing/Community.astro';
-import { footer } from '../config.ts';
+import { footer } from '../config.js';
 
 const { quote } = Astro.slots;
 const YYYY = new Date().getFullYear();

--- a/src/components/Mention.astro
+++ b/src/components/Mention.astro
@@ -1,5 +1,5 @@
 ---
-import { mentions } from '../mentions.ts';
+import { mentions } from '../mentions.js';
 const { name } = Astro.props;
 
 const mention = mentions[name];

--- a/src/components/MobileMenu.astro
+++ b/src/components/MobileMenu.astro
@@ -1,7 +1,7 @@
 ---
 import { Sprite } from 'astro-icon';
 import MobileMenuGroup from './MobileMenuGroup.astro';
-import { footer, globalNavigation, social } from '../config.ts';
+import { footer, globalNavigation, social } from '../config.js';
 
 const visibleOnMobile = (item) => !item.hiddenMobile;
 

--- a/src/components/MobileMenuGroup.astro
+++ b/src/components/MobileMenuGroup.astro
@@ -1,6 +1,6 @@
 ---
 import { Sprite } from 'astro-icon';
-import type { NavigationGroup } from '../config.ts';
+import type { NavigationGroup } from '../config.js';
 
 export type Props = NavigationGroup;
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -3,7 +3,7 @@ import { Sprite } from 'astro-icon';
 import Drawer from './Drawer.astro';
 import MobileMenu from './MobileMenu.astro';
 import FlyoutMenu from './FlyoutMenu.astro';
-import { globalNavigation, social } from '../config.ts';
+import { globalNavigation, social } from '../config.js';
 
 const { invert = false, marginBottom = false } = Astro.props;
 ---

--- a/src/components/landing/Community.astro
+++ b/src/components/landing/Community.astro
@@ -3,7 +3,7 @@ import Section from './Section.astro';
 import Title from './Title.astro';
 import ArrowLink from '../ArrowLink.astro';
 import Panel from '../Panel.astro';
-import { social } from '../../config.ts';
+import { social } from '../../config.js';
 
 const { style } = Astro.props;
 ---

--- a/src/pages/integrations/[slug].astro
+++ b/src/pages/integrations/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import { collections, getIntegrationsForCollection } from '../../data/integrations.ts';
+import { collections, getIntegrationsForCollection } from '../../data/integrations.js';
 import Layout from '../../layouts/Catalog.astro';
 import IntegrationCard from '../../components/integrations/IntegrationCard.astro';
 

--- a/src/pages/integrations/index.astro
+++ b/src/pages/integrations/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../layouts/Catalog.astro';
 import integrations from '../../data/integrations.json';
-import { collections } from '../../data/integrations.ts';
+import { collections } from '../../data/integrations.js';
 import IntegrationCard from '../../components/integrations/IntegrationCard.astro';
 
 const meta = {

--- a/src/pages/showcase/[slug].astro
+++ b/src/pages/showcase/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import { fetchCollections, fetchSitesForCollection } from '../../data/showcase.ts';
+import { fetchCollections, fetchSitesForCollection } from '../../data/showcase.js';
 import Layout from '../../layouts/Catalog.astro';
 import ShowcaseCard from '../../components/showcase/ShowcaseCard.astro';
 

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -1,5 +1,5 @@
 ---
-import { fetchCollections, fetchShowcase } from '../../data/showcase.ts';
+import { fetchCollections, fetchShowcase } from '../../data/showcase.js';
 import Layout from '../../layouts/Catalog.astro';
 import ShowcaseCard from '../../components/showcase/ShowcaseCard.astro';
 

--- a/src/pages/themes/[slug].astro
+++ b/src/pages/themes/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import { collections, getThemesForCollection } from '../../data/themes.ts';
+import { collections, getThemesForCollection } from '../../data/themes.js';
 import Layout from '../../layouts/Catalog.astro';
 import ThemeCard from '../../components/themes/ThemeCard.astro';
 

--- a/src/pages/themes/index.astro
+++ b/src/pages/themes/index.astro
@@ -1,6 +1,6 @@
 ---
 import themes from '../../data/themes.json';
-import { collections } from '../../data/themes.ts';
+import { collections } from '../../data/themes.js';
 import Layout from '../../layouts/Catalog.astro';
 import ThemeCard from '../../components/themes/ThemeCard.astro';
 


### PR DESCRIPTION
Cleaning up outdated syntax that was importing TypeScript files with the `.ts` extension - this still works but is now recommended to use `.js` extensions to match TS behavior