### PR TITLE
Update data sources

### DIFF
--- a/src/data/integrations.json
+++ b/src/data/integrations.json
@@ -17,7 +17,7 @@
             "text": "View @astrojs/prism on NPM"
         },
         "url": {
-            "href": "https://astro.build",
+            "href": "https://docs.astro.build/en/reference/api-reference/#prism-",
             "text": "Learn more about @astrojs/prism"
         },
         "downloads": 136099,
@@ -483,7 +483,7 @@
             "text": "View @astrojs/markdown-component on NPM"
         },
         "url": {
-            "href": "https://astro.build",
+            "href": "https://docs.astro.build/en/migrate/#markdown--component-removed",
             "text": "Learn more about @astrojs/markdown-component"
         },
         "downloads": 7930,
@@ -3980,7 +3980,7 @@
             "text": "View agnosticui-astro on NPM"
         },
         "url": {
-            "href": "https://astro.build",
+            "href": "https://github.com/AgnosticUI/agnosticui#readme",
             "text": "Learn more about agnosticui-astro"
         },
         "downloads": 11,


### PR DESCRIPTION
Some of the links on the Integrations page were linking back to https://astro.build, changed them to lead to a reference in the doc (for prism and markdown-component) and GitHub readme (for agnosticui-astro).

Prism and legacy markdown-component are mentioned in multiple places, so I tried to pick the reference that gives the most useful information about them.