### PR TITLE
Add Astropub Plugins

### DIFF
--- a/src/data/integrations.json
+++ b/src/data/integrations.json
@@ -2422,6 +2422,75 @@
         "badges": []
     },
     {
+        "slug": "@astropub/doc",
+        "title": "@astropub/doc",
+        "description": "Create document layouts with minimal markup in Astro",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/astro-community/doc",
+            "text": "View the @astropub/doc source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@astropub/doc",
+            "text": "View @astropub/doc on NPM"
+        },
+        "url": {
+            "href": "https://github.com/astro-community/doc#readme",
+            "text": "Learn more about @astropub/doc"
+        },
+        "downloads": 336,
+        "badges": []
+    },
+    {
+        "slug": "@astropub/flow",
+        "title": "@astropub/flow",
+        "description": "Use components to control flow in Astro",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/astro-community/flow",
+            "text": "View the @astropub/flow source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@astropub/flow",
+            "text": "View @astropub/flow on NPM"
+        },
+        "url": {
+            "href": "https://github.com/astro-community/flow#readme",
+            "text": "Learn more about @astropub/flow"
+        },
+        "downloads": 1354,
+        "badges": []
+    },
+    {
+        "slug": "@astropub/md",
+        "title": "@astropub/md",
+        "description": "Renders any Markdown in Astro, optionally integrating with any existing configuration",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/astro-community/md",
+            "text": "View the @astropub/md source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@astropub/md",
+            "text": "View @astropub/md on NPM"
+        },
+        "url": {
+            "href": "https://github.com/astro-community/md#readme",
+            "text": "Learn more about @astropub/md"
+        },
+        "downloads": 438,
+        "badges": []
+    },
+    {
         "slug": "@astropub/icons",
         "title": "@astropub/icons",
         "description": "Radix Icons for Astro",


### PR DESCRIPTION
Adds 3 Astro plugins:

- `@astropub/doc`, creates document layouts with minimal markup in Astro.
- `@astropub/flow`, lets you use components to control flow in Astro.
- `@astropub/md`, lets you render any Markdown in Astro, optionally integrating with any existing configuration.