### PR TITLE
Adds a validation step for theme/showcase submission file size limits

### DIFF
--- a/src/pages/showcase/submit.astro
+++ b/src/pages/showcase/submit.astro
@@ -63,7 +63,7 @@ const bestPractices = [
                 </label>
             </p>
 
-            <Field label="Preview images (max 8MB combined)">
+            <Field label="Preview images (max 6MB combined)">
                 <ImageInput
                     name="previewImage"
                     label="Preview image"

--- a/src/pages/showcase/submit.astro
+++ b/src/pages/showcase/submit.astro
@@ -48,7 +48,7 @@ const bestPractices = [
     </section>
 
     <form
-        name="themeSubmit"
+        name="showcaseSubmit"
         method="POST"
         enctype="multipart/form-data"
         action="/.netlify/functions/submit-showcase"
@@ -106,3 +106,48 @@ const bestPractices = [
         </div>
     </form>
 </Base>
+
+<script>
+    const MAX_SIZE = 6 * 1000 * 1000 // 6MB limit for Netlify Functions
+
+    const form = document.querySelector('form[name="showcaseSubmit"]')
+
+    if (form) {
+        form.addEventListener('submit', (event) => {
+            // calculate the total size of the form data
+            const formsize = getFormDataSize(event.target as HTMLFormElement)
+
+            if (formsize >= MAX_SIZE) {
+                // block the form submission and pop up an alert (lazy UI...I know)
+                event.preventDefault()
+                alert('File size is too large! This is likely due to attached images, try reducing the image size or minifying the image and resubmit.')
+            }
+        })
+    }
+
+    function getFormDataSize(form: HTMLFormElement) {
+        const formdata = new FormData(form)
+
+        return [...formdata.values()]
+            .reduce((acc, next) => {
+                return acc + getSize(next)
+            }, 0)
+    }
+
+    function getSize(value: unknown) {
+        switch (typeof value) {
+            case 'string':
+                return value.length * 2
+            case 'boolean':
+                return 4
+            case 'number':
+                return 8
+        }
+
+        if (value instanceof File) {
+            return value.size
+        }
+
+        return 0
+    }
+</script>

--- a/src/pages/showcase/submit.astro
+++ b/src/pages/showcase/submit.astro
@@ -108,49 +108,19 @@ const bestPractices = [
 </Base>
 
 <script>
+    import { formSizeValidator } from '../../utils/formSize.js'
+
     const MAX_SIZE = 6 * 1000 * 1000 // 6MB limit for Netlify Functions
+    const ALERT =
+        'File size is too large! This is likely due to attached images, try reducing the image size or minifying the image and resubmit.'
+    const FATHOM_EVENT_ID = '4KYQKJX0'
 
     const form = document.querySelector('form[name="showcaseSubmit"]')
 
     if (form) {
-        form.addEventListener('submit', (event) => {
-            // calculate the total size of the form data
-            const formsize = getFormDataSize(event.target as HTMLFormElement)
-
-            if (formsize >= MAX_SIZE) {
-                // block the form submission and pop up an alert (lazy UI...I know)
-                event.preventDefault()
-                alert('File size is too large! This is likely due to attached images, try reducing the image size or minifying the image and resubmit.')
-                if ('fathom' in window) {
-                    (window.fathom as any).trackGoal('4KYQKJX0', 0)
-                }
-            }
-        })
-    }
-
-    function getFormDataSize(form: HTMLFormElement) {
-        const formdata = new FormData(form)
-
-        return [...formdata.values()]
-            .reduce((acc, next) => {
-                return acc + getSize(next)
-            }, 0)
-    }
-
-    function getSize(value: unknown) {
-        switch (typeof value) {
-            case 'string':
-                return value.length * 2
-            case 'boolean':
-                return 4
-            case 'number':
-                return 8
-        }
-
-        if (value instanceof File) {
-            return value.size
-        }
-
-        return 0
+        form.addEventListener(
+            'submit',
+            formSizeValidator(MAX_SIZE, ALERT, FATHOM_EVENT_ID)
+        )
     }
 </script>

--- a/src/pages/showcase/submit.astro
+++ b/src/pages/showcase/submit.astro
@@ -121,6 +121,9 @@ const bestPractices = [
                 // block the form submission and pop up an alert (lazy UI...I know)
                 event.preventDefault()
                 alert('File size is too large! This is likely due to attached images, try reducing the image size or minifying the image and resubmit.')
+                if ('fathom' in window) {
+                    (window.fathom as any).trackGoal('4KYQKJX0', 0)
+                }
             }
         })
     }

--- a/src/pages/themes/submit/index.astro
+++ b/src/pages/themes/submit/index.astro
@@ -101,7 +101,7 @@ const toolOptions = [
                 </label>
             </p>
 
-            <Field label="Preview images (max 8MB combined)">
+            <Field label="Preview images (max 6MB combined)">
                 <ImageInput
                     name="images"
                     label="Preview image"

--- a/src/pages/themes/submit/index.astro
+++ b/src/pages/themes/submit/index.astro
@@ -203,6 +203,9 @@ if (form) {
             // block the form submission and pop up an alert (lazy UI...I know)
             event.preventDefault()
             alert('File size is too large! This is likely due to attached images, try reducing the image size or minifying the image and resubmit.')
+            if ('fathom' in window) {
+                (window.fathom as any).trackGoal('GMXMIRTN', 0)
+            }
         }
     })
 }

