### PR TITLE
Redirecting astro.build/play to astro.new

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,6 @@
 # Netlify Redirects
 /chat                   https://discord.gg/grF4GTXXYm
-/play/*                 https://play.astro.build/play/:splat  200
+/play/*                 https://astro.new 301
 /company                https://astroinc.notion.site/Join-The-Astro-Company-51cbe3489aab41388100bc875121ac15 302
 
 # Common GitHub destinations


### PR DESCRIPTION
closes #373

The [Astro Playground](https://astro.build/play) is a little outdated and really won't match more full-featured tools like StackBlitz

This effectively deprecates our playground by redirecting to [astro.new](https://astro.new) where multiple different browser-based editors can be used to try out Astro