### PR TITLE
Tailwind right margin class affecting nav

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -64,7 +64,7 @@ const stars = formatter.format(monorepo.stars)
                         <Icon name="full-logo-dark" height={32} class="-mb-1" aria-hidden="true" />
                         <span class="sr-only">Astro</span>
                     </a>
-                    <div class="-mr-2 flex items-center md:hidden">
+                    <div class="mr-3 flex items-center md:hidden">
                         <button
                             type="button"
                             id="menubtn"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -64,7 +64,7 @@ const stars = formatter.format(monorepo.stars)
                         <Icon name="full-logo-dark" height={32} class="-mb-1" aria-hidden="true" />
                         <span class="sr-only">Astro</span>
                     </a>
-                    <div class="mr-3 flex items-center md:hidden">
+                    <div class="-mr-2 flex items-center md:hidden">
                         <button
                             type="button"
                             id="menubtn"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -64,7 +64,7 @@ const stars = formatter.format(monorepo.stars)
                         <Icon name="full-logo-dark" height={32} class="-mb-1" aria-hidden="true" />
                         <span class="sr-only">Astro</span>
                     </a>
-                    <div class="-mr-2 flex items-center md:hidden">
+                    <div class="-mr-2 sm:-mr-6 flex items-center md:hidden">
                         <button
                             type="button"
                             id="menubtn"
@@ -78,7 +78,7 @@ const stars = formatter.format(monorepo.stars)
                 </div>
                 <div
                     id="menu"
-                    class="flex flex-col sm:flex-row gap-x-8 gap-y-4 md:ml-10 text-center sm:text-left sm:pb-0"
+                    class="flex flex-col sm:flex-row gap-x-8 gap-y-4 sm:ml-10 text-center sm:text-left sm:pb-0"
                 >
                     {links.map(({ href, text }) => (
                         <a


### PR DESCRIPTION
Closes #323 

Issue: For a small range of screen widths, the hamburger menu opens the nav bar horizontally, but also overlaps with the first menu item. 
![Screenshot 2022-10-03 08 55 43](https://user-images.githubusercontent.com/5098874/193574764-33dc4110-dc83-48ee-b459-7993a0067500.png)

Changing the Tailwind class from `-mr-2` to `mr-2` fixes the hamburger overlap, but when the item is focused, the outline still touches the first nav menu item: (Good enough, though, when no focus is visible.)

![Screenshot 2022-10-03 09 14 05](https://user-images.githubusercontent.com/5098874/193574512-9523da8b-ac00-433e-ab77-fe50908179f1.png)

This PR changes the Tailwind class to `mr-3` which shifts the entire hamburger and its outline far enough so as not to interfere with the menu items, but when closed, is maybe a little too large for what you'd ideally want?

![Screenshot 2022-10-03 09 15 26](https://user-images.githubusercontent.com/5098874/193574511-68ed97db-3432-494a-bc8e-de50accc71ac.png)
![Screenshot 2022-10-03 09 15 41](https://user-images.githubusercontent.com/5098874/193574507-ba79eeb1-f4d6-4665-a43c-dfbbe56ab638.png)

Anyway, do with this what you will!