--- a/src/pages/themes/submit/index.astro
+++ b/src/pages/themes/submit/index.astro
@@ -79,7 +79,12 @@ const toolOptions = [
                 class="inline-block"
                 aria-hidden="true"
             />
-            Looking for inspiration for your theme's preview images? Check out our <a href="/resources/image-templates" target="_blank" class="underline font-semibold">Image Templates</a>!
+            Looking for inspiration for your theme's preview images? Check out our
+            <a
+                href="/resources/image-templates"
+                target="_blank"
+                class="underline font-semibold">Image Templates</a
+            >!
         </p>
     </Aside>
 
@@ -190,49 +195,19 @@ const toolOptions = [
 </Base>
 
 <script>
+    import { formSizeValidator } from '../../../utils/formSize.js'
+
     const MAX_SIZE = 6 * 1000 * 1000 // 6MB limit for Netlify Functions
+    const ALERT =
+        'File size is too large! This is likely due to attached images, try reducing the image size or minifying the image and resubmit.'
+    const FATHOM_EVENT_ID = 'GMXMIRTN'
 
-const form = document.querySelector('form[name="themeSubmit"]')
+    const form = document.querySelector('form[name="themeSubmit"]')
 
-if (form) {
-    form.addEventListener('submit', (event) => {
-        // calculate the total size of the form data
-        const formsize = getFormDataSize(event.target as HTMLFormElement)
-
-        if (formsize >= MAX_SIZE) {
-            // block the form submission and pop up an alert (lazy UI...I know)
-            event.preventDefault()
-            alert('File size is too large! This is likely due to attached images, try reducing the image size or minifying the image and resubmit.')
-            if ('fathom' in window) {
-                (window.fathom as any).trackGoal('GMXMIRTN', 0)
-            }
-        }
-    })
-}
-
-function getFormDataSize(form: HTMLFormElement) {
-    const formdata = new FormData(form)
-
-    return [...formdata.values()]
-        .reduce((acc, next) => {
-            return acc + getSize(next)
-        }, 0)
-}
-
-function getSize(value: unknown) {
-    switch (typeof value) {
-        case 'string':
-            return value.length * 2
-        case 'boolean':
-            return 4
-        case 'number':
-            return 8
+    if (form) {
+        form.addEventListener(
+            'submit',
+            formSizeValidator(MAX_SIZE, ALERT, FATHOM_EVENT_ID)
+        )
     }
-
-    if (value instanceof File) {
-        return value.size
-    }
-
-    return 0
-}
 </script>

--- a/src/pages/themes/submit/index.astro
+++ b/src/pages/themes/submit/index.astro
@@ -6,7 +6,6 @@ import Field from '../../../components/forms/Field.jsx'
 import ImageInput from '../../../components/forms/ImageInput.jsx'
 import InputField from '../../../components/forms/InputField.jsx'
 import LabelText from '../../../components/forms/LabelText.jsx'
-import Note from '../../../components/Note.astro'
 import RichTextEditor from '../../../components/forms/RichTextEditor.astro'
 import { TagInput, TagSelect } from '../../../components/forms/TagInput.jsx'
 import TextAreaField from '../../../components/forms/TextAreaField.astro'
@@ -189,3 +188,48 @@ const toolOptions = [
         </div>
     </form>
 </Base>
+
+<script>
+    const MAX_SIZE = 6 * 1000 * 1000 // 6MB limit for Netlify Functions
+
+const form = document.querySelector('form[name="themeSubmit"]')
+
+if (form) {
+    form.addEventListener('submit', (event) => {
+        // calculate the total size of the form data
+        const formsize = getFormDataSize(event.target as HTMLFormElement)
+
+        if (formsize >= MAX_SIZE) {
+            // block the form submission and pop up an alert (lazy UI...I know)
+            event.preventDefault()
+            alert('File size is too large! This is likely due to attached images, try reducing the image size or minifying the image and resubmit.')
+        }
+    })
+}
+
+function getFormDataSize(form: HTMLFormElement) {
+    const formdata = new FormData(form)
+
+    return [...formdata.values()]
+        .reduce((acc, next) => {
+            return acc + getSize(next)
+        }, 0)
+}
+
+function getSize(value: unknown) {
+    switch (typeof value) {
+        case 'string':
+            return value.length * 2
+        case 'boolean':
+            return 4
+        case 'number':
+            return 8
+    }
+
+    if (value instanceof File) {
+        return value.size
+    }
+
+    return 0
+}
+</script>

--- a/src/utils/formSize.ts
+++ b/src/utils/formSize.ts
@@ -1,0 +1,42 @@
+export function getFormDataSize(form: HTMLFormElement) {
+    const formdata = new FormData(form)
+
+    return [...formdata.values()]
+        .reduce((acc, next) => {
+            return acc + getSize(next)
+        }, 0)
+}
+
+export function formSizeValidator(maxSize: number, message: string, fathomEventId?: string) {
+    return function onSubmit(event: SubmitEvent) {
+        // calculate the total size of the form data
+        const formsize = getFormDataSize(event.target as HTMLFormElement)
+
+        if (formsize >= maxSize) {
+            // block the form submission and pop up an alert (lazy UI...I know)
+            event.preventDefault()
+            alert(message)
+
+            if (fathomEventId && 'fathom' in window) {
+                (window.fathom as any).trackGoal(fathomEventId, 0)
+            }
+        }
+    }
+}
+
+function getSize(value: unknown) {
+    switch (typeof value) {
+        case 'string':
+            return value.length * 2
+        case 'boolean':
+            return 4
+        case 'number':
+            return 8
+    }
+
+    if (value instanceof File) {
+        return value.size
+    }
+
+    return 0
+}

--- a/src/utils/formSize.ts
+++ b/src/utils/formSize.ts
@@ -1,13 +1,16 @@
 export function getFormDataSize(form: HTMLFormElement) {
     const formdata = new FormData(form)
 
-    return [...formdata.values()]
-        .reduce((acc, next) => {
-            return acc + getSize(next)
-        }, 0)
+    return [...formdata.values()].reduce((acc, next) => {
+        return acc + getSize(next)
+    }, 0)
 }
 
-export function formSizeValidator(maxSize: number, message: string, fathomEventId?: string) {
+export function formSizeValidator(
+    maxSize: number,
+    message: string,
+    fathomEventId?: string
+) {
     return function onSubmit(event: SubmitEvent) {
         // calculate the total size of the form data
         const formsize = getFormDataSize(event.target as HTMLFormElement)
@@ -18,7 +21,7 @@ export function formSizeValidator(maxSize: number, message: string, fathomEventI
             alert(message)
 
             if (fathomEventId && 'fathom' in window) {
-                (window.fathom as any).trackGoal(fathomEventId, 0)
+                ;(window.fathom as any).trackGoal(fathomEventId, 0)
             }
         }
     }


### PR DESCRIPTION
Netlify Functions limits requests to [6MB max](https://docs.netlify.com/functions/overview/#default-deployment-options)

[x] updates the submission forms to show 6MB as the max
[x] adds a basic FormData size calculation to alert users when images are too large **before** hitting Netlify (where the function just fails)
[x] logs a custom event to Fathom so we can track how often the file limit is hit