### PR TITLE
Testing netlify's deploy URL env flag

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,7 @@ import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://astro.build',
+  site: process.env.DEPLOY_PRIME_URL || 'https://astro.build',
   integrations: [
     tailwind(),
     image({ serviceEntryPoint: '@astrojs/image/sharp' }),

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,31 +1,34 @@
-import image from '@astrojs/image';
-import mdx from '@astrojs/mdx';
-import preact from '@astrojs/preact';
-import prefetch from '@astrojs/prefetch';
-import sitemap from '@astrojs/sitemap';
-import tailwind from '@astrojs/tailwind';
-import webfinger from 'astro-webfinger';
-import { defineConfig } from 'astro/config';
+import image from '@astrojs/image'
+import mdx from '@astrojs/mdx'
+import preact from '@astrojs/preact'
+import prefetch from '@astrojs/prefetch'
+import sitemap from '@astrojs/sitemap'
+import tailwind from '@astrojs/tailwind'
+import webfinger from 'astro-webfinger'
+import { defineConfig } from 'astro/config'
+
+/* https://docs.netlify.com/configure-builds/environment-variables/#read-only-variables */
+const NETLIFY_PREVIEW_SITE = process.env.CONTEXT !== 'production' && process.env.DEPLOY_PRIME_URL
 
 // https://astro.build/config
 export default defineConfig({
-  site: process.env.DEPLOY_PRIME_URL || 'https://astro.build',
-  integrations: [
-    tailwind(),
-    image({ serviceEntryPoint: '@astrojs/image/sharp' }),
-    prefetch(),
-    mdx(),
-    sitemap(),
-    preact(),
-    webfinger({
-      instance: 'webtoo.ls',
-      username: 'astro',
-    }),
-  ],
-  vite: {
-    ssr: {
-      noExternal: ['smartypants'],
-      external: ['svgo']
+    site: NETLIFY_PREVIEW_SITE || 'https://astro.build',
+    integrations: [
+        tailwind(),
+        image({ serviceEntryPoint: '@astrojs/image/sharp' }),
+        prefetch(),
+        mdx(),
+        sitemap(),
+        preact(),
+        webfinger({
+            instance: 'webtoo.ls',
+            username: 'astro'
+        })
+    ],
+    vite: {
+        ssr: {
+            noExternal: ['smartypants'],
+            external: ['svgo']
+        }
     }
-  }
 })


### PR DESCRIPTION
This updates the `astro.config.mjs` file to prioritize Netlify preview URLs for the main `site` config

In non-production deployments, the Netlify preview URL will be used as the root domain, in production or when Netlify env variables are undefined `https://astro.build` will be used