### PR TITLE
Update Code of Conduct and Governance urls

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -7,8 +7,8 @@
 /issues/site            https://github.com/withastro/astro.build/issues/new/choose
 /issues                 https://github.com/withastro/astro/issues/new/choose
 /releases/:v            https://github.com/withastro/astro/releases/tag/astro@:v  301
-/code-of-conduct        https://github.com/withastro/astro/blob/main/CODE_OF_CONDUCT.md#readme 301
-/governance             https://github.com/withastro/astro/blob/main/GOVERNANCE.md#readme 301
+/code-of-conduct        https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md 301
+/governance             https://github.com/withastro/.github/blob/main/GOVERNANCE.md 301
 
 # Documentation shortcuts
 /config                 https://docs.astro.build/reference/configuration-reference 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -7,8 +7,8 @@
 /issues/site            https://github.com/withastro/astro.build/issues/new/choose
 /issues                 https://github.com/withastro/astro/issues/new/choose
 /releases/:v            https://github.com/withastro/astro/releases/tag/astro@:v  301
-/code-of-conduct        https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md 301
-/governance             https://github.com/withastro/.github/blob/main/GOVERNANCE.md 301
+/code-of-conduct        https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md#readme 301
+/governance             https://github.com/withastro/.github/blob/main/GOVERNANCE.md#readme 301
 
 # Documentation shortcuts
 /config                 https://docs.astro.build/reference/configuration-reference 301


### PR DESCRIPTION
Existing links for Code of Conduct and Governance result in `404` since these files have been moved to the organization community health files location: https://github.com/withastro/.github.