### PR TITLE
Accessibility Improvements

### DIFF
--- a/src/components/Aside.astro
+++ b/src/components/Aside.astro
@@ -20,6 +20,8 @@ const { type = 'tip', title, class: className } = Astro.props;
 		background: var(--color-dawn);
 		color: var(--color-midnight);
         border-radius: var(--corner-md);
+		/* Outline only visible for high contrast users */
+        outline: 1px solid transparent;
 	}
 
 	aside > :global(* + *) {

--- a/src/components/FlyoutMenu.astro
+++ b/src/components/FlyoutMenu.astro
@@ -20,20 +20,22 @@ const hasDescriptions = items.some(({ description }) => !!description);
 <details class:list={['flyout', align, { light: invert }]}>
     <summary>
         {title}
-        <Sprite pack="heroicons-solid" name="chevron-down" size={20} aria-label={`Open ${title} menu`} />
+        <Sprite pack="heroicons-solid" name="chevron-down" size={20} aria-hidden="true" />
     </summary>
 
     <div>
-        <nav class:list={[{ descriptions: hasDescriptions }]} aria-label={title}>
+        <ul class:list={[{ descriptions: hasDescriptions }]}>
             {items.map(({ title, href, description }) => (
-                <a href={href} alt={title} class="subtle">
-                    <span>{title}</span>
-                    {description && (
-                        <p>{description}</p>
-                    )}
-                </a>
+                <li>
+                    <a href={href} class="subtle">
+                        <span>{title}</span>
+                        {description && (
+                            <p>{description}</p>
+                        )}
+                    </a>
+                </li>
             ))}
-        </nav>
+        </ul>
     </div>
 </details>
 
@@ -77,6 +79,8 @@ const hasDescriptions = items.some(({ description }) => !!description);
         opacity: 0;
         transition: opacity 150ms ease;
         will-change: opacity;
+        /* Outline only visible for high contrast users */
+        outline: 1px solid transparent;
     }
 
     details.left div {
@@ -87,7 +91,7 @@ const hasDescriptions = items.some(({ description }) => !!description);
         transform: translateX(-85%);
     }
 
-    nav {
+    details ul {
         display: flex;
         flex-direction: column;
         gap: 2rem;
@@ -105,7 +109,7 @@ const hasDescriptions = items.some(({ description }) => !!description);
         opacity: 1;
     }
 
-    nav.descriptions {
+    ul.descriptions {
         width: 100vw;
         text-align: start;
         white-space: normal;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -26,13 +26,15 @@ const YYYY = new Date().getFullYear();
         </Quote>
     )}
     
-    <div class="astro-container container content">
-        <ul class="links">
-            <li>&copy; {YYYY} The Astro Technology Company</li>
-            {footer.map(item => (
-                <li><a href={item.href} target={item.external ? "_blank" : undefined}>{item.title}</a></li>
-            ))}
-        </ul>
+    <div class="container astro-container content">
+        <nav aria-label="Secondary">
+            <ul class="links">
+                <li role="presentation">&copy; {YYYY} The Astro Technology Company</li>
+                {footer.map(item => (
+                    <li><a href={item.href} target={item.external ? "_blank" : undefined}>{item.title}</a></li>
+                ))}
+            </ul>
+        </nav>
     </div>
 </footer>
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -12,13 +12,13 @@ function isNavigationGroup(value: NavigationItem | NavigationGroup): value is Na
 }
 ---
 
-<nav id="nav" class={`main ${invert ? 'dark' : ''} ${marginBottom ? 'margin-bottom' : ''}`.trim()} style={`--offset: 2.5;`}>
-    <ul class="astro-container container" role="list">
+<nav aria-label="Primary" id="nav" class={`main ${invert ? 'dark' : ''} ${marginBottom ? 'margin-bottom' : ''}`.trim()} style={`--offset: 2.5;`}>
+    <ul class="container astro-container">
         <li class="logo">
             <a href="/" id="navlogo">
-                <h1 class="visually-hidden sr-only">Astro</h1>
-                <Sprite class="logomark" name="logo" size="3em" aria-label="Astro" aria-hidden="true" />
-                <Sprite class="wordmark" name="wordmark" height="3.5em" width="6em" aria-label="Astro" aria-hidden="true" />
+                <span class="sr-only visually-hidden">Astro</span>
+                <Sprite class="logomark" name="logo" size="3em" aria-hidden="true" />
+                <Sprite class="wordmark" name="wordmark" height="3.5em" width="6em" aria-hidden="true" />
             </a>
         </li>
 
@@ -37,7 +37,7 @@ function isNavigationGroup(value: NavigationItem | NavigationGroup): value is Na
         {social.map(item => (
             <li class="icon">
                 <a class="subtle" href={item.href} title={item.title}>
-                    <Sprite name={item.icon} size="1.5em" role="presentation" aria-hidden="true" />
+                    <Sprite name={item.icon} size="1.5em" aria-hidden="true" />
                 </a>
             </li>
         ))}
