### PR TITLE
adding a CI action to verify node 14 builds don't break smoke testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        OS: [ubuntu-latest]
-        NODE_VERSION: [14]
+        OS: [ubuntu-latest, 'windows-latest', 'macos-latest']
+        NODE_VERSION: [14, 16, 18]
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        OS: [ubuntu-latest, 'windows-latest', 'macos-latest']
-        NODE_VERSION: [14, 16, 18]
+        OS: [ubuntu-latest, windows-latest]
+        NODE_VERSION: [14]
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: "Build: ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 3
+    timeout-minutes: 10
     strategy:
       matrix:
         OS: [ubuntu-latest, windows-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    name: "Build: ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 3
+    strategy:
+      matrix:
+        OS: [ubuntu-latest]
+        NODE_VERSION: [14]
+      fail-fast: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2.2.1
+
+      - name: Setup node@${{ matrix.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.NODE_VERSION }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Packages
+        run: pnpm run build
+

--- a/package.json
+++ b/package.json
@@ -64,5 +64,6 @@
         "@tailwindcss/container-queries": "^0.1.0",
         "busboy": "^1.6.0",
         "preact": "^10.11.2"
-    }
+    },
+    "packageManager": "pnpm@7.12.2"
 }


### PR DESCRIPTION
The [monorepo's smoke tests](https://github.com/withastro/astro/blob/d7da0996b6b80499a6f8f2c86a5cfc3e39f741d2/.github/workflows/ci.yml#L183) run a build of the astro.build repo again Node v14

Adding this CI job that will test open PRs against Node 14 so we can deploy with Node 18 without accidentally slipping through a build break that will only hit in the smoke test's v14 environment