### PR TITLE
adds Fathom events to theme details CTAs

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -2,13 +2,15 @@
 interface Props {
     theme?: 'primary' | 'secondary' | 'hollow'
     size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
-    href?: string
     alt?: string
     download?: boolean
     type?: 'button' | 'submit' | 'reset'
     external?: boolean
     class?: string
+    analyticsEvent?: string
+    analyticsEventValue?: number
 }
+
 const {
     theme = 'primary',
     size = 'md',
@@ -18,8 +20,11 @@ const {
     type,
     external,
     class: className = '',
+    analyticsEvent,
+    analyticsEventValue = 0,
     ...props
 } = Astro.props as Props
+
 const Component = href ? 'a' : 'button'
 ---
 
@@ -31,9 +36,22 @@ const Component = href ? 'a' : 'button'
     type={type}
     download={download}
     target={href && external ? "_blank" : undefined}
+    data-analytics-event={`${analyticsEvent}:${analyticsEventValue}`}
 >
     <slot />
 </Component>
+
+<script>
+    document.querySelectorAll<HTMLElement>('[data-analytics-event]').forEach((elem) => {
+        if ('fathom' in window && elem.dataset.analyticsEvent) {
+            const [eventId, value] = elem.dataset.analyticsEvent.split(':')
+
+            elem.addEventListener('click', () => {
+                (window.fathom as any).trackGoal(eventId, parseInt(value!))
+            })
+        }
+    })
+</script>
 
 <style>
     .btn {

--- a/src/pages/themes/details/[slug].astro
+++ b/src/pages/themes/details/[slug].astro
@@ -135,17 +135,37 @@ const { theme } = Astro.props
                 }
 
                 <div class="flex flex-wrap gap-4">
-                    <Button external href={theme.buyUrl?.href || theme.repoUrl.href} class="flex gap-2">
-                        {
-                            theme.buyUrl?.href ? 'Buy Now' : 'Get Started'
-                        }
-                        <Icon name='heroicons-solid:external-link' size={18} class="opacity-70 -mr-1" aria-hidden="true" />
+                    <Button
+                        external
+                        href={theme.buyUrl?.href || theme.repoUrl.href}
+                        class="flex gap-2"
+                        analyticsEvent="PDDOCXCA"
+                        analyticsEventValue={theme.buyUrl?.href ? 1 : 0}
+                    >
+                        {theme.buyUrl?.href ? 'Buy Now' : 'Get Started'}
+                        <Icon
+                            name="heroicons-solid:external-link"
+                            size={18}
+                            class="opacity-70 -mr-1"
+                            aria-hidden="true"
+                        />
                     </Button>
                     {
                         theme.demoUrl?.href && (
-                            <Button external theme="secondary" href={theme.demoUrl.href} class="flex gap-2">
+                            <Button
+                                external
+                                theme="secondary"
+                                href={theme.demoUrl.href}
+                                class="flex gap-2"
+                                analyticsEvent="DI9WVRXV"
+                            >
                                 Live Demo
-                                <Icon name='heroicons-solid:external-link' size={18} class="opacity-70 -mr-1" aria-hidden="true" />
+                                <Icon
+                                    name="heroicons-solid:external-link"
+                                    size={18}
+                                    class="opacity-70 -mr-1"
+                                    aria-hidden="true"
+                                />
                             </Button>
                         )
                     }
@@ -222,7 +242,9 @@ const { theme } = Astro.props
     requestIdleCallback(() => {
         const carousel = document.querySelector('astro-carousel')
         if (carousel) {
-            carousel.querySelectorAll('img').forEach((elem) => elem.setAttribute('loading', 'eager'))
+            carousel
+                .querySelectorAll('img')
+                .forEach((elem) => elem.setAttribute('loading', 'eager'))
         }
     })
 </script>


### PR DESCRIPTION
Adds two separate events when visitors click on "Get Started" or "Live Demo" for a theme

Note that these events still fall under Fathom's terms of service and match our existing privacy-focused data policy