### PR TITLE
Fix invisible a11y issue in lighthouse

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -6,7 +6,7 @@ import HeroCard from './HeroCard.astro'
 import Starfield from './Starfield.astro'
 ---
 
-<section class="pt-24 pb-8 overflow-hidden relative bg-purple-800">
+<section class="pt-24 pb-8 overflow-hidden relative bg-purple-800 z-10">
     <Starfield />
     <div class="mx-auto max-w-7xl px-4 sm:px-6">
         <div class="lg:grid lg:grid-cols-12 mx-auto lg:gap-16 justify-center">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -6,7 +6,7 @@ import HeroCard from './HeroCard.astro'
 import Starfield from './Starfield.astro'
 ---
 
-<section class="pt-24 pb-8 overflow-hidden relative">
+<section class="pt-24 pb-8 overflow-hidden relative bg-purple-800">
     <Starfield />
     <div class="mx-auto max-w-7xl px-4 sm:px-6">
         <div class="lg:grid lg:grid-cols-12 mx-auto lg:gap-16 justify-center">

--- a/src/components/Starfield.astro
+++ b/src/components/Starfield.astro
@@ -9,7 +9,7 @@ const { subtle, noGradient } = Astro.props as Props;
 
 <div class:list={[
     "pointer-events-none",
-    "absolute inset-0 border-t-[3.5rem] border-slate-900",
+    "absolute inset-0 -z-50 border-t-[3.5rem] border-slate-900",
     subtle && "bg-[length:100%_175%]",
     noGradient ? 'bg-slate-900' : 'bg-gradient-to-b bg-no-repeat bg-purple-800 from-slate-900 to-purple-800'
 ]}>

--- a/src/components/Starfield.astro
+++ b/src/components/Starfield.astro
@@ -9,7 +9,7 @@ const { subtle, noGradient } = Astro.props as Props;
 
 <div class:list={[
     "pointer-events-none",
-    "absolute inset-0 -z-50 border-t-[3.5rem] border-slate-900",
+    "absolute inset-0 border-t-[3.5rem] border-slate-900",
     subtle && "bg-[length:100%_175%]",
     noGradient ? 'bg-slate-900' : 'bg-gradient-to-b bg-no-repeat bg-purple-800 from-slate-900 to-purple-800'
 ]}>


### PR DESCRIPTION
Lighthouse showed an accessibility issue with the background to text contrast ratio on a specific element. The issue didn't really exist, because the `Starfield` component floats behind, applying a gradient with a dark enough color not to cause any issues. Lighthouse can't detect this, so we give a "fallback" background to the header which exists behind the `Starfield` component. 

TLDR: The end result is the same, but the single accessibility issue on the homepage is fixed

![image](https://user-images.githubusercontent.com/64310361/211097569-78c39a65-cda3-4c48-9dbd-f1993e1d6cba.png)
