### PR TITLE
remove mastodon from main header nav

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -29,6 +29,8 @@ const links: Link[] = [
 
 const formatter = Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 })
 const stars = formatter.format(monorepo.stars)
+
+const socialLinks = site.socialLinks.filter((link) => !link.footerOnly)
 ---
 
 <script>
@@ -94,7 +96,7 @@ const stars = formatter.format(monorepo.stars)
                     id="mobilesocial"
                     class="items-center gap-x-3 flex sm:hidden pb-4"
                 >
-                    {site.socialLinks.map(({ href, text, pack, name }) => {
+                    {socialLinks.map(({ href, text, pack, name }) => {
                         return name === 'github' ? (
                             <a
                                 class="flex items-center no-underline ml-3"
@@ -140,7 +142,7 @@ const stars = formatter.format(monorepo.stars)
                 </div>
             </div>
             <div class="items-center ml-6 pl-1 gap-x-3 hidden md:flex">
-                {site.socialLinks.map(({ href, text, pack, name }) => {
+                {socialLinks.map(({ href, text, pack, name }) => {
                     return name === 'github' ? (
                         <a
                             class="flex items-center no-underline ml-3"

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -33,7 +33,8 @@ const site: Site = {
             me: 'https://m.webtoo.ls/@astro',
             text: 'Follow Astro on Mastodon',
             pack: 'bi',
-            name: 'mastodon'
+            name: 'mastodon',
+            footerOnly: true
         }
     ]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface Site {
     description: string
     image: ImageMetadata
     twitterHandle: string
-    socialLinks: (IconLink & { me?: string })[]
+    socialLinks: (IconLink & { me?: string; footerOnly?: boolean })[]
 }
 
 export interface BlogPost {


### PR DESCRIPTION
Follow-up to #453, includes Mastodon in the site footer but not the main navigation header