### PR TITLE
hotfix: JSX stopped supporting nested maps?

### DIFF
--- a/src/components/landing/Integrations.astro
+++ b/src/components/landing/Integrations.astro
@@ -7,6 +7,8 @@ const rows = [
     ['rss', 'wordpress', 'strapi', 'prismic', 'shopify'],
     ['contentful', 'netlify-grid', 'vercel-grid', 'cloudflare', 'github'],
 ]
+
+const icons = rows.flat();
 ---
 
 <Section id="frameworks">
@@ -17,7 +19,9 @@ const rows = [
         </div>
     </div>
     <ul class="integrations astro-container container">
-        {rows.map(row => row.map(icon => <li class={`icon-${icon}`}><Icon title={icon.replace(/\-grid$/, '')} name={`logos/${icon}`} height="64" /></li>))}
+        {icons.map(icon => (
+            <li class={`icon-${icon}`}><Icon title={icon.replace(/\-grid$/, '')} name={`logos/${icon}`} height="64" /></li>
+        ))}
     </ul>
 </Section>
 


### PR DESCRIPTION
Need to track down why this broke after beta.51, but nesting `map()` calls in JSX is no longer rendering properly