@@ -57,7 +57,7 @@ function isNavigationGroup(value: NavigationItem | NavigationGroup): value is Na
         </noscript>
 
         <button type="button" id="menubtn">
-            <span class="visually-hidden sr-only">Open navigation menu</span>
+            <span class="sr-only visually-hidden">Open navigation menu</span>
             <Sprite pack="heroicons-outline" name="menu" size={24} />
         </button>
     </ul>

--- a/src/components/PillList.astro
+++ b/src/components/PillList.astro
@@ -11,8 +11,8 @@ const { links, current, title, prefetch, class: className } = Astro.props as Pro
 ---
 
 <section class:list={["max-w-4xl", className]}>
-    <h2 class="text-xs pb-2 font-display font-bold tracking-wider uppercase text-dusk">{title}</h2>
-    <ul class="flex flex-row gap-2 flex-wrap">
+    <h2 class="pb-2 text-xs font-bold tracking-wider uppercase font-display text-dusk">{title}</h2>
+    <ul class="flex flex-row flex-wrap gap-2">
         {links.map(link => (
             <li>
                 <a rel={prefetch ? 'prefetch' : undefined} class:list={["pill", { "pill--hollow": current !== link }]} href={link.href} aria-current={current === link ? "page" : undefined}>{link.text}</a>
@@ -20,3 +20,11 @@ const { links, current, title, prefetch, class: className } = Astro.props as Pro
         ))}
     </ul>
 </section>
+
+<style>
+    @media (forced-colors: active) {
+        a[aria-current="page"] {
+            color: Highlight;
+        }
+    }
+</style>

--- a/src/components/PixelLink.astro
+++ b/src/components/PixelLink.astro
@@ -103,6 +103,9 @@ const { before, after } = Astro.slots;
         transition-delay: var(--delay);
         transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
     }
+    html.dark .link {
+        color: var(--color-white);
+    }
     .link:hover,
     .link:focus-within {
         transform: translateY(calc(var(--pixel-size) * -0.5px));

--- a/src/components/blocks/CardsBlock.astro
+++ b/src/components/blocks/CardsBlock.astro
@@ -9,10 +9,9 @@ const { id, title } = Astro.props as Props;
 
 <section {id}>
     {title && (
-        <h2 class="text-xs pb-3 font-display font-bold tracking-wider uppercase text-dusk">{title}</h2>
+        <h2 class="pb-3 text-xs font-bold tracking-wider uppercase font-display text-dusk">{title}</h2>
     )}
-
-    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 grid-flow-row-dense">
+    <ul class="grid grid-flow-row-dense grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         <slot />
-    </div>
+    </ul>
 </section>

--- a/src/components/integrations/IntegrationCard.astro
+++ b/src/components/integrations/IntegrationCard.astro
@@ -39,9 +39,8 @@ function randomIcon() {
     return icons[Math.floor(Math.random() * icons.length)]
 }
 ---
-
-<article class="isolate p-4 rounded-lg shadow-md bg-white relative">
-    <a href={integration.url?.href} alt={integration.url?.text} class="absolute inset-0 z-10" target="_blank">
+<article role="listitem" class="relative p-4 bg-white rounded-lg shadow-md isolate">
+    <a href={integration.url?.href} class="absolute inset-0 z-10" target="_blank">
         <span class="sr-only">Learn more about {integration.title}</span>
     </a>
 
@@ -51,22 +50,22 @@ function randomIcon() {
             : (<Sprite {...randomIcon()} size="2em" class={randomColor()} />)}
     </div>
 
-    <h3 class="font-display font-bold break-word pt-2 flex items-center gap-2">
+    <h3 class="flex items-center gap-2 pt-2 font-bold font-display break-word">
         <span>{integration.title}</span>
         {integration.official && (
             <Sprite pack="heroicons-solid" name="badge-check" size={20} class="text-blue opacity-70" aria-label="Official Integration" />
         )}
     </h3>
 
-    <p class="text-sm flex-1 line-clamp-2">
+    <p class="flex-1 text-sm line-clamp-2">
         {integration.description}
     </p>
 
     {downloads && (
-        <a href={integration.npmUrl?.href} target="_blank" rel="noopener noreferrer" class="justify-self-end inline-block z-20 subtle flex items-center gap-x-1 text-sm">
+        <a href={integration.npmUrl?.href} target="_blank" rel="noopener noreferrer" class="z-20 flex items-center inline-block text-sm justify-self-end subtle gap-x-1">
             <span class="sr-only">{downloads} weekly downloads</span>
             <Sprite pack="heroicons-outline" name="download" size="1.25em" aria-hidden="true" />
-            <span>{downloads}</span>
+            <span aria-hidden="true">{downloads}</span>
         </a>
     )}
 </article>
@@ -86,6 +85,8 @@ function randomIcon() {
             'title title'
             'description description';
         row-gap: 0.5rem;
+        /* Outline only visible for high contrast users */
+        outline: 1px solid transparent;
     }
 
     .icon {

--- a/src/components/landing/Community.astro
+++ b/src/components/landing/Community.astro
@@ -11,7 +11,7 @@ const { style } = Astro.props;
 <Section class="community" style={style} pad={1.0}>
     <Panel size="md" background="var(--color-dawn)">
         <Fragment slot="title">
-            <h3 class="head-md"><Title id="community"><slot name="title">Connect with Astro</slot></Title></h3>
+            <h2 class="head-md"><Title id="community"><slot name="title">Connect with Astro</slot></Title></h2>
             <div class="description">
                 <slot>
                     <p>Learn more about Astro, get support, and meet thousands of other devs in our Discord community!</p>

--- a/src/components/landing/Demo.astro
+++ b/src/components/landing/Demo.astro
@@ -5,7 +5,7 @@ const { reverse, gradient = false } = Astro.props;
 <Section pad={2} class={"demo" + (gradient ? ' gradient' : '')}>
     <div class="astro-container">
         <div class="content">
-            <h3 class="head-md title"><slot name="title" /></h3>
+            <h2 class="head-md title"><slot name="title" /></h2>
             <slot />
         </div>
 

--- a/src/components/landing/DemoIllustration.astro
+++ b/src/components/landing/DemoIllustration.astro
@@ -70,6 +70,10 @@ const { before, after, name } = Astro.props;
     --color: #E8D6F3;
     --color-rgb: 232, 214, 243;
 }
+.before-astro, .after-astro {
+    /* Outline only visible for high contrast users */
+    outline: 1px solid transparent;
+}
 .before-astro :is(.label, .screen) {
     background: #FAFAFA  linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, #F4EFED 100%);
 }

--- a/src/components/landing/Hero.astro
+++ b/src/components/landing/Hero.astro
@@ -8,10 +8,10 @@ import Grid from './Grid.astro';
         <div class="blob-c" />
     </div>
     <Grid />
-    <div class="astro-container container content">
-        <h2 class="text-gradient"><slot name="title" /></h2>
+    <div class="container astro-container content">
+        <h1 class="text-gradient"><slot name="title" /></h1>
         <p><slot name="tagline" /></p>
-        <div class="cta astro-container container">
+        <div class="container cta astro-container">
             <slot />
         </div>
     </div>
@@ -53,7 +53,7 @@ import Grid from './Grid.astro';
         }
     }
     
