### PR TITLE
Redirect to correct link on showcase submit

### DIFF
--- a/netlify/functions/submit-showcase/index.ts
+++ b/netlify/functions/submit-showcase/index.ts
@@ -135,5 +135,5 @@ export const handler: Handler = async (event) => {
         )
     }
 
-    return redirect('/themes/submit/success')
+    return redirect('/showcase/submit/success')
 }


### PR DESCRIPTION
Currently the Netlify function for Showcase submissions redirects to the theme success page.