### PR TITLE
Fix error on showcase submit

### DIFF
--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -1,4 +1,4 @@
-import fetch, { FormData, Response } from 'node-fetch'
+import fetch, { FormData, Headers, Response } from 'node-fetch'
 import { posix } from 'node:path'
 import * as z from 'zod'
 


### PR DESCRIPTION
This probably also applies to theme submissions. The issue was the use of `Headers`, which exists in Node 18, but not the lambda's node 14

Might also be a good idea to update to 18