### PR TITLE
🐛  fix: Fix broken link of `position-component` integration

### DIFF
--- a/src/data/integrations.json
+++ b/src/data/integrations.json
@@ -1043,7 +1043,7 @@
             "text": "View position-component on NPM"
         },
         "url": {
-            "href": "https://github.com/sacarvy/astro-components/tree/master/position-component",
+            "href": "https://github.com/sacarvy/astro-components/tree/main/packages/position-component",
             "text": "Learn more about position-component"
         },
         "downloads": 317,


### PR DESCRIPTION
**What this PR does**
This PR fixes the bug, described down below, and replaces the dead link with an updated one.

-----

**Describe the bug**
When clicking on the `position-component` integration it redirects to a dead URL

**To Reproduce**
Steps to reproduce the behavior:

- Go to Page https://astro.build/integrations/css+ui/
- Click on `position-component`

**Screenshots**

https://user-images.githubusercontent.com/53407297/185571545-9a47889f-0c99-425f-a8d1-e59a7fbb70e6.mov

**Expected Behavior**

The URL should redirect to https://github.com/sacarvy/astro-components/tree/main/packages/position-component instead of https://github.com/sacarvy/astro-components/tree/main/position-component, since the integration was moved to a sudirectory.

```diff
- https://github.com/sacarvy/astro-components/tree/main/position-component
+ https://github.com/sacarvy/astro-components/tree/main/packages/position-component
```