### PR TITLE
Updates the figma redirect with the final Community URL

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -19,4 +19,4 @@
 /hack                   https://astroinc.notion.site/FRIDAY-Astro-1-0-Hackathon-9fb3499b375e4b01b88b080fd918b184
 
 # Themes catalog shortcuts
-/resources/image-templates https://www.figma.com/file/eMH1pXPpdciuqIxlOSCqH8/Astro-Theme-Image-Templates-(Community)?node-id=0%3A1&t=sEPaDgiGlukKS3tU-1
+/resources/image-templates https://www.figma.com/community/file/1182357255394426899


### PR DESCRIPTION
We had been using a temporary URL while waiting on Figma to approve the community submission, it's now live 🚀 