### PR TITLE
Fix 404 monitoring

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -8,7 +8,7 @@ export interface Props {
     title?: string
     description?: string
     image?: string | ImageMetadata
-    canonicalURL?: URL
+    canonicalURL?: URL | null
     pageType?: 'website' | 'article'
 }
 
@@ -47,7 +47,7 @@ const title = Astro.props.title ? [Astro.props.title, site.title].join(' | ') : 
     image={resolvedImageWithDomain}
     twitterHandle={site.twitterHandle}
     pageType={pageType}
-    url={ensureTrailingSlash(canonicalURL.toString())}
+    url={canonicalURL && ensureTrailingSlash(canonicalURL.toString())}
 />
 
 <!-- Fathom - beautiful, simple website analytics -->

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,10 +5,9 @@ import Layout from '../layouts/Base.astro'
 
 const title = 'Page Not Found'
 const description = 'Astro is a new kind of static site builder for the modern web. Powerful developer experience meets lightweight output.'
-const canonicalURL = new URL('./404', Astro.site)
 ---
 
-<Layout title={title} description={description} canonicalURL={canonicalURL} class="flex items-center">
+<Layout title={title} description={description} canonicalURL={null} class="flex items-center">
     <Section class="flex flex-col justify-center items-center text-center">
 		<h2 class="font-display text-3xl font-bold pb-6">Lost in space there, astronaut?</h2>
 		<p class="pb-8">We couldn&rsquo;t find the page you were looking for&mdash;let&rsquo;s get you back to HQ.</p>


### PR DESCRIPTION
I noticed that all 404 events in Fathom are being reported as for the `/404/` path rather than a useful path like we get for docs. My guess is that this because we don’t set a canonical URL for 404 pages in docs but this is set for astro.build.

This PR sets the canonical URL to `null` on the 404 page. The SEO component we’re using still emits the canonical tag but with the value an empty string, so we need to test if Fathom will ignore that as I would hope.