### PR TITLE
fix zod import

### DIFF
--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -1,6 +1,6 @@
+import { z } from 'astro/zod'
 import fetch, { FormData, Headers, Response } from 'node-fetch'
 import { posix } from 'node:path'
-import * as z from 'astro/zod'
 
 const discordMessageAttachmentSchema = z.object({
     filename: z.string(),


### PR DESCRIPTION
`import * as z from 'astro/zod'` is not valid at runtime at the moment