-    h2 {
+    h1 {
         --fill: var(--gradient-pop-1);
         font-size: 4rem;
         font-size: var(--size-800);
@@ -62,7 +62,7 @@ import Grid from './Grid.astro';
         margin-bottom: 1.25rem;
     }
     @media (min-width: 52rem) {
-        h2 {
+        h1 {
             font-size: var(--size-900);
         }
     }

--- a/src/components/landing/Integrations.astro
+++ b/src/components/landing/Integrations.astro
@@ -12,13 +12,13 @@ const icons = rows.flat();
 ---
 
 <Section id="frameworks">
-    <div class="astro-container container content">
-        <h3 class="head-md title"><slot name="title" /></h3>
+    <div class="container astro-container content">
+        <h2 class="head-md title"><slot name="title" /></h2>
         <div class="body">
             <slot />
         </div>
     </div>
-    <ul class="integrations astro-container container">
+    <ul class="container integrations astro-container">
         {icons.map(icon => (
             <li class={`icon-${icon}`}><Icon title={icon.replace(/\-grid$/, '')} name={`logos/${icon}`} height="64" /></li>
         ))}
@@ -55,7 +55,7 @@ const icons = rows.flat();
         color: black;
     }
     .integrations > li {
-        border: 1rem solid transparent;
+        margin-inline: 1rem;
         display: flex;
         justify-content: center;
         align-items: center;
@@ -63,7 +63,6 @@ const icons = rows.flat();
     .integrations svg {
         height: var(--size-800);
     }
-
     @media (min-width: 42rem) {
         .integrations {
             margin: 2rem auto;

--- a/src/components/landing/Performance.astro
+++ b/src/components/landing/Performance.astro
@@ -13,7 +13,7 @@ const tweet = {
     <Starfield height={48} />
     <div class="astro-container">
         <div class="content">
-            <h3 class="head-md"><slot name="title" /></h3>
+            <h2 class="head-md"><slot name="title" /></h2>
             <div class="body">
                 <slot />
             </div>
@@ -65,7 +65,7 @@ const tweet = {
         padding: 0;
         align-items: center;
     }
-    h3 {
+    h2 {
         margin-bottom: 1rem;
     }
     abbr {

--- a/src/components/landing/Sponsors.astro
+++ b/src/components/landing/Sponsors.astro
@@ -19,7 +19,7 @@ const individuals = members.sort(() => 0.5 - Math.random())
 
 <Section class="sponsor-section" pad={2} {...Astro.props}>
     <div class="astro-container">
-        <h3 class="head-sm title"><slot name="title" /></h3>
+        <h2 class="head-sm title"><slot name="title" /></h2>
         <ul class="sponsors exclusive">
             {exclusive.map(sponsor => (
                 <li><a href={sponsor.href} title={sponsor.title}><span><Icon name={`sponsors/${sponsor.name}`} width={sponsor.width} height={sponsor.height} aria-hidden="true" /></span></a></li>

--- a/src/components/landing/Title.astro
+++ b/src/components/landing/Title.astro
@@ -6,25 +6,23 @@ if (!id) {
 }
 ---
 
-<a class="subtle" href={`#${id}`} id={id}>
+<div>
     <slot />
-</a>
+     <a class="subtle" href={`#${id}`} id={id} aria-label="Section anchor">#</a>
+</div>
 
 <style>
 a {
     font: inherit;
     color: inherit;
     text-decoration: none;
-}
-a::after {
-    content: "#";
-    color: inherit;
     opacity: 0;
     transition: opacity 200ms cubic-bezier(0.23, 1, 0.320, 1);
 }
-a:active::after,
-a:hover::after,
-a:focus::after {
+
+a:active,
+a:hover,
+a:focus {
     opacity: 0.6;
 }
 </style>

--- a/src/components/landing/Trusted.astro
+++ b/src/components/landing/Trusted.astro
@@ -6,7 +6,7 @@ import Section from './Section.astro'
 <Section id="trusted">
     <Panel background="var(--color-dawn)" offset={4}>
         <Fragment slot="title">
-            <h3 class="head-sm"><slot name="title" /></h3>
+            <h2 class="head-sm"><slot name="title" /></h2>
         </Fragment>
 
         <ul class="logos">

--- a/src/components/showcase/ShowcaseCard.astro
+++ b/src/components/showcase/ShowcaseCard.astro
@@ -14,16 +14,16 @@ const widths = site.highlight ? [453, 906, image.width] : [453, 906]
 const sizes = site.highlight ? '(min-width: 1024px) 67vw, 100vw' : '(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 100vw)'
 ---
 
-<article class:list={["relative flex flex-col rounded-lg overflow-hidden shadow-md bg-white aspect-w-16 aspect-h-9", site.highlight && "sm:col-span-2 sm:row-span-2"]}>
-    <a {...site.url} alt={site.title} rel="noopener">
+<article role="listitem" class:list={["relative flex flex-col rounded-lg overflow-hidden shadow-md bg-white aspect-w-16 aspect-h-9", site.highlight && "sm:col-span-2 sm:row-span-2"]}>
+    <a {...site.url} rel="noopener">
         <span class="sr-only">{site.title}</span>
 
-        <Picture src={image} widths={widths} sizes={sizes} alt={site.title} />
+        <Picture src={image} widths={widths} sizes={sizes} alt="" />
     </a>
 
-    <footer class="pointer-events-none absolute z-10 py-4 rounded-b-lg overflow-hidden bg-black text-center text-white font-normal h-fit inset-x-0 top-full -translate-y-full opacity-0 transition-opacity duration-300 ease-out">
+    <footer class="absolute inset-x-0 z-10 py-4 overflow-hidden font-normal text-center text-white transition-opacity duration-300 ease-out -translate-y-full bg-black rounded-b-lg opacity-0 pointer-events-none h-fit top-full">
         <p>{site.title}</p>
-        <small {...site.url} class="underline font-light">{site.url.href}</small>
+        <small {...site.url} class="font-light underline">{site.url.href}</small>
     </footer>
 </article>
 

--- a/src/components/themes/ThemeCard.astro
+++ b/src/components/themes/ThemeCard.astro
@@ -17,13 +17,13 @@ const stars = theme.stars;
 const netlifyUrl = stars !== undefined && `https://app.netlify.com/start/deploy?repository=${theme.repoUrl.href}`;
 ---
 
-<article class="flex flex-col rounded-lg shadow-md bg-white">
-    <a href={linkHref} alt={theme.image.alt} target="_blank" rel="noopener" class="aspect-w-16 aspect-h-9 rounded-t-lg overflow-hidden shadow">
+<article role="listitem" class="flex flex-col bg-white rounded-lg shadow-md">
+    <a href={linkHref} target="_blank" rel="noopener" class="overflow-hidden rounded-t-lg shadow aspect-w-16 aspect-h-9">
         <Picture src={image} alt={theme.title} sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 100vw)" widths={[400, 800]} />
     </a>
 
-    <div class="flex justify-between items-center p-4">
-        <h2 class="text-lg font-display font-bold flex items-center gap-2">
+    <div class="flex items-center justify-between p-4">
+        <h2 class="flex items-center gap-2 text-lg font-bold font-display">
             <a href={linkHref} class="subtle">{theme.title}</a>
             {theme.official && (
                 <Sprite pack="heroicons-solid" name="badge-check" size={20} class="text-blue opacity-70" aria-label="Official Integration" />
@@ -31,14 +31,15 @@ const netlifyUrl = stars !== undefined && `https://app.netlify.com/start/deploy?
         </h2>
 
         {stars && (
-            <a href={theme.repoUrl.href} alt="View the source code" target="_blank" rel="noopener" class="subtle flex items-center gap-x-1 col-start-2 text-sm">
+            <a href={theme.repoUrl.href} target="_blank" rel="noopener" class="flex items-center col-start-2 text-sm subtle gap-x-1">
+                <span class="sr-only">View the source code</span>
                 <Sprite pack="fa-regular" name="star" size="1.25em" aria-label="GitHub stars count" />
                 <span>{stars}</span>
             </a>
         )}
     </div>
 
-    <p class="px-4 mb-4 text-sm flex-1 line-clamp-3">
+    <p class="flex-1 px-4 mb-4 text-sm line-clamp-3">
         {theme.description}
     </p>
 
@@ -49,9 +50,16 @@ const netlifyUrl = stars !== undefined && `https://app.netlify.com/start/deploy?
             </a>
         )}
 
-        <a href={theme.repoUrl.href} alt="View on GitHub" class="subtle ml-auto p-3 -mr-3">
+        <a href={theme.repoUrl.href} class="p-3 ml-auto -mr-3 subtle">
             <span class="sr-only">View on GitHub</span>
             <Sprite name="logos/github-mark" size={28} aria-hidden="true" />
         </a>        
     </footer>
 </article>
+
+<style>
+    article {
+        /* Outline only visible for high contrast users */
+        outline: 1px solid transparent;
+    }
+</style>

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ export const social = [
 	},
 	{
 		icon: 'mdi:twitter',
-		title: '@astrodotbuild',
+		title: 'Twitter',
 		href: 'https://twitter.com/astrodotbuild',
 	},
 ]

--- a/src/layouts/Catalog.astro
+++ b/src/layouts/Catalog.astro
@@ -15,9 +15,10 @@ export interface Props {
     current?: string;
     baseHref: string;
     searchable?: boolean;
+    searchLabel?: string;
 }
 
-const { meta, collections, current = 'featured', baseHref, searchable = true } = Astro.props as Props;
+const { meta, collections, current = 'featured', baseHref, searchable = true, searchLabel = 'Search' } = Astro.props as Props;
 
 const collectionLinks: App.Link[] = [
     {
@@ -43,18 +44,18 @@ const currentCollection = collectionLinks.find(({ text }) => text === current);
     </TitleBlock>
 
     {(searchable || collectionLinks.length > 1) && (
-        <header id="collections" class="flex flex-col gap-4 mb-4 md:flex-row items-center justify-between md:items-end">
+        <header id="collections" class="flex flex-col items-center justify-between gap-4 mb-4 md:flex-row md:items-end">
             {collectionLinks.length > 1 && (
                 <PillList title="collections" links={collectionLinks} current={currentCollection} prefetch />
             )}
 
             {searchable && (
-                <Search id="catalogsearch" selector="#catalog article" groupSelector="#catalog > section" placeholder="Search" />
+                <Search id="catalogsearch" selector="#catalog article" groupSelector="#catalog > section" placeholder={searchLabel} />
             )}
         </header>
     )}
 
-    <section id="catalog" class="flex flex-col gap-y-12 lg:gap-y-16 pt-4 sm:pt-6 lg:pt-8">
+    <section id="catalog" class="flex flex-col pt-4 gap-y-12 lg:gap-y-16 sm:pt-6 lg:pt-8">
         <slot name="cards" />
     </section>
     

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -33,12 +33,12 @@ const meta = { title: 'Blog' };
         {posts.map(post => {
             return (
                 <li>
+                    <a class="overlay" href={post.href}>
+                        <span class="sr-only visually-hidden">{post.title}</span>
+                    </a>
                     <Panel size="md" elevation="sm" container={false} background="var(--color-white)">
                         <Card post={post} variant="summary" />
                     </Panel>
-                    <a class="overlay" href={post.href}>
-                        <span class="sr-only visually-hidden">Read more from "{post.title}"</span>
-                    </a>
                 </li>
             )
         })}
@@ -84,6 +84,8 @@ const meta = { title: 'Blog' };
         left: 0;
         display: block;
         z-index: 1;
+        /* Border only visible for high contrast users */
+        border: 1px solid transparent;
     }
 
     li :global(a:not(.overlay)) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,41 +84,41 @@ const meta = {
 	<Section>
 		<Panel pad={2} background="var(--gradient-pop-3)">
 			<Fragment slot="title">
-				<h3 class="head-md"><Title id="byof">Bring your favorite framework</Title></h3>
+				<h2 class="head-md"><Title id="byof">Bring your favorite framework</Title></h2>
 				<p style="margin-top: 0.5rem;">Astro natively supports every popular framework&mdash;you can even mix and match!</p>
 			</Fragment>
 
 			<Checklist cols={4}>
 				<ChecklistItem href="https://astro.new/framework-react">
-					<Sprite role="img" name="frameworks/react" size={24} slot="icon" aria-label="React" aria-hidden="true" />
+					<Sprite role="img" name="frameworks/react" size={24} slot="icon" aria-hidden="true" />
 					React
 				</ChecklistItem>
 				<ChecklistItem href="https://astro.new/framework-svelte">
-					<Sprite role="img" name="frameworks/svelte" size={24} slot="icon" aria-label="Svelte" aria-hidden="true" />
+					<Sprite role="img" name="frameworks/svelte" size={24} slot="icon" aria-hidden="true" />
 					Svelte
 				</ChecklistItem>
 				<ChecklistItem href="https://astro.new/framework-vue">
-					<Sprite role="img" name="frameworks/vue" size={24} slot="icon" aria-label="Vue" aria-hidden="true" />
+					<Sprite role="img" name="frameworks/vue" size={24} slot="icon" aria-hidden="true" />
 					Vue
 				</ChecklistItem>
 				<ChecklistItem href="https://astro.new/framework-solid">
-					<Sprite role="img" name="frameworks/solid" size={24} slot="icon" aria-label="Solid" aria-hidden="true" />
+					<Sprite role="img" name="frameworks/solid" size={24} slot="icon" aria-hidden="true" />
 					Solid
 				</ChecklistItem>
 				<ChecklistItem href="https://astro.new/framework-preact">
-					<Sprite role="img" name="frameworks/preact" size={24} slot="icon" aria-label="Preact" aria-hidden="true" />
+					<Sprite role="img" name="frameworks/preact" size={24} slot="icon" aria-hidden="true" />
 					Preact
 				</ChecklistItem>
 				<ChecklistItem href="https://astro.new/framework-alpine">
-					<Sprite role="img" name="frameworks/alpine" size={24} slot="icon" aria-label="Alpine" aria-hidden="true" />
+					<Sprite role="img" name="frameworks/alpine" size={24} slot="icon" aria-hidden="true" />
 					Alpine
 				</ChecklistItem>
 				<ChecklistItem href="https://astro.new/framework-lit">
-					<Sprite role="img" name="frameworks/lit" size={24} slot="icon" aria-label="Lit" aria-hidden="true" />
+					<Sprite role="img" name="frameworks/lit" size={24} slot="icon"aria-hidden="true" />
 					Lit
 				</ChecklistItem>
 				<ChecklistItem href="https://astro.new/minimal">
-					<Sprite role="img" name="frameworks/js" size={24} slot="icon" aria-label="JavaScript" aria-hidden="true" />
+					<Sprite role="img" name="frameworks/js" size={24} slot="icon" aria-hidden="true" />
 					Vanilla
 				</ChecklistItem>
 			</Checklist>

--- a/src/pages/integrations/[slug].astro
+++ b/src/pages/integrations/[slug].astro
@@ -22,7 +22,7 @@ const meta = {
 };
 ---
 
-<Layout meta={meta} collections={collections} current={slug.replace('+', ' + ')} baseHref="/integrations">
+<Layout meta={meta} collections={collections} current={slug.replace('+', ' + ')} baseHref="/integrations" searchLabel="Search integrations">
     <Fragment slot="description">
         <p>Launch your next Astro project at warp speed.</p>
         <p>Try the plugins and components built by our amazing community.</p>
@@ -33,11 +33,11 @@ const meta = {
             href="https://docs.astro.build/en/guides/publish-to-npm/#integrations-library"
             target="_blank"
             rel="noopener noreferrer"
-            class="subtle underline">
+            class="underline subtle">
             Add your own integrations.
         </a>
         Questions about building plugins and components? Join our community on
-        <a href="https://astro.build/chat" class="subtle underline">Discord!</a>
+        <a href="https://astro.build/chat" class="underline subtle">Discord!</a>
     </Fragment>
 
     <Fragment slot="cards">

--- a/src/pages/integrations/index.astro
+++ b/src/pages/integrations/index.astro
@@ -24,7 +24,7 @@ const groups = [
 ];
 ---
 
-<Layout meta={meta} collections={collections} baseHref="/integrations">
+<Layout meta={meta} collections={collections} baseHref="/integrations" searchLabel="Search integrations">
     <Fragment slot="description">
         <p>Launch your next Astro project at warp speed.</p>
         <p>Try the plugins and components built by our amazing community.</p>
@@ -35,10 +35,10 @@ const groups = [
             href="https://docs.astro.build/en/guides/publish-to-npm/#integrations-library"
             target="_blank"
             rel="noopener noreferrer"
-            class="subtle underline"
+            class="underline subtle"
         >Add your own integrations.</a>
         Questions about building plugins and components? Join our community on
-        <a href="https://astro.build/chat" class="subtle underline">Discord!</a>
+        <a href="https://astro.build/chat" class="underline subtle">Discord!</a>
     </Fragment>
 
     <Fragment slot="cards">

--- a/src/pages/themes/[slug].astro
+++ b/src/pages/themes/[slug].astro
@@ -22,17 +22,17 @@ const meta = {
 }
 ---
 
-<Layout meta={meta} collections={collections} current={slug} baseHref="/themes">
+<Layout meta={meta} collections={collections} current={slug} baseHref="/themes" searchLabel="Search integrations">
     <Fragment slot="info">
         <a
             href="https://github.com/withastro/astro.build/issues/new/choose"
             target="_blank"
             rel="noopener noreferrer"
-            class="subtle underline">
+            class="underline subtle">
             Add your own starter project.
         </a>
         Questions about building your own themes? Join our community on
-        <a href="https://astro.build/chat" class="subtle underline">Discord!</a>
+        <a href="https://astro.build/chat" class="underline subtle">Discord!</a>
     </Fragment>
 
     <Fragment slot="cards">

--- a/src/pages/themes/index.astro
+++ b/src/pages/themes/index.astro
@@ -20,16 +20,16 @@ const groups = [
 ]
 ---
 
-<Layout meta={meta} collections={collections} baseHref="/themes">
+<Layout meta={meta} collections={collections} baseHref="/themes" searchLabel="Search themes">
     <Fragment slot="info">
         <a
             href="https://github.com/withastro/astro.build/issues/new/choose"
             target="_blank"
             rel="noopener noreferrer"
-            class="subtle underline"
+            class="underline subtle"
         >Submit your site.</a>
         Questions about building your own themes? Join our community on
-        <a href="https://astro.build/chat" class="subtle underline">Discord!</a>
+        <a href="https://astro.build/chat" class="underline subtle">Discord!</a>
     </Fragment>
 
     <Fragment slot="cards">


### PR DESCRIPTION
I audited `astro.build` with the same test suite used in the docs repo:
- Screen reader navigation using NVDA (Duplicate/missing announcements, unclear or unnecessary landmarks, non-descriptive text, etc).
- Keyboard-only navigation.
- Mobile navigation with/without screen reader and keyboard-only.
- High Contrast/Forced Colors mode (Elements boundaries visibility, unclear active elements, styling conflicts, etc).
- HTML/ARIA semantics.
- Color contrast.

Per-commit, additional comments to clarify decisions and reasons (plus images!):

[Add custom search placeholder prop](https://github.com/withastro/astro.build/commit/57d54e467cd5a14338934da8e0d302f3364db957)
Placeholder text needs to be descriptive and not only use the same label as the input name/type as a way to add more clarity and avoid duplicate announcements. For this reason, I used "Search integrations/themes" as the placeholder text.

[FlyoutMenu accessibility improvements](https://github.com/withastro/astro.build/commit/7f024fc6fd332e7e56c9e792af280c28165f5eac)
- `<details>` elements don't need additional "open" labels since they are already announced as collapsable.
- I removed the navigation landmark inside the collapsible menu, it isn't a different navigation context but rather collapsed links. Having multiple, non-labeled navigation landmarks is bad UX for people who navigate using landmark shortcuts.
- Added an invisible outline (it becomes visible in high contrast) so the collapsed links' boundaries are clear.
- Removed the alt attribute in `<a>` tags.

[Improve cards accessibility](https://github.com/withastro/astro.build/commit/815778e203650ac8fb190e9e30f5d13a82239798)
- Wrapped the cards in lists, so screen reader users know how many themes/integrations/showcases are. 
- Added `role="listitem"` for each card, I wanted to use `<li>` but this caused some CSS issues I couldn't fix, but this role has good compatibility across screen readers so I think it's fine.
- Added an invisible outline for high contrast to know the card's boundaries.

| PR  |  astro.build  |
| ------------------- | ------------------- |
| ![image](https://user-images.githubusercontent.com/61414485/181604269-0e709aea-5f6f-4edd-b3ac-22cd5d9646ee.png) | ![image](https://user-images.githubusercontent.com/61414485/181604162-eb9bd1ae-f374-4ece-9fa2-1082e4a2e866.png)|

[Add descriptive anchor link text](https://github.com/withastro/astro.build/commit/99ad8944a82a4b18163285f0e9d9a08ab8499db4)
- NVDA was announcing headings as "Automatic Partial Hydration, number", this happens because of the "#" anchor link being part of the text. I changed the anchor a bit so it is announced as "Automatic Partial Hydration, section anchor link"

[Highlight selected pill in high contrast](https://github.com/withastro/astro.build/commit/86040ee2c3e7c95a2d4da0de05fb3b1d0262c243)
- In high contrast mode the currently selected pill was not being highlighted, I added a forced-colors media query that fixes the problem using a system color:

| PR  |  astro.build  |
| ------------------- | ------------------- |
| ![image](https://user-images.githubusercontent.com/61414485/181605793-fcb607d0-d92f-44de-8ae5-4be0ff29ea32.png) | ![image](https://user-images.githubusercontent.com/61414485/181605951-e5884f8e-c9f3-43dc-b14a-67690b31d061.png)|

[Fix PixelLink contrast in 404 page](https://github.com/withastro/astro.build/commit/985321ec41825b8f8776bdc8f692c2bc869500a5)
- How I will return home if I can't see "Return Home"? 🤣

| PR  |  astro.build  |
| ------------------- | ------------------- |
| ![image](https://user-images.githubusercontent.com/61414485/181606366-a9bc5a6c-cda8-4752-814f-0586e56bb407.png) | ![image](https://user-images.githubusercontent.com/61414485/181606408-8f896c1e-12a1-4482-8db9-8e67f07d7bce.png)|

[Use descriptive text in the Twitter link](https://github.com/withastro/astro.build/commit/b3117aeebc429b06ec58dd8aefa22529a69415db)
- NVDA announced the Twitter link only was "@astrodotbuild", which isn't clear and could mean any social that uses "@" for profiles, so I changed it for "Twitter".

[Indicate Aside boundaries in high contrast](https://github.com/withastro/astro.build/commit/f2941ffa40e227eac08762f0f46429dae9f2031c)
- Same trick I used for the cards for the same reason.

[Rework landing heading structure and remove unnecessary labels](https://github.com/withastro/astro.build/commit/1fb1dde0be8119a8cd215df2d3d7aecd0eda309e)
- In the commit below I removed h1 from the header nav, this prompted me to restructure the heading levels to be more accurate to the page visual structure (h2 for each of Astro's important features). This should also improve SEO a bit.

[Remove Nav duplicate announcements, unnecessary label/heading, and add primary navigation label](https://github.com/withastro/astro.build/commit/8aba209edef52f190e7fe84458109b2d9754ddc3)
- Removed some unnecessary labels, like using `aria-label` and `aria-hidden` at the same time (aria-hidden just removes the element from the accessibility tree so other roles and labels are ignored).
- Changed `<h1>` for `<span>` since we don't need a heading for header links and this just worsens screen reader users' navigability.

[Indicate DemoIllustration boundaries in high contrast](https://github.com/withastro/astro.build/commit/35c21c9c8a365090d53f91fdbdb50f5ece625481)
- Same old trick, but here's a comparison:

| PR  |  astro.build  |
| ------------------- | ------------------- |
| ![image](https://user-images.githubusercontent.com/61414485/181608901-ca938133-1c2f-4c0a-a8df-0e24297206e0.png) | ![image](https://user-images.githubusercontent.com/61414485/181608933-d490e320-d90b-41f4-923a-c6ef24eab873.png)|

Note: The header is white instead of yellow in the PR because of the anchor link change, now the anchor is an adjacent element rather than part of the heading so it's properly colored in high contrast as a heading and not as a link.

[Add Footer secondary navigation landmark and remove copyright from the list context](https://github.com/withastro/astro.build/commit/7434a140c2ed3bf5664863274a19b6113b7c2125)
- The copyright text was being indicated as a list item, this incorrectly makes the user believe you have 5 links to navigate to, rather than 4.
- The footer should be considered a navigation landmark since it's globally available on the page and has different links from the header (that's why "Connect with Astro" isn't its own navigation landmark, but more like a call to action)

[Change blog tab order and add high contrast border](https://github.com/withastro/astro.build/pull/216/commits/30e579e2c6e762b42f207f14d80d7ec9c062321d)
- Changed the order in which the elements are focused (currently the Twitter link is being focused before the blog post itself)
- Removed the unnecessary "Read more from" text to improve navigability. Now screen reader users can easily skim through the blog posts without needing to wait for "Read more from" to be read or have to use skip text shortcuts.
- Added a border indicating the blog post boundaries for high contrast users (in this case I'm using a border rather than an outline because the focus outline was being mixed with the boundaries outline)

| PR  |  astro.build  |
| ------------------- | ------------------- |
| ![image](https://user-images.githubusercontent.com/61414485/181613216-83bc3476-889b-4214-944b-51a4729db45b.png) | ![image](https://user-images.githubusercontent.com/61414485/181613299-cfd543b5-94fe-48dc-9aae-4fe2d3ca862b.png)|

