### PR TITLE
Fix link to The Guardian Engineering site

### DIFF
--- a/src/data/showcase/the-guardian-engineering.json
+++ b/src/data/showcase/the-guardian-engineering.json
@@ -1,7 +1,7 @@
 {
     "title": "The Guardian Engineering",
     "image": "./images/the-guardian-engineering.png",
-    "url": "https://theguardian.engineering/open-source/",
+    "url": "https://theguardian.engineering/open-source",
     "categories": ["tech"],
     "featured": 2
 }


### PR DESCRIPTION
Previously, the link to The Guardian Engineering led to a `Page Not Found` page: https://theguardian.engineering/open-source/. Removing the trailing slash fixes the issue: https://theguardian.engineering/open-source