### PR TITLE
Remove redundant entries for @astrojs/cloudflare adapter

### DIFF
--- a/scripts/npm.mjs
+++ b/scripts/npm.mjs
@@ -73,8 +73,14 @@ export async function searchByKeyword(keyword, ranking = 'quality') {
         total = results.total
     } while (total > objects.length)
 
-    return objects.reduce((acc, next) => {
-        acc.set(next.package.name, next)
-        return acc
-    }, new Map())
+    return objects
+        .filter(({ package: pkg }) => {
+            // remove any published forks of official @astrojs integrations
+            return pkg.links.repository !== 'https://github.com/withastro/astro'
+                || pkg.name.startsWith('@astrojs/')
+        })
+        .reduce((acc, next) => {
+            acc.set(next.package.name, next)
+            return acc
+        }, new Map())
 }

--- a/src/data/integrations.json
+++ b/src/data/integrations.json
@@ -20,7 +20,7 @@
             "href": "https://docs.astro.build/en/reference/api-reference/#prism-",
             "text": "Learn more about @astrojs/prism"
         },
-        "downloads": 212838,
+        "downloads": 221690,
         "badges": []
     },
     {
@@ -48,7 +48,7 @@
             "alt": "@astrojs/tailwind",
             "src": "/assets/integrations/tailwind.svg"
         },
-        "downloads": 106071,
+        "downloads": 110218,
         "badges": [
             "featured"
         ],
@@ -74,7 +74,7 @@
             "href": "https://github.com/unocss/unocss#readme",
             "text": "Learn more about @unocss/astro"
         },
-        "downloads": 99491,
+        "downloads": 104113,
         "badges": []
     },
     {
@@ -103,7 +103,7 @@
             "alt": "@astrojs/sitemap",
             "src": "/assets/integrations/sitemap.svg"
         },
-        "downloads": 72983,
+        "downloads": 76043,
         "badges": [
             "featured"
         ],
@@ -135,7 +135,7 @@
             "alt": "@astrojs/react",
             "src": "/assets/integrations/react.svg"
         },
-        "downloads": 57945,
+        "downloads": 60807,
         "badges": []
     },
     {
@@ -163,7 +163,7 @@
             "alt": "@astrojs/mdx",
             "src": "/assets/integrations/mdx.svg"
         },
-        "downloads": 49403,
+        "downloads": 51427,
         "badges": [
             "featured"
         ],
@@ -194,7 +194,7 @@
             "alt": "@astrojs/image",
             "src": "/assets/integrations/image.svg"
         },
-        "downloads": 38489,
+        "downloads": 40032,
         "badges": [
             "featured"
         ],
@@ -226,7 +226,7 @@
             "alt": "@astrojs/vue",
             "src": "/assets/integrations/vue.svg"
         },
-        "downloads": 29779,
+        "downloads": 30832,
         "badges": []
     },
     {
@@ -255,35 +255,8 @@
             "alt": "@astrojs/svelte",
             "src": "/assets/integrations/svelte.svg"
         },
-        "downloads": 28277,
+        "downloads": 29393,
         "badges": []
-    },
-    {
-        "slug": "astro-compress",
-        "title": "astro-compress",
-        "description": "🗜️ AstroJS compression utilities. Compress HTML, CSS, JavaScript and more.",
-        "categories": [
-            "css+ui",
-            "performance+seo"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/astro-community/astro-compress",
-            "text": "View the astro-compress source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-compress",
-            "text": "View astro-compress on NPM"
-        },
-        "url": {
-            "href": "https://github.com/astro-community/astro-compress#readme",
-            "text": "Learn more about astro-compress"
-        },
-        "downloads": 21897,
-        "badges": [
-            "featured"
-        ],
-        "featured": 4
     },
     {
         "slug": "astro-icon",
@@ -310,11 +283,38 @@
             "alt": "astro-icon",
             "src": "/assets/integrations/astro-icon.svg"
         },
-        "downloads": 21895,
+        "downloads": 22758,
         "badges": [
             "featured"
         ],
         "featured": 6
+    },
+    {
+        "slug": "astro-compress",
+        "title": "astro-compress",
+        "description": "🗜️ AstroJS compression utilities. Compress HTML, CSS, JavaScript and more.",
+        "categories": [
+            "css+ui",
+            "performance+seo"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/astro-community/astro-compress",
+            "text": "View the astro-compress source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-compress",
+            "text": "View astro-compress on NPM"
+        },
+        "url": {
+            "href": "https://github.com/astro-community/astro-compress#readme",
+            "text": "Learn more about astro-compress"
+        },
+        "downloads": 22618,
+        "badges": [
+            "featured"
+        ],
+        "featured": 4
     },
     {
         "slug": "@astrojs/prefetch",
@@ -338,7 +338,7 @@
             "href": "https://docs.astro.build/en/guides/integrations-guide/prefetch/",
             "text": "Learn more about @astrojs/prefetch"
         },
-        "downloads": 19233,
+        "downloads": 19787,
         "badges": []
     },
     {
@@ -367,7 +367,7 @@
             "alt": "@astrojs/node",
             "src": "/assets/integrations/node.svg"
         },
-        "downloads": 17965,
+        "downloads": 18830,
         "badges": []
     },
     {
@@ -396,7 +396,7 @@
             "alt": "@astrojs/preact",
             "src": "/assets/integrations/preact.svg"
         },
-        "downloads": 17377,
+        "downloads": 18210,
         "badges": []
     },
     {
@@ -426,7 +426,7 @@
             "alt": "@astrojs/partytown",
             "src": "/assets/integrations/partytown.svg"
         },
-        "downloads": 16520,
+        "downloads": 17144,
         "badges": [
             "featured"
         ],
@@ -453,7 +453,7 @@
             "href": "https://github.com/astro-community/astro-critters#readme",
             "text": "Learn more about astro-critters"
         },
-        "downloads": 12723,
+        "downloads": 12961,
         "badges": []
     },
     {
@@ -482,8 +482,35 @@
             "alt": "@astrojs/vercel",
             "src": "/assets/integrations/vercel.svg"
         },
-        "downloads": 10895,
+        "downloads": 11399,
         "badges": []
+    },
+    {
+        "slug": "astro-seo",
+        "title": "astro-seo",
+        "description": "Makes it easy to add SEO relevant tags to your Astro app.",
+        "categories": [
+            "css+ui",
+            "performance+seo"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/jonasmerlin/astro-seo",
+            "text": "View the astro-seo source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-seo",
+            "text": "View astro-seo on NPM"
+        },
+        "url": {
+            "href": "https://github.com/jonasmerlin/astro-seo#readme",
+            "text": "Learn more about astro-seo"
+        },
+        "downloads": 10230,
+        "badges": [
+            "featured"
+        ],
+        "featured": 10
     },
     {
         "slug": "@astrojs/solid-js",
@@ -511,35 +538,8 @@
             "alt": "@astrojs/solid-js",
             "src": "/assets/integrations/solid.svg"
         },
-        "downloads": 9844,
+        "downloads": 10188,
         "badges": []
-    },
-    {
-        "slug": "astro-seo",
-        "title": "astro-seo",
-        "description": "Makes it easy to add SEO relevant tags to your Astro app.",
-        "categories": [
-            "css+ui",
-            "performance+seo"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/jonasmerlin/astro-seo",
-            "text": "View the astro-seo source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-seo",
-            "text": "View astro-seo on NPM"
-        },
-        "url": {
-            "href": "https://github.com/jonasmerlin/astro-seo#readme",
-            "text": "Learn more about astro-seo"
-        },
-        "downloads": 9785,
-        "badges": [
-            "featured"
-        ],
-        "featured": 10
     },
     {
         "slug": "@astrojs/markdown-component",
@@ -562,7 +562,7 @@
             "href": "https://docs.astro.build/en/migrate/#markdown--component-removed",
             "text": "Learn more about @astrojs/markdown-component"
         },
-        "downloads": 9548,
+        "downloads": 9886,
         "badges": []
     },
     {
@@ -587,7 +587,7 @@
             "href": "https://docs.astro.build/en/guides/integrations-guide/cloudflare/",
             "text": "Learn more about @astrojs/cloudflare"
         },
-        "downloads": 9151,
+        "downloads": 9591,
         "badges": []
     },
     {
@@ -611,7 +611,7 @@
             "href": "https://github.com/alextim/astro-lib/tree/main/packages/astro-robots-txt#readme",
             "text": "Learn more about astro-robots-txt"
         },
-        "downloads": 8247,
+        "downloads": 8602,
         "badges": [
             "featured"
         ],
@@ -638,7 +638,7 @@
             "href": "https://astro-i18next.yassinedoghri.com/",
             "text": "Learn more about astro-i18next"
         },
-        "downloads": 8152,
+        "downloads": 8465,
         "badges": [
             "featured"
         ],
@@ -670,7 +670,7 @@
             "alt": "@astrojs/netlify",
             "src": "/assets/integrations/netlify.svg"
         },
-        "downloads": 6641,
+        "downloads": 6952,
         "badges": []
     },
     {
@@ -699,7 +699,7 @@
             "alt": "@astrojs/lit",
             "src": "/assets/integrations/lit.svg"
         },
-        "downloads": 5573,
+        "downloads": 5725,
         "badges": []
     },
     {
@@ -723,11 +723,34 @@
             "href": "https://github.com/RafidMuhymin/astro-imagetools#readme",
             "text": "Learn more about astro-imagetools"
         },
-        "downloads": 5518,
+        "downloads": 5701,
         "badges": [
             "featured"
         ],
         "featured": 2
+    },
+    {
+        "slug": "@astro-community/astro-embed-youtube",
+        "title": "@astro-community/astro-embed-youtube",
+        "description": "Component to easily embed YouTube videos on your Astro site",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/astro-community/astro-embed",
+            "text": "View the @astro-community/astro-embed-youtube source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@astro-community/astro-embed-youtube",
+            "text": "View @astro-community/astro-embed-youtube on NPM"
+        },
+        "url": {
+            "href": "https://github.com/astro-community/astro-embed/tree/main/packages/astro-embed-youtube#readme",
+            "text": "Learn more about @astro-community/astro-embed-youtube"
+        },
+        "downloads": 4718,
+        "badges": []
     },
     {
         "slug": "@astrolib/seo",
@@ -750,30 +773,7 @@
             "href": "https://github.com/onwidget/astrolib/tree/main/packages/seo",
             "text": "Learn more about @astrolib/seo"
         },
-        "downloads": 4515,
-        "badges": []
-    },
-    {
-        "slug": "@astro-community/astro-embed-youtube",
-        "title": "@astro-community/astro-embed-youtube",
-        "description": "Component to easily embed YouTube videos on your Astro site",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/astro-community/astro-embed",
-            "text": "View the @astro-community/astro-embed-youtube source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@astro-community/astro-embed-youtube",
-            "text": "View @astro-community/astro-embed-youtube on NPM"
-        },
-        "url": {
-            "href": "https://github.com/astro-community/astro-embed/tree/main/packages/astro-embed-youtube#readme",
-            "text": "Learn more about @astro-community/astro-embed-youtube"
-        },
-        "downloads": 4443,
+        "downloads": 4688,
         "badges": []
     },
     {
@@ -797,7 +797,7 @@
             "href": "https://github.com/onwidget/astrolib/tree/main/packages/analytics",
             "text": "Learn more about @astrolib/analytics"
         },
-        "downloads": 4175,
+        "downloads": 4320,
         "badges": []
     },
     {
@@ -820,7 +820,30 @@
             "href": "https://github.com/astro-community/astro-embed/tree/main/packages/astro-embed-twitter#readme",
             "text": "Learn more about @astro-community/astro-embed-twitter"
         },
-        "downloads": 2887,
+        "downloads": 3038,
+        "badges": []
+    },
+    {
+        "slug": "@astro-community/astro-embed-vimeo",
+        "title": "@astro-community/astro-embed-vimeo",
+        "description": "Component to easily embed Vimeo videos on your Astro site",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/astro-community/astro-embed",
+            "text": "View the @astro-community/astro-embed-vimeo source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@astro-community/astro-embed-vimeo",
+            "text": "View @astro-community/astro-embed-vimeo on NPM"
+        },
+        "url": {
+            "href": "https://github.com/astro-community/astro-embed/tree/main/packages/astro-embed-vimeo#readme",
+            "text": "Learn more about @astro-community/astro-embed-vimeo"
+        },
+        "downloads": 3018,
         "badges": []
     },
     {
@@ -850,30 +873,7 @@
             "alt": "@astrojs/alpinejs",
             "src": "/assets/integrations/alpinejs.svg"
         },
-        "downloads": 2881,
-        "badges": []
-    },
-    {
-        "slug": "@astro-community/astro-embed-vimeo",
-        "title": "@astro-community/astro-embed-vimeo",
-        "description": "Component to easily embed Vimeo videos on your Astro site",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/astro-community/astro-embed",
-            "text": "View the @astro-community/astro-embed-vimeo source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@astro-community/astro-embed-vimeo",
-            "text": "View @astro-community/astro-embed-vimeo on NPM"
-        },
-        "url": {
-            "href": "https://github.com/astro-community/astro-embed/tree/main/packages/astro-embed-vimeo#readme",
-            "text": "Learn more about @astro-community/astro-embed-vimeo"
-        },
-        "downloads": 2867,
+        "downloads": 2993,
         "badges": []
     },
     {
@@ -896,7 +896,7 @@
             "href": "https://github.com/astro-community/astro-embed/tree/main/packages/astro-embed#readme",
             "text": "Learn more about astro-embed"
         },
-        "downloads": 2825,
+        "downloads": 2978,
         "badges": []
     },
     {
@@ -923,7 +923,7 @@
             "alt": "@storyblok/astro",
             "src": "/assets/integrations/storyblok.svg"
         },
-        "downloads": 2286,
+        "downloads": 2366,
         "badges": [
             "featured"
         ],
@@ -950,7 +950,7 @@
             "href": "https://github.com/astro-community/astro-rome#readme",
             "text": "Learn more about astro-rome"
         },
-        "downloads": 2192,
+        "downloads": 2202,
         "badges": []
     },
     {
@@ -979,7 +979,7 @@
             "alt": "@astrojs/deno",
             "src": "/assets/integrations/deno.svg"
         },
-        "downloads": 2071,
+        "downloads": 2092,
         "badges": []
     },
     {
@@ -1003,7 +1003,7 @@
             "href": "https://github.com/delucis/astro-og-canvas#readme",
             "text": "Learn more about astro-og-canvas"
         },
-        "downloads": 1919,
+        "downloads": 2069,
         "badges": []
     },
     {
@@ -1026,7 +1026,7 @@
             "href": "https://github.com/delucis/astro-auto-import#readme",
             "text": "Learn more about astro-auto-import"
         },
-        "downloads": 1836,
+        "downloads": 1989,
         "badges": []
     },
     {
@@ -1050,7 +1050,7 @@
             "href": "https://github.com/codiume/orbit",
             "text": "Learn more about astro-seo-schema"
         },
-        "downloads": 1736,
+        "downloads": 1790,
         "badges": []
     },
     {
@@ -1073,7 +1073,30 @@
             "href": "https://github.com/edazpotato/astro-feather-icons#readme",
             "text": "Learn more about astro-feather-icons"
         },
-        "downloads": 1701,
+        "downloads": 1762,
+        "badges": []
+    },
+    {
+        "slug": "astro-bootstrap",
+        "title": "astro-bootstrap",
+        "description": "Bootstrap 5 components crafted for use with Astro",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/astro-bootstrap/astro-bootstrap",
+            "text": "View the astro-bootstrap source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-bootstrap",
+            "text": "View astro-bootstrap on NPM"
+        },
+        "url": {
+            "href": "https://astro-bootstrap.github.io",
+            "text": "Learn more about astro-bootstrap"
+        },
+        "downloads": 1544,
         "badges": []
     },
     {
@@ -1097,34 +1120,11 @@
             "href": "https://github.com/Princesseuh/astro-eleventy-img#readme",
             "text": "Learn more about astro-eleventy-img"
         },
-        "downloads": 1472,
+        "downloads": 1526,
         "badges": [
             "featured"
         ],
         "featured": 7
-    },
-    {
-        "slug": "astro-bootstrap",
-        "title": "astro-bootstrap",
-        "description": "Bootstrap 5 components crafted for use with Astro",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/astro-bootstrap/astro-bootstrap",
-            "text": "View the astro-bootstrap source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-bootstrap",
-            "text": "View astro-bootstrap on NPM"
-        },
-        "url": {
-            "href": "https://astro-bootstrap.github.io",
-            "text": "Learn more about astro-bootstrap"
-        },
-        "downloads": 1460,
-        "badges": []
     },
     {
         "slug": "astro-uno",
@@ -1150,7 +1150,7 @@
             "alt": "astro-uno",
             "src": "/assets/integrations/astro-uno.svg"
         },
-        "downloads": 1182,
+        "downloads": 1215,
         "badges": []
     },
     {
@@ -1173,7 +1173,7 @@
             "href": "https://github.com/delucis/astro-netlify-cms",
             "text": "Learn more about astro-netlify-cms"
         },
-        "downloads": 1162,
+        "downloads": 1194,
         "badges": []
     },
     {
@@ -1196,31 +1196,30 @@
             "href": "https://github.com/surjithctly/astro-navbar#readme",
             "text": "Learn more about astro-navbar"
         },
-        "downloads": 1123,
+        "downloads": 1164,
         "badges": []
     },
     {
-        "slug": "astro-compressor",
-        "title": "astro-compressor",
-        "description": "A gzip and brotli compressor for Astro",
+        "slug": "astro-sanity",
+        "title": "astro-sanity",
+        "description": "A helper package to integrate Astro and Sanity",
         "categories": [
-            "css+ui",
-            "performance+seo"
+            "css+ui"
         ],
         "official": false,
         "repoUrl": {
-            "href": "ssh://git@github.com/sondr3/astro-compressor",
-            "text": "View the astro-compressor source code"
+            "href": "https://github.com/littlesticks/astro-sanity",
+            "text": "View the astro-sanity source code"
         },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-compressor",
-            "text": "View astro-compressor on NPM"
+            "href": "https://www.npmjs.com/package/astro-sanity",
+            "text": "View astro-sanity on NPM"
         },
         "url": {
-            "href": "https://github.com/sondr3/astro-compressor#readme",
-            "text": "Learn more about astro-compressor"
+            "href": "https://github.com/littlesticks/astro-sanity#readme",
+            "text": "Learn more about astro-sanity"
         },
-        "downloads": 1039,
+        "downloads": 1082,
         "badges": []
     },
     {
@@ -1244,30 +1243,31 @@
             "href": "https://github.com/codiume/orbit",
             "text": "Learn more about astro-purgecss"
         },
-        "downloads": 1034,
+        "downloads": 1070,
         "badges": []
     },
     {
-        "slug": "astro-sanity",
-        "title": "astro-sanity",
-        "description": "A helper package to integrate Astro and Sanity",
+        "slug": "astro-compressor",
+        "title": "astro-compressor",
+        "description": "A gzip and brotli compressor for Astro",
         "categories": [
-            "css+ui"
+            "css+ui",
+            "performance+seo"
         ],
         "official": false,
         "repoUrl": {
-            "href": "https://github.com/littlesticks/astro-sanity",
-            "text": "View the astro-sanity source code"
+            "href": "ssh://git@github.com/sondr3/astro-compressor",
+            "text": "View the astro-compressor source code"
         },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-sanity",
-            "text": "View astro-sanity on NPM"
+            "href": "https://www.npmjs.com/package/astro-compressor",
+            "text": "View astro-compressor on NPM"
         },
         "url": {
-            "href": "https://github.com/littlesticks/astro-sanity#readme",
-            "text": "Learn more about astro-sanity"
+            "href": "https://github.com/sondr3/astro-compressor#readme",
+            "text": "Learn more about astro-compressor"
         },
-        "downloads": 1033,
+        "downloads": 1067,
         "badges": []
     },
     {
@@ -1291,7 +1291,7 @@
             "href": "https://github.com/Destiner/astro-analytics#readme",
             "text": "Learn more about astro-analytics"
         },
-        "downloads": 1013,
+        "downloads": 1042,
         "badges": []
     },
     {
@@ -1320,7 +1320,7 @@
             "alt": "@astrojs/turbolinks",
             "src": "/assets/integrations/turbolinks.svg"
         },
-        "downloads": 981,
+        "downloads": 1026,
         "badges": []
     },
     {
@@ -1349,7 +1349,7 @@
             "alt": "astro-i18n",
             "src": "/assets/integrations/astro-i18n.svg"
         },
-        "downloads": 849,
+        "downloads": 861,
         "badges": []
     },
     {
@@ -1372,7 +1372,7 @@
             "href": "https://github.com/astro-community/md",
             "text": "Learn more about @astropub/md"
         },
-        "downloads": 840,
+        "downloads": 854,
         "badges": []
     },
     {
@@ -1396,7 +1396,7 @@
             "href": "https://github.com/codiume/orbit",
             "text": "Learn more about astro-seo-meta"
         },
-        "downloads": 710,
+        "downloads": 754,
         "badges": []
     },
     {
@@ -1423,7 +1423,7 @@
             "alt": "@stylify/astro",
             "src": "/assets/integrations/stylify.svg"
         },
-        "downloads": 686,
+        "downloads": 688,
         "badges": []
     },
     {
@@ -1451,7 +1451,7 @@
             "alt": "accessible-astro-components",
             "src": "/assets/integrations/accessible-astro-components.png"
         },
-        "downloads": 658,
+        "downloads": 687,
         "badges": [
             "featured"
         ],
@@ -1477,31 +1477,11 @@
             "href": "https://github.com/RafidMuhymin/astro-spa#readme",
             "text": "Learn more about astro-spa"
         },
-        "downloads": 639,
+        "downloads": 655,
         "badges": [
             "featured"
         ],
         "featured": 13
-    },
-    {
-        "slug": "astro-google-fonts-optimizer",
-        "title": "astro-google-fonts-optimizer",
-        "description": "An Astro integration to optimize the Google Fonts loading performance",
-        "categories": [
-            "css+ui",
-            "performance+seo"
-        ],
-        "official": false,
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-google-fonts-optimizer",
-            "text": "View astro-google-fonts-optimizer on NPM"
-        },
-        "url": {
-            "href": "https://github.com/sebholstein/astro-google-fonts-optimizer",
-            "text": "Learn more about astro-google-fonts-optimizer"
-        },
-        "downloads": 628,
-        "badges": []
     },
     {
         "slug": "astro-remote",
@@ -1523,7 +1503,7 @@
             "href": "https://github.com/natemoo-re/astro-remote#README",
             "text": "Learn more about astro-remote"
         },
-        "downloads": 593,
+        "downloads": 654,
         "badges": []
     },
     {
@@ -1546,7 +1526,27 @@
             "href": "https://github.com/alextim/astro-lib/tree/main/packages/astro-webmanifest#readme",
             "text": "Learn more about astro-webmanifest"
         },
-        "downloads": 580,
+        "downloads": 647,
+        "badges": []
+    },
+    {
+        "slug": "astro-google-fonts-optimizer",
+        "title": "astro-google-fonts-optimizer",
+        "description": "An Astro integration to optimize the Google Fonts loading performance",
+        "categories": [
+            "css+ui",
+            "performance+seo"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-google-fonts-optimizer",
+            "text": "View astro-google-fonts-optimizer on NPM"
+        },
+        "url": {
+            "href": "https://github.com/sebholstein/astro-google-fonts-optimizer",
+            "text": "Learn more about astro-google-fonts-optimizer"
+        },
+        "downloads": 645,
         "badges": []
     },
     {
@@ -1569,7 +1569,7 @@
             "href": "https://github.com/kevinzunigacuellar/astro-layouts#README",
             "text": "Learn more about astro-layouts"
         },
-        "downloads": 525,
+        "downloads": 532,
         "badges": []
     },
     {
@@ -1592,7 +1592,7 @@
             "href": "https://github.com/jasikpark/astro-svg-loader#readme",
             "text": "Learn more about @jasikpark/astro-svg-loader"
         },
-        "downloads": 516,
+        "downloads": 531,
         "badges": []
     },
     {
@@ -1616,7 +1616,30 @@
             "href": "https://github.com/alextim/astro-lib/tree/main/packages/astro-sitemap#readme",
             "text": "Learn more about astro-sitemap"
         },
-        "downloads": 486,
+        "downloads": 492,
+        "badges": []
+    },
+    {
+        "slug": "astro-portabletext",
+        "title": "astro-portabletext",
+        "description": "Render Portable Text with Astro",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/theisel/astro-portabletext",
+            "text": "View the astro-portabletext source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-portabletext",
+            "text": "View astro-portabletext on NPM"
+        },
+        "url": {
+            "href": "https://github.com/theisel/astro-portabletext#readme",
+            "text": "Learn more about astro-portabletext"
+        },
+        "downloads": 469,
         "badges": []
     },
     {
@@ -1639,7 +1662,7 @@
             "href": "https://github.com/BryceRussell/astro-headless-ui#readme",
             "text": "Learn more about astro-headless-ui"
         },
-        "downloads": 464,
+        "downloads": 465,
         "badges": []
     },
     {
@@ -1663,30 +1686,7 @@
             "href": "https://github.com/tony-sull/astro-fathom#readme",
             "text": "Learn more about astro-fathom"
         },
-        "downloads": 454,
-        "badges": []
-    },
-    {
-        "slug": "astro-portabletext",
-        "title": "astro-portabletext",
-        "description": "Render Portable Text with Astro",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/theisel/astro-portabletext",
-            "text": "View the astro-portabletext source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-portabletext",
-            "text": "View astro-portabletext on NPM"
-        },
-        "url": {
-            "href": "https://github.com/theisel/astro-portabletext#readme",
-            "text": "Learn more about astro-portabletext"
-        },
-        "downloads": 453,
+        "downloads": 455,
         "badges": []
     },
     {
@@ -1709,7 +1709,7 @@
             "href": "https://github.com/littlesticksdev/odyssey-theme#readme",
             "text": "Learn more about @littlesticks/odyssey-theme-components"
         },
-        "downloads": 416,
+        "downloads": 440,
         "badges": []
     },
     {
@@ -1732,7 +1732,7 @@
             "href": "https://www.npmjs.com/package/astro-markdoc-renderer",
             "text": "View astro-markdoc-renderer on NPM"
         },
-        "downloads": 412,
+        "downloads": 421,
         "badges": []
     },
     {
@@ -1755,34 +1755,8 @@
             "href": "https://github.com/AgnosticUI/agnosticui#readme",
             "text": "Learn more about agnostic-astro"
         },
-        "downloads": 388,
+        "downloads": 391,
         "badges": []
-    },
-    {
-        "slug": "astro-xelement",
-        "title": "astro-xelement",
-        "description": "XElement is a powerful Astro Web Component generator. Create your own Astro compliant Web Components using only HTML Elements with additional Client-Side JS/TS interactivity sprinkled into the Element.",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/aFuzzyBear/xelement",
-            "text": "View the astro-xelement source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-xelement",
-            "text": "View astro-xelement on NPM"
-        },
-        "url": {
-            "href": "https://github.com/aFuzzyBear/xelement",
-            "text": "Learn more about astro-xelement"
-        },
-        "downloads": 369,
-        "badges": [
-            "featured"
-        ],
-        "featured": 11
     },
     {
         "slug": "simple-astro-seo",
@@ -1805,27 +1779,34 @@
             "href": "https://github.com/perkinsjr/simple-astro-seo/tree/master/",
             "text": "Learn more about simple-astro-seo"
         },
-        "downloads": 359,
+        "downloads": 377,
         "badges": []
     },
     {
-        "slug": "astro-imagekit",
-        "title": "astro-imagekit",
-        "description": "Integrate the ImageKit media provider in your Astro projects. Auto-synchronization, CLI, Component.",
+        "slug": "astro-xelement",
+        "title": "astro-xelement",
+        "description": "XElement is a powerful Astro Web Component generator. Create your own Astro compliant Web Components using only HTML Elements with additional Client-Side JS/TS interactivity sprinkled into the Element.",
         "categories": [
             "css+ui"
         ],
         "official": false,
+        "repoUrl": {
+            "href": "https://github.com/aFuzzyBear/xelement",
+            "text": "View the astro-xelement source code"
+        },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-imagekit",
-            "text": "View astro-imagekit on NPM"
+            "href": "https://www.npmjs.com/package/astro-xelement",
+            "text": "View astro-xelement on NPM"
         },
         "url": {
-            "href": "https://www.npmjs.com/package/astro-imagekit",
-            "text": "View astro-imagekit on NPM"
+            "href": "https://github.com/aFuzzyBear/xelement",
+            "text": "Learn more about astro-xelement"
         },
-        "downloads": 349,
-        "badges": []
+        "downloads": 374,
+        "badges": [
+            "featured"
+        ],
+        "featured": 11
     },
     {
         "slug": "astro-emoji",
@@ -1848,7 +1829,26 @@
             "href": "https://github.com/seanmcp/astro-emoji#readme",
             "text": "Learn more about astro-emoji"
         },
-        "downloads": 345,
+        "downloads": 349,
+        "badges": []
+    },
+    {
+        "slug": "astro-imagekit",
+        "title": "astro-imagekit",
+        "description": "Integrate the ImageKit media provider in your Astro projects. Auto-synchronization, CLI, Component.",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-imagekit",
+            "text": "View astro-imagekit on NPM"
+        },
+        "url": {
+            "href": "https://www.npmjs.com/package/astro-imagekit",
+            "text": "View astro-imagekit on NPM"
+        },
+        "downloads": 349,
         "badges": []
     },
     {
@@ -1871,7 +1871,7 @@
             "href": "https://github.com/seanmcp/astro-heroicons#readme",
             "text": "Learn more about astro-heroicons"
         },
-        "downloads": 330,
+        "downloads": 335,
         "badges": []
     },
     {
@@ -1895,30 +1895,7 @@
             "href": "https://github.com/dc7290/astro-fonts-next#readme",
             "text": "Learn more about astro-fonts-next"
         },
-        "downloads": 326,
-        "badges": []
-    },
-    {
-        "slug": "astro-vanilla-extract",
-        "title": "astro-vanilla-extract",
-        "description": "Adds vanilla-extract support to Astro",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/codiume/orbit",
-            "text": "View the astro-vanilla-extract source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-vanilla-extract",
-            "text": "View astro-vanilla-extract on NPM"
-        },
-        "url": {
-            "href": "https://github.com/codiume/orbit",
-            "text": "Learn more about astro-vanilla-extract"
-        },
-        "downloads": 294,
+        "downloads": 330,
         "badges": []
     },
     {
@@ -1942,7 +1919,30 @@
             "href": "https://github.com/sondr3/astro-html-minifier#readme",
             "text": "Learn more about astro-html-minifier"
         },
-        "downloads": 292,
+        "downloads": 302,
+        "badges": []
+    },
+    {
+        "slug": "astro-vanilla-extract",
+        "title": "astro-vanilla-extract",
+        "description": "Adds vanilla-extract support to Astro",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/codiume/orbit",
+            "text": "View the astro-vanilla-extract source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-vanilla-extract",
+            "text": "View astro-vanilla-extract on NPM"
+        },
+        "url": {
+            "href": "https://github.com/codiume/orbit",
+            "text": "Learn more about astro-vanilla-extract"
+        },
+        "downloads": 299,
         "badges": []
     },
     {
@@ -1966,7 +1966,7 @@
             "href": "https://github.com/tatethurston/astrojs-service-worker#readme",
             "text": "Learn more about astrojs-service-worker"
         },
-        "downloads": 288,
+        "downloads": 293,
         "badges": []
     },
     {
@@ -1989,11 +1989,35 @@
             "href": "https://github.com/astro-community/icons#readme",
             "text": "Learn more about @astropub/icons"
         },
-        "downloads": 256,
+        "downloads": 274,
         "badges": [
             "featured"
         ],
         "featured": 18
+    },
+    {
+        "slug": "astro-sst",
+        "title": "astro-sst",
+        "description": "Adapter for Astro apps to work on AWS Lambda and AWS Lambda@Edge.",
+        "categories": [
+            "css+ui",
+            "adapters"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/serverless-stack/sst",
+            "text": "View the astro-sst source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-sst",
+            "text": "View astro-sst on NPM"
+        },
+        "url": {
+            "href": "https://github.com/serverless-stack/sst#readme",
+            "text": "Learn more about astro-sst"
+        },
+        "downloads": 258,
+        "badges": []
     },
     {
         "slug": "astro-diagram",
@@ -2015,50 +2039,7 @@
             "href": "https://code.juliancataldo.com/component/astro-diagram",
             "text": "Learn more about astro-diagram"
         },
-        "downloads": 239,
-        "badges": []
-    },
-    {
-        "slug": "@common-web/astro-lambda-edge",
-        "title": "@common-web/astro-lambda-edge",
-        "description": "This Adapter allows Astro to deploy your SSR site to Lambda@Edge Lambda target.",
-        "categories": [
-            "css+ui",
-            "adapters"
-        ],
-        "official": false,
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@common-web/astro-lambda-edge",
-            "text": "View @common-web/astro-lambda-edge on NPM"
-        },
-        "url": {
-            "href": "https://www.npmjs.com/package/@common-web/astro-lambda-edge",
-            "text": "View @common-web/astro-lambda-edge on NPM"
-        },
-        "downloads": 236,
-        "badges": []
-    },
-    {
-        "slug": "@astro-reactive/form",
-        "title": "@astro-reactive/form",
-        "description": "The Reactive Form component for Astro 🔥",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/astro-reactive/astro-reactive",
-            "text": "View the @astro-reactive/form source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@astro-reactive/form",
-            "text": "View @astro-reactive/form on NPM"
-        },
-        "url": {
-            "href": "https://docs.astro-reactive.dev/en/api/form/form-component/",
-            "text": "Learn more about @astro-reactive/form"
-        },
-        "downloads": 229,
+        "downloads": 243,
         "badges": []
     },
     {
@@ -2082,7 +2063,50 @@
             "href": "https://github.com/manuelmeister/astro-iconify#readme",
             "text": "Learn more about astro-iconify"
         },
-        "downloads": 227,
+        "downloads": 241,
+        "badges": []
+    },
+    {
+        "slug": "@astro-reactive/form",
+        "title": "@astro-reactive/form",
+        "description": "The Reactive Form component for Astro 🔥",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/astro-reactive/astro-reactive",
+            "text": "View the @astro-reactive/form source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@astro-reactive/form",
+            "text": "View @astro-reactive/form on NPM"
+        },
+        "url": {
+            "href": "https://docs.astro-reactive.dev/en/api/form/form-component/",
+            "text": "Learn more about @astro-reactive/form"
+        },
+        "downloads": 237,
+        "badges": []
+    },
+    {
+        "slug": "@common-web/astro-lambda-edge",
+        "title": "@common-web/astro-lambda-edge",
+        "description": "This Adapter allows Astro to deploy your SSR site to Lambda@Edge Lambda target.",
+        "categories": [
+            "css+ui",
+            "adapters"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@common-web/astro-lambda-edge",
+            "text": "View @common-web/astro-lambda-edge on NPM"
+        },
+        "url": {
+            "href": "https://www.npmjs.com/package/@common-web/astro-lambda-edge",
+            "text": "View @common-web/astro-lambda-edge on NPM"
+        },
+        "downloads": 236,
         "badges": []
     },
     {
@@ -2105,7 +2129,7 @@
             "href": "https://github.com/surjithctly/astro-color-scheme#readme",
             "text": "Learn more about astro-color-scheme"
         },
-        "downloads": 213,
+        "downloads": 227,
         "badges": []
     },
     {
@@ -2129,7 +2153,7 @@
             "href": "https://code.juliancataldo.com/component/astro-analytics",
             "text": "Learn more about astro-google-analytics"
         },
-        "downloads": 208,
+        "downloads": 214,
         "badges": []
     },
     {
@@ -2152,7 +2176,7 @@
             "href": "https://code.juliancataldo.com/component/astro-tooltips",
             "text": "Learn more about astro-tooltips"
         },
-        "downloads": 200,
+        "downloads": 203,
         "badges": []
     },
     {
@@ -2175,7 +2199,7 @@
             "href": "https://github.com/astro-reactive/astro-reactive/blob/main/packages/validator/README.md",
             "text": "Learn more about @astro-reactive/validator"
         },
-        "downloads": 191,
+        "downloads": 198,
         "badges": []
     },
     {
@@ -2202,27 +2226,22 @@
         "badges": []
     },
     {
-        "slug": "astro-sst",
-        "title": "astro-sst",
-        "description": "Adapter for Astro apps to work on AWS Lambda and AWS Lambda@Edge.",
+        "slug": "@astro-auth/core",
+        "title": "@astro-auth/core",
+        "description": "The core package of the Astro Auth library",
         "categories": [
-            "css+ui",
-            "adapters"
+            "css+ui"
         ],
         "official": false,
-        "repoUrl": {
-            "href": "https://github.com/serverless-stack/sst",
-            "text": "View the astro-sst source code"
-        },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-sst",
-            "text": "View astro-sst on NPM"
+            "href": "https://www.npmjs.com/package/@astro-auth/core",
+            "text": "View @astro-auth/core on NPM"
         },
         "url": {
-            "href": "https://github.com/serverless-stack/sst#readme",
-            "text": "Learn more about astro-sst"
+            "href": "https://www.npmjs.com/package/@astro-auth/core",
+            "text": "View @astro-auth/core on NPM"
         },
-        "downloads": 180,
+        "downloads": 179,
         "badges": []
     },
     {
@@ -2251,20 +2270,25 @@
         ]
     },
     {
-        "slug": "@astro-auth/core",
-        "title": "@astro-auth/core",
-        "description": "The core package of the Astro Auth library",
+        "slug": "@sarissa/pagination",
+        "title": "@sarissa/pagination",
+        "description": "Add page number buttons for pagination. Automaticly add and disable numbers as current page number.",
         "categories": [
-            "css+ui"
+            "css+ui",
+            "accessibility"
         ],
         "official": false,
+        "repoUrl": {
+            "href": "https://github.com/iozcelik/SarissaPagination",
+            "text": "View the @sarissa/pagination source code"
+        },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/@astro-auth/core",
-            "text": "View @astro-auth/core on NPM"
+            "href": "https://www.npmjs.com/package/@sarissa/pagination",
+            "text": "View @sarissa/pagination on NPM"
         },
         "url": {
-            "href": "https://www.npmjs.com/package/@astro-auth/core",
-            "text": "View @astro-auth/core on NPM"
+            "text": "View on Github",
+            "href": "https://github.com/iozcelik/SarissaPagination"
         },
         "downloads": 177,
         "badges": []
@@ -2285,7 +2309,30 @@
             "href": "https://www.npmjs.com/package/@astro-auth/providers",
             "text": "View @astro-auth/providers on NPM"
         },
-        "downloads": 173,
+        "downloads": 175,
+        "badges": []
+    },
+    {
+        "slug": "astro-integration-lottie",
+        "title": "astro-integration-lottie",
+        "description": "Use Lottie animations within your Astro website",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/giuseppelt/astro-lottie",
+            "text": "View the astro-integration-lottie source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-integration-lottie",
+            "text": "View astro-integration-lottie on NPM"
+        },
+        "url": {
+            "href": "https://github.com/giuseppelt/astro-lottie#readme.md",
+            "text": "Learn more about astro-integration-lottie"
+        },
+        "downloads": 172,
         "badges": []
     },
     {
@@ -2313,30 +2360,6 @@
         "badges": []
     },
     {
-        "slug": "@sarissa/pagination",
-        "title": "@sarissa/pagination",
-        "description": "Add page number buttons for pagination. Automaticly add and disable numbers as current page number.",
-        "categories": [
-            "css+ui",
-            "accessibility"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/iozcelik/SarissaPagination",
-            "text": "View the @sarissa/pagination source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@sarissa/pagination",
-            "text": "View @sarissa/pagination on NPM"
-        },
-        "url": {
-            "text": "View on Github",
-            "href": "https://github.com/iozcelik/SarissaPagination"
-        },
-        "downloads": 165,
-        "badges": []
-    },
-    {
         "slug": "@analogjs/astro-angular",
         "title": "@analogjs/astro-angular",
         "description": "An Angular integration for Astro",
@@ -2357,49 +2380,7 @@
             "href": "https://analogjs.org",
             "text": "Learn more about @analogjs/astro-angular"
         },
-        "downloads": 164,
-        "badges": []
-    },
-    {
-        "slug": "astro-integration-lottie",
-        "title": "astro-integration-lottie",
-        "description": "Use Lottie animations within your Astro website",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/giuseppelt/astro-lottie",
-            "text": "View the astro-integration-lottie source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-integration-lottie",
-            "text": "View astro-integration-lottie on NPM"
-        },
-        "url": {
-            "href": "https://github.com/giuseppelt/astro-lottie#readme.md",
-            "text": "Learn more about astro-integration-lottie"
-        },
-        "downloads": 163,
-        "badges": []
-    },
-    {
-        "slug": "@astro-auth/client",
-        "title": "@astro-auth/client",
-        "description": "The client package of the Astro Auth library",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@astro-auth/client",
-            "text": "View @astro-auth/client on NPM"
-        },
-        "url": {
-            "href": "https://www.npmjs.com/package/@astro-auth/client",
-            "text": "View @astro-auth/client on NPM"
-        },
-        "downloads": 161,
+        "downloads": 169,
         "badges": []
     },
     {
@@ -2424,7 +2405,26 @@
             "href": "https://github.com/bangkitdev/astro-html-beautifier#readme",
             "text": "Learn more about astro-html-beautifier"
         },
-        "downloads": 157,
+        "downloads": 163,
+        "badges": []
+    },
+    {
+        "slug": "@astro-auth/client",
+        "title": "@astro-auth/client",
+        "description": "The client package of the Astro Auth library",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@astro-auth/client",
+            "text": "View @astro-auth/client on NPM"
+        },
+        "url": {
+            "href": "https://www.npmjs.com/package/@astro-auth/client",
+            "text": "View @astro-auth/client on NPM"
+        },
+        "downloads": 163,
         "badges": []
     },
     {
@@ -2477,7 +2477,7 @@
             "alt": "@lagon/astro",
             "src": "/assets/integrations/lagon-astro.png"
         },
-        "downloads": 152,
+        "downloads": 153,
         "badges": []
     },
     {
@@ -2504,7 +2504,7 @@
             "alt": "hello-astro",
             "src": "/assets/integrations/hello-astro.png"
         },
-        "downloads": 149,
+        "downloads": 150,
         "badges": []
     },
     {
@@ -2528,7 +2528,7 @@
             "href": "https://github.com/Kendy205/astro-og-image",
             "text": "Learn more about astro-og-image"
         },
-        "downloads": 135,
+        "downloads": 139,
         "badges": []
     },
     {
@@ -2555,7 +2555,30 @@
             "alt": "astro-github-stats",
             "src": "/assets/integrations/astro-github-stats.png"
         },
-        "downloads": 134,
+        "downloads": 137,
+        "badges": []
+    },
+    {
+        "slug": "astro-themes",
+        "title": "astro-themes",
+        "description": "Easy dark mode for Astro websites",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/alex-grover/astro-themes",
+            "text": "View the astro-themes source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-themes",
+            "text": "View astro-themes on NPM"
+        },
+        "url": {
+            "href": "https://github.com/alex-grover/astro-themes#readme",
+            "text": "Learn more about astro-themes"
+        },
+        "downloads": 133,
         "badges": []
     },
     {
@@ -2602,7 +2625,7 @@
             "href": "https://github.com/codiume/orbit",
             "text": "Learn more about astro-useragent"
         },
-        "downloads": 125,
+        "downloads": 126,
         "badges": []
     },
     {
@@ -2630,26 +2653,49 @@
         "badges": []
     },
     {
-        "slug": "astro-themes",
-        "title": "astro-themes",
-        "description": "Easy dark mode for Astro websites",
+        "slug": "@astro-github-elements/time",
+        "title": "@astro-github-elements/time",
+        "description": "An Astro wrapper for the '@github/relative-time-element' package",
         "categories": [
             "css+ui"
         ],
         "official": false,
         "repoUrl": {
-            "href": "https://github.com/alex-grover/astro-themes",
-            "text": "View the astro-themes source code"
+            "href": "https://github.com/BryceRussell/astro-github-elements",
+            "text": "View the @astro-github-elements/time source code"
         },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-themes",
-            "text": "View astro-themes on NPM"
+            "href": "https://www.npmjs.com/package/@astro-github-elements/time",
+            "text": "View @astro-github-elements/time on NPM"
         },
         "url": {
-            "href": "https://github.com/alex-grover/astro-themes#readme",
-            "text": "Learn more about astro-themes"
+            "href": "https://github.com/BryceRussell/astro-github-elements/tree/main/packages/time#readme",
+            "text": "Learn more about @astro-github-elements/time"
         },
-        "downloads": 118,
+        "downloads": 121,
+        "badges": []
+    },
+    {
+        "slug": "astro-tabs",
+        "title": "astro-tabs",
+        "description": "A tabs bar + panels component which works entirely without JS.\nSupports height equalization and automatic vertical scroll bar for tabs bar.",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/JulianCataldo/web-garden",
+            "text": "View the astro-tabs source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-tabs",
+            "text": "View astro-tabs on NPM"
+        },
+        "url": {
+            "href": "https://code.juliancataldo.com/component/astro-tabs",
+            "text": "Learn more about astro-tabs"
+        },
+        "downloads": 117,
         "badges": []
     },
     {
@@ -2672,7 +2718,7 @@
             "href": "https://code.juliancataldo.com/component/astro-base",
             "text": "Learn more about astro-base-document"
         },
-        "downloads": 115,
+        "downloads": 116,
         "badges": []
     },
     {
@@ -2695,7 +2741,7 @@
             "href": "https://code.juliancataldo.com/component/astro-transition",
             "text": "Learn more about astro-page-transition"
         },
-        "downloads": 111,
+        "downloads": 115,
         "badges": []
     },
     {
@@ -2726,29 +2772,6 @@
         "badges": []
     },
     {
-        "slug": "astro-tabs",
-        "title": "astro-tabs",
-        "description": "A tabs bar + panels component which works entirely without JS.\nSupports height equalization and automatic vertical scroll bar for tabs bar.",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/JulianCataldo/web-garden",
-            "text": "View the astro-tabs source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-tabs",
-            "text": "View astro-tabs on NPM"
-        },
-        "url": {
-            "href": "https://code.juliancataldo.com/component/astro-tabs",
-            "text": "Learn more about astro-tabs"
-        },
-        "downloads": 109,
-        "badges": []
-    },
-    {
         "slug": "@astropub/flow",
         "title": "@astropub/flow",
         "description": "Use components to control flow in Astro",
@@ -2770,7 +2793,7 @@
             "href": "https://github.com/astro-community/flow",
             "text": "Learn more about @astropub/flow"
         },
-        "downloads": 103,
+        "downloads": 105,
         "badges": []
     },
     {
@@ -2797,6 +2820,32 @@
         "badges": []
     },
     {
+        "slug": "astro-json-element",
+        "title": "astro-json-element",
+        "description": "Create/define HTML elements using JSON objects",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/BryceRussell/astro-json-element",
+            "text": "View the astro-json-element source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-json-element",
+            "text": "View astro-json-element on NPM"
+        },
+        "url": {
+            "href": "https://github.com/BryceRussell/astro-json-element#readme",
+            "text": "Learn more about astro-json-element"
+        },
+        "downloads": 95,
+        "badges": [
+            "featured"
+        ],
+        "featured": 19
+    },
+    {
         "slug": "@jam-comments/astro",
         "title": "@jam-comments/astro",
         "description": "Easily add performant, SEO-friendly comments to your Astro blog with JamComments.",
@@ -2816,32 +2865,7 @@
             "href": "https://jamcomments.com",
             "text": "Learn more about @jam-comments/astro"
         },
-        "downloads": 88,
-        "badges": []
-    },
-    {
-        "slug": "astro-partytown-resolveurl",
-        "title": "astro-partytown-resolveurl",
-        "description": "Astro + Partytown integration",
-        "categories": [
-            "css+ui",
-            "analytics",
-            "performance+seo"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/withastro/astro",
-            "text": "View the astro-partytown-resolveurl source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-partytown-resolveurl",
-            "text": "View astro-partytown-resolveurl on NPM"
-        },
-        "url": {
-            "href": "https://docs.astro.build/en/guides/integrations-guide/partytown/",
-            "text": "Learn more about astro-partytown-resolveurl"
-        },
-        "downloads": 87,
+        "downloads": 89,
         "badges": []
     },
     {
@@ -2864,34 +2888,8 @@
             "href": "https://github.com/LyraSearch/plugin-astro#readme",
             "text": "Learn more about @lyrasearch/plugin-astro"
         },
-        "downloads": 87,
+        "downloads": 88,
         "badges": []
-    },
-    {
-        "slug": "astro-json-element",
-        "title": "astro-json-element",
-        "description": "Create/define HTML elements using JSON objects",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/BryceRussell/astro-json-element",
-            "text": "View the astro-json-element source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-json-element",
-            "text": "View astro-json-element on NPM"
-        },
-        "url": {
-            "href": "https://github.com/BryceRussell/astro-json-element#readme",
-            "text": "Learn more about astro-json-element"
-        },
-        "downloads": 85,
-        "badges": [
-            "featured"
-        ],
-        "featured": 19
     },
     {
         "slug": "astro-critical-css",
@@ -2940,29 +2938,6 @@
         "badges": []
     },
     {
-        "slug": "@astro-github-elements/time",
-        "title": "@astro-github-elements/time",
-        "description": "An Astro wrapper for the '@github/relative-time-element' package",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/BryceRussell/astro-github-elements",
-            "text": "View the @astro-github-elements/time source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@astro-github-elements/time",
-            "text": "View @astro-github-elements/time on NPM"
-        },
-        "url": {
-            "href": "https://github.com/BryceRussell/astro-github-elements/tree/main/packages/time#readme",
-            "text": "Learn more about @astro-github-elements/time"
-        },
-        "downloads": 72,
-        "badges": []
-    },
-    {
         "slug": "astro-social-images",
         "title": "astro-social-images",
         "description": "Social images generator for Astro",
@@ -2983,7 +2958,7 @@
             "href": "https://github.com/Princesseuh/astro-social-images#readme",
             "text": "Learn more about astro-social-images"
         },
-        "downloads": 72,
+        "downloads": 73,
         "badges": []
     },
     {
@@ -3026,7 +3001,7 @@
             "href": "https://www.npmjs.com/package/@astro-auth/ui",
             "text": "View @astro-auth/ui on NPM"
         },
-        "downloads": 69,
+        "downloads": 70,
         "badges": []
     },
     {
@@ -3049,7 +3024,7 @@
             "href": "https://github.com/Bwc9876/Djazztro",
             "text": "Learn more about create-djazztro"
         },
-        "downloads": 68,
+        "downloads": 69,
         "badges": []
     },
     {
@@ -3072,7 +3047,30 @@
             "href": "https://code.juliancataldo.com/component/astro-lightbox",
             "text": "Learn more about @julian_cataldo/astro-lightbox"
         },
-        "downloads": 66,
+        "downloads": 67,
+        "badges": []
+    },
+    {
+        "slug": "astro-breakpoints",
+        "title": "astro-breakpoints",
+        "description": "Provides cross languages breakpoints handlers for your app. SCSS mixin, JS hook and a DOM data attribute, all share the same responsive scale you choose to feed in.",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/JulianCataldo/web-garden",
+            "text": "View the astro-breakpoints source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-breakpoints",
+            "text": "View astro-breakpoints on NPM"
+        },
+        "url": {
+            "href": "https://code.juliancataldo.com/component/astro-breakpoints",
+            "text": "Learn more about astro-breakpoints"
+        },
+        "downloads": 65,
         "badges": []
     },
     {
@@ -3098,26 +3096,27 @@
         "badges": []
     },
     {
-        "slug": "astro-breakpoints",
-        "title": "astro-breakpoints",
-        "description": "Provides cross languages breakpoints handlers for your app. SCSS mixin, JS hook and a DOM data attribute, all share the same responsive scale you choose to feed in.",
+        "slug": "custom-elements-ssr",
+        "title": "custom-elements-ssr",
+        "description": "Custom elements renderer for ssr",
         "categories": [
-            "css+ui"
+            "css+ui",
+            "frameworks"
         ],
         "official": false,
         "repoUrl": {
-            "href": "https://github.com/JulianCataldo/web-garden",
-            "text": "View the astro-breakpoints source code"
+            "href": "https://github.com/thepassle/custom-elements-ssr",
+            "text": "View the custom-elements-ssr source code"
         },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-breakpoints",
-            "text": "View astro-breakpoints on NPM"
+            "href": "https://www.npmjs.com/package/custom-elements-ssr",
+            "text": "View custom-elements-ssr on NPM"
         },
         "url": {
-            "href": "https://code.juliancataldo.com/component/astro-breakpoints",
-            "text": "Learn more about astro-breakpoints"
+            "href": "https://github.com/thepassle/custom-elements-ssr#readme",
+            "text": "Learn more about custom-elements-ssr"
         },
-        "downloads": 64,
+        "downloads": 63,
         "badges": []
     },
     {
@@ -3163,97 +3162,7 @@
             "href": "https://code.juliancataldo.com/component/astro-geo-map",
             "text": "Learn more about astro-geo-map"
         },
-        "downloads": 61,
-        "badges": []
-    },
-    {
-        "slug": "astro-breadcrumbs",
-        "title": "astro-breadcrumbs",
-        "description": "Dynamic breadcrumbs component for Astro.js.",
-        "categories": [
-            "css+ui",
-            "accessibility"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/felix-berlin/astro-breadcrumbs",
-            "text": "View the astro-breadcrumbs source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-breadcrumbs",
-            "text": "View astro-breadcrumbs on NPM"
-        },
-        "url": {
-            "href": "https://github.com/felix-berlin/astro-breadcrumbs#readme",
-            "text": "Learn more about astro-breadcrumbs"
-        },
-        "downloads": 57,
-        "badges": []
-    },
-    {
-        "slug": "custom-elements-ssr",
-        "title": "custom-elements-ssr",
-        "description": "Custom elements renderer for ssr",
-        "categories": [
-            "css+ui",
-            "frameworks"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/thepassle/custom-elements-ssr",
-            "text": "View the custom-elements-ssr source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/custom-elements-ssr",
-            "text": "View custom-elements-ssr on NPM"
-        },
-        "url": {
-            "href": "https://github.com/thepassle/custom-elements-ssr#readme",
-            "text": "Learn more about custom-elements-ssr"
-        },
-        "downloads": 57,
-        "badges": []
-    },
-    {
-        "slug": "@simpleauthority/astro-icon-ssr",
-        "title": "@simpleauthority/astro-icon-ssr",
-        "description": "A straight-forward `Icon` component for [Astro](https://astro.build).",
-        "categories": [
-            "css+ui",
-            "performance+seo"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/natemoo-re/astro-icon",
-            "text": "View the @simpleauthority/astro-icon-ssr source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@simpleauthority/astro-icon-ssr",
-            "text": "View @simpleauthority/astro-icon-ssr on NPM"
-        },
-        "url": {
-            "href": "https://github.com/natemoo-re/astro-icon#readme",
-            "text": "Learn more about @simpleauthority/astro-icon-ssr"
-        },
-        "downloads": 57,
-        "badges": []
-    },
-    {
-        "slug": "@astroshuttle/core",
-        "title": "@astroshuttle/core",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@astroshuttle/core",
-            "text": "View @astroshuttle/core on NPM"
-        },
-        "url": {
-            "href": "https://www.npmjs.com/package/@astroshuttle/core",
-            "text": "View @astroshuttle/core on NPM"
-        },
-        "downloads": 55,
+        "downloads": 62,
         "badges": []
     },
     {
@@ -3277,7 +3186,55 @@
             "alt": "astroid",
             "src": "/assets/integrations/astroid.png"
         },
-        "downloads": 55,
+        "downloads": 60,
+        "badges": []
+    },
+    {
+        "slug": "astro-breadcrumbs",
+        "title": "astro-breadcrumbs",
+        "description": "Dynamic breadcrumbs component for Astro.js.",
+        "categories": [
+            "css+ui",
+            "accessibility"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/felix-berlin/astro-breadcrumbs",
+            "text": "View the astro-breadcrumbs source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-breadcrumbs",
+            "text": "View astro-breadcrumbs on NPM"
+        },
+        "url": {
+            "href": "https://github.com/felix-berlin/astro-breadcrumbs#readme",
+            "text": "Learn more about astro-breadcrumbs"
+        },
+        "downloads": 58,
+        "badges": []
+    },
+    {
+        "slug": "@simpleauthority/astro-icon-ssr",
+        "title": "@simpleauthority/astro-icon-ssr",
+        "description": "A straight-forward `Icon` component for [Astro](https://astro.build).",
+        "categories": [
+            "css+ui",
+            "performance+seo"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/natemoo-re/astro-icon",
+            "text": "View the @simpleauthority/astro-icon-ssr source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@simpleauthority/astro-icon-ssr",
+            "text": "View @simpleauthority/astro-icon-ssr on NPM"
+        },
+        "url": {
+            "href": "https://github.com/natemoo-re/astro-icon#readme",
+            "text": "Learn more about @simpleauthority/astro-icon-ssr"
+        },
+        "downloads": 58,
         "badges": []
     },
     {
@@ -3300,7 +3257,7 @@
             "href": "https://code.juliancataldo.com/component/astro-licenses-report",
             "text": "Learn more about astro-licenses-report"
         },
-        "downloads": 54,
+        "downloads": 57,
         "badges": []
     },
     {
@@ -3323,7 +3280,48 @@
             "href": "https://github.com/tony-sull/astro-navigation#readme",
             "text": "Learn more about astro-navigation"
         },
-        "downloads": 53,
+        "downloads": 57,
+        "badges": []
+    },
+    {
+        "slug": "@astroshuttle/core",
+        "title": "@astroshuttle/core",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@astroshuttle/core",
+            "text": "View @astroshuttle/core on NPM"
+        },
+        "url": {
+            "href": "https://www.npmjs.com/package/@astroshuttle/core",
+            "text": "View @astroshuttle/core on NPM"
+        },
+        "downloads": 56,
+        "badges": []
+    },
+    {
+        "slug": "astro-netlify-components",
+        "title": "astro-netlify-components",
+        "description": "Astro components for Netlify",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/seanmcp/astro-netlify-components",
+            "text": "View the astro-netlify-components source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-netlify-components",
+            "text": "View astro-netlify-components on NPM"
+        },
+        "url": {
+            "href": "https://github.com/seanmcp/astro-netlify-components#readme",
+            "text": "Learn more about astro-netlify-components"
+        },
+        "downloads": 52,
         "badges": []
     },
     {
@@ -3347,7 +3345,7 @@
             "href": "https://github.com/astro-community/doc",
             "text": "Learn more about @astropub/doc"
         },
-        "downloads": 51,
+        "downloads": 52,
         "badges": []
     },
     {
@@ -3370,7 +3368,7 @@
             "href": "https://github.com/theisel/astro-toc#readme",
             "text": "Learn more about astro-toc"
         },
-        "downloads": 51,
+        "downloads": 52,
         "badges": []
     },
     {
@@ -3393,7 +3391,7 @@
             "href": "https://code.juliancataldo.com/component/astro-resets",
             "text": "Learn more about @julian_cataldo/astro-resets"
         },
-        "downloads": 50,
+        "downloads": 51,
         "badges": []
     },
     {
@@ -3417,33 +3415,10 @@
             "href": "https://github.com/bikeshaving/crank#readme",
             "text": "Learn more about astro-crank"
         },
-        "downloads": 48,
+        "downloads": 50,
         "badges": [
             "new"
         ]
-    },
-    {
-        "slug": "astro-color-mode",
-        "title": "astro-color-mode",
-        "description": "Provides system or user-defined color scheme preference, with a toggle mechanism. Settings are persisted, component is progressively enhanced and flash of unstyled content avoided. Also, it will provide an easier way to target theme with CSS / SCSS / JS.",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/JulianCataldo/web-garden",
-            "text": "View the astro-color-mode source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-color-mode",
-            "text": "View astro-color-mode on NPM"
-        },
-        "url": {
-            "href": "https://code.juliancataldo.com/component/astro-color-mode",
-            "text": "Learn more about astro-color-mode"
-        },
-        "downloads": 46,
-        "badges": []
     },
     {
         "slug": "@jackcarey/astro-filter-content",
@@ -3465,7 +3440,7 @@
             "href": "https://github.com/jackcarey/astro-filter-content#readme",
             "text": "Learn more about @jackcarey/astro-filter-content"
         },
-        "downloads": 46,
+        "downloads": 47,
         "badges": []
     },
     {
@@ -3488,6 +3463,29 @@
         "url": {
             "href": "https://github.com/readonlychild/astro-ixmage#readme",
             "text": "Learn more about astro-ixmage"
+        },
+        "downloads": 47,
+        "badges": []
+    },
+    {
+        "slug": "astro-color-mode",
+        "title": "astro-color-mode",
+        "description": "Provides system or user-defined color scheme preference, with a toggle mechanism. Settings are persisted, component is progressively enhanced and flash of unstyled content avoided. Also, it will provide an easier way to target theme with CSS / SCSS / JS.",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/JulianCataldo/web-garden",
+            "text": "View the astro-color-mode source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-color-mode",
+            "text": "View astro-color-mode on NPM"
+        },
+        "url": {
+            "href": "https://code.juliancataldo.com/component/astro-color-mode",
+            "text": "Learn more about astro-color-mode"
         },
         "downloads": 46,
         "badges": []
@@ -3521,25 +3519,6 @@
         "badges": []
     },
     {
-        "slug": "astro-gap",
-        "title": "astro-gap",
-        "description": "Astro doesn't have a generic way of creating gaps between html elements. There are times where two elements need to be separated with different spaces. Astro Gap solves that problem. It works depending on the parent element's flex, inline  or grid positio",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-gap",
-            "text": "View astro-gap on NPM"
-        },
-        "url": {
-            "href": "https://www.npmjs.com/package/astro-gap",
-            "text": "View astro-gap on NPM"
-        },
-        "downloads": 45,
-        "badges": []
-    },
-    {
         "slug": "@igor.dvlpr/astro-post-excerpt",
         "title": "@igor.dvlpr/astro-post-excerpt",
         "description": "⭐ An Astro component that renders post excerpts for your Astro blog - directly from your Markdown files! 💎",
@@ -3564,7 +3543,68 @@
             "alt": "astro-post-excerpt",
             "src": "/assets/integrations/astro-post-excerpt.png"
         },
+        "downloads": 45,
+        "badges": []
+    },
+    {
+        "slug": "astro-gap",
+        "title": "astro-gap",
+        "description": "Astro doesn't have a generic way of creating gaps between html elements. There are times where two elements need to be separated with different spaces. Astro Gap solves that problem. It works depending on the parent element's flex, inline  or grid positio",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-gap",
+            "text": "View astro-gap on NPM"
+        },
+        "url": {
+            "href": "https://www.npmjs.com/package/astro-gap",
+            "text": "View astro-gap on NPM"
+        },
+        "downloads": 45,
+        "badges": []
+    },
+    {
+        "slug": "@lloydjatkinson/astro-snipcart",
+        "title": "@lloydjatkinson/astro-snipcart",
+        "description": "This is [an unofficial template](#how-is-this-different-from-the-official-component-template) meant to ease the development of components for [Astro](https://astro.build/) that are intended for distribution. It does so by providing you with:",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@lloydjatkinson/astro-snipcart",
+            "text": "View @lloydjatkinson/astro-snipcart on NPM"
+        },
+        "url": {
+            "href": "https://www.npmjs.com/package/@lloydjatkinson/astro-snipcart",
+            "text": "View @lloydjatkinson/astro-snipcart on NPM"
+        },
         "downloads": 44,
+        "badges": []
+    },
+    {
+        "slug": "astro-scroll-observer",
+        "title": "astro-scroll-observer",
+        "description": "Viewport scroll position and direction watcher.\nBinds states data attributes to `HTML` for further JS/CSS usage.\nScroll event is throttled for performance economy.",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/JulianCataldo/web-garden",
+            "text": "View the astro-scroll-observer source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-scroll-observer",
+            "text": "View astro-scroll-observer on NPM"
+        },
+        "url": {
+            "href": "https://code.juliancataldo.com/component/astro-scroll-observer",
+            "text": "Learn more about astro-scroll-observer"
+        },
+        "downloads": 42,
         "badges": []
     },
     {
@@ -3591,43 +3631,47 @@
         "badges": []
     },
     {
-        "slug": "@lloydjatkinson/astro-snipcart",
-        "title": "@lloydjatkinson/astro-snipcart",
-        "description": "This is [an unofficial template](#how-is-this-different-from-the-official-component-template) meant to ease the development of components for [Astro](https://astro.build/) that are intended for distribution. It does so by providing you with:",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@lloydjatkinson/astro-snipcart",
-            "text": "View @lloydjatkinson/astro-snipcart on NPM"
-        },
-        "url": {
-            "href": "https://www.npmjs.com/package/@lloydjatkinson/astro-snipcart",
-            "text": "View @lloydjatkinson/astro-snipcart on NPM"
-        },
-        "downloads": 40,
-        "badges": []
-    },
-    {
-        "slug": "astro-scroll-observer",
-        "title": "astro-scroll-observer",
-        "description": "Viewport scroll position and direction watcher.\nBinds states data attributes to `HTML` for further JS/CSS usage.\nScroll event is throttled for performance economy.",
+        "slug": "@astro-github-elements/clipboard-copy",
+        "title": "@astro-github-elements/clipboard-copy",
+        "description": "An Astro wrapper for the '@github/clipboard-copy' web component, an easy to use copy to clipboard button",
         "categories": [
             "css+ui"
         ],
         "official": false,
         "repoUrl": {
-            "href": "https://github.com/JulianCataldo/web-garden",
-            "text": "View the astro-scroll-observer source code"
+            "href": "https://github.com/BryceRussell/astro-github-elements",
+            "text": "View the @astro-github-elements/clipboard-copy source code"
         },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-scroll-observer",
-            "text": "View astro-scroll-observer on NPM"
+            "href": "https://www.npmjs.com/package/@astro-github-elements/clipboard-copy",
+            "text": "View @astro-github-elements/clipboard-copy on NPM"
         },
         "url": {
-            "href": "https://code.juliancataldo.com/component/astro-scroll-observer",
-            "text": "Learn more about astro-scroll-observer"
+            "href": "https://github.com/BryceRussell/astro-github-elements/tree/main/packages/clipboard-copy#readme",
+            "text": "Learn more about @astro-github-elements/clipboard-copy"
+        },
+        "downloads": 40,
+        "badges": []
+    },
+    {
+        "slug": "djazztro",
+        "title": "djazztro",
+        "description": "The web development stack for astronauts with deadlines.",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/Bwc9876/Djazztro",
+            "text": "View the djazztro source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/djazztro",
+            "text": "View djazztro on NPM"
+        },
+        "url": {
+            "href": "https://github.com/Bwc9876/Djazztro",
+            "text": "Learn more about djazztro"
         },
         "downloads": 40,
         "badges": []
@@ -3679,52 +3723,6 @@
         "badges": []
     },
     {
-        "slug": "djazztro",
-        "title": "djazztro",
-        "description": "The web development stack for astronauts with deadlines.",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/Bwc9876/Djazztro",
-            "text": "View the djazztro source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/djazztro",
-            "text": "View djazztro on NPM"
-        },
-        "url": {
-            "href": "https://github.com/Bwc9876/Djazztro",
-            "text": "Learn more about djazztro"
-        },
-        "downloads": 39,
-        "badges": []
-    },
-    {
-        "slug": "@astro-github-elements/clipboard-copy",
-        "title": "@astro-github-elements/clipboard-copy",
-        "description": "An Astro wrapper for the '@github/clipboard-copy' web component, an easy to use copy to clipboard button",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/BryceRussell/astro-github-elements",
-            "text": "View the @astro-github-elements/clipboard-copy source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@astro-github-elements/clipboard-copy",
-            "text": "View @astro-github-elements/clipboard-copy on NPM"
-        },
-        "url": {
-            "href": "https://github.com/BryceRussell/astro-github-elements/tree/main/packages/clipboard-copy#readme",
-            "text": "Learn more about @astro-github-elements/clipboard-copy"
-        },
-        "downloads": 36,
-        "badges": []
-    },
-    {
         "slug": "@senseimarv/astro-icon",
         "title": "@senseimarv/astro-icon",
         "description": "> This is a fork of [Astro Icon](https://github.com/natemoo-re/astro-icon) with `@iconify/json` as peer dependency.",
@@ -3744,6 +3742,48 @@
         "url": {
             "href": "https://github.com/natemoo-re/astro-icon#readme",
             "text": "Learn more about @senseimarv/astro-icon"
+        },
+        "downloads": 37,
+        "badges": []
+    },
+    {
+        "slug": "@ryandejaegher/my-component",
+        "title": "@ryandejaegher/my-component",
+        "description": "This is an example package, exported as `@example/my-component`. It consists of two Astro components, **Button** and **Heading**.",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@ryandejaegher/my-component",
+            "text": "View @ryandejaegher/my-component on NPM"
+        },
+        "url": {
+            "href": "https://www.npmjs.com/package/@ryandejaegher/my-component",
+            "text": "View @ryandejaegher/my-component on NPM"
+        },
+        "downloads": 37,
+        "badges": []
+    },
+    {
+        "slug": "astro-image",
+        "title": "astro-image",
+        "description": "Image util for astro",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/warpsio/astro-image",
+            "text": "View the astro-image source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-image",
+            "text": "View astro-image on NPM"
+        },
+        "url": {
+            "href": "https://github.com/warpsio/astro-image",
+            "text": "Learn more about astro-image"
         },
         "downloads": 36,
         "badges": []
@@ -3772,6 +3812,29 @@
         "badges": []
     },
     {
+        "slug": "astro-list-component",
+        "title": "astro-list-component",
+        "description": "A List component for your project with svg elements.",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/sacarvy/ListAstroComponent",
+            "text": "View the astro-list-component source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-list-component",
+            "text": "View astro-list-component on NPM"
+        },
+        "url": {
+            "href": "https://github.com/sacarvy#readme",
+            "text": "Learn more about astro-list-component"
+        },
+        "downloads": 36,
+        "badges": []
+    },
+    {
         "slug": "nativelatex",
         "title": "nativelatex",
         "description": "package to provide svg from tex in astro",
@@ -3788,29 +3851,6 @@
             "text": "View nativelatex on NPM"
         },
         "downloads": 36,
-        "badges": []
-    },
-    {
-        "slug": "astro-image",
-        "title": "astro-image",
-        "description": "Image util for astro",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/warpsio/astro-image",
-            "text": "View the astro-image source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-image",
-            "text": "View astro-image on NPM"
-        },
-        "url": {
-            "href": "https://github.com/warpsio/astro-image",
-            "text": "Learn more about astro-image"
-        },
-        "downloads": 35,
         "badges": []
     },
     {
@@ -3837,25 +3877,6 @@
         "badges": []
     },
     {
-        "slug": "@ryandejaegher/my-component",
-        "title": "@ryandejaegher/my-component",
-        "description": "This is an example package, exported as `@example/my-component`. It consists of two Astro components, **Button** and **Heading**.",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@ryandejaegher/my-component",
-            "text": "View @ryandejaegher/my-component on NPM"
-        },
-        "url": {
-            "href": "https://www.npmjs.com/package/@ryandejaegher/my-component",
-            "text": "View @ryandejaegher/my-component on NPM"
-        },
-        "downloads": 33,
-        "badges": []
-    },
-    {
         "slug": "astro-latex",
         "title": "astro-latex",
         "description": "LaTeX component for Astro",
@@ -3875,30 +3896,31 @@
             "href": "https://github.com/Destiner/astro-latex#readme",
             "text": "Learn more about astro-latex"
         },
-        "downloads": 33,
+        "downloads": 34,
         "badges": []
     },
     {
-        "slug": "astro-list-component",
-        "title": "astro-list-component",
-        "description": "A List component for your project with svg elements.",
+        "slug": "@futurefabric/astro-imagetools",
+        "title": "@futurefabric/astro-imagetools",
+        "description": "Image Optimization tools for the Astro JS framework",
         "categories": [
-            "css+ui"
+            "css+ui",
+            "performance+seo"
         ],
         "official": false,
         "repoUrl": {
-            "href": "https://github.com/sacarvy/ListAstroComponent",
-            "text": "View the astro-list-component source code"
+            "href": "https://github.com/RafidMuhymin/astro-imagetools",
+            "text": "View the @futurefabric/astro-imagetools source code"
         },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-list-component",
-            "text": "View astro-list-component on NPM"
+            "href": "https://www.npmjs.com/package/@futurefabric/astro-imagetools",
+            "text": "View @futurefabric/astro-imagetools on NPM"
         },
         "url": {
-            "href": "https://github.com/sacarvy#readme",
-            "text": "Learn more about astro-list-component"
+            "href": "https://github.com/RafidMuhymin/astro-imagetools#readme",
+            "text": "Learn more about @futurefabric/astro-imagetools"
         },
-        "downloads": 33,
+        "downloads": 32,
         "badges": []
     },
     {
@@ -3925,30 +3947,6 @@
         "badges": []
     },
     {
-        "slug": "solidjs-upgraded-babel-preset",
-        "title": "solidjs-upgraded-babel-preset",
-        "description": "Use Solid components within Astro",
-        "categories": [
-            "css+ui",
-            "frameworks"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/withastro/astro",
-            "text": "View the solidjs-upgraded-babel-preset source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/solidjs-upgraded-babel-preset",
-            "text": "View solidjs-upgraded-babel-preset on NPM"
-        },
-        "url": {
-            "href": "https://docs.astro.build/en/guides/integrations-guide/solid-js/",
-            "text": "Learn more about solidjs-upgraded-babel-preset"
-        },
-        "downloads": 31,
-        "badges": []
-    },
-    {
         "slug": "astro-terminal-player",
         "title": "astro-terminal-player",
         "description": "Embed player for terminal sessions (recorded with asciinema) in your Astro project.\nUsing asciinema player under the hood.\nComes with full asciinema player settings support, typings and docs hints.",
@@ -3972,30 +3970,6 @@
         "badges": []
     },
     {
-        "slug": "@futurefabric/astro-imagetools",
-        "title": "@futurefabric/astro-imagetools",
-        "description": "Image Optimization tools for the Astro JS framework",
-        "categories": [
-            "css+ui",
-            "performance+seo"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/RafidMuhymin/astro-imagetools",
-            "text": "View the @futurefabric/astro-imagetools source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@futurefabric/astro-imagetools",
-            "text": "View @futurefabric/astro-imagetools on NPM"
-        },
-        "url": {
-            "href": "https://github.com/RafidMuhymin/astro-imagetools#readme",
-            "text": "Learn more about @futurefabric/astro-imagetools"
-        },
-        "downloads": 30,
-        "badges": []
-    },
-    {
         "slug": "astro-adoc",
         "title": "astro-adoc",
         "description": "AsciiDoctor inside Astro",
@@ -4015,7 +3989,7 @@
             "href": "https://github.com/devidw/astro-addons/tree/main/packages/astro-adoc#readme",
             "text": "Learn more about astro-adoc"
         },
-        "downloads": 30,
+        "downloads": 31,
         "badges": []
     },
     {
@@ -4042,25 +4016,6 @@
         "badges": []
     },
     {
-        "slug": "@lloydjatkinson/astro-snipcart-design-system",
-        "title": "@lloydjatkinson/astro-snipcart-design-system",
-        "description": "This is [an unofficial template](#how-is-this-different-from-the-official-component-template) meant to ease the development of components for [Astro](https://astro.build/) that are intended for distribution. It does so by providing you with:",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@lloydjatkinson/astro-snipcart-design-system",
-            "text": "View @lloydjatkinson/astro-snipcart-design-system on NPM"
-        },
-        "url": {
-            "href": "https://www.npmjs.com/package/@lloydjatkinson/astro-snipcart-design-system",
-            "text": "View @lloydjatkinson/astro-snipcart-design-system on NPM"
-        },
-        "downloads": 28,
-        "badges": []
-    },
-    {
         "slug": "@rebelchris/astro-static-tweet",
         "title": "@rebelchris/astro-static-tweet",
         "description": "This is a open source [Astro](https://astro.build/) component. Astro is a open-source Static Site Generator... But it comes with a bring your own framework approach as well as the option to use components but output fully static websites.",
@@ -4079,6 +4034,25 @@
         "url": {
             "href": "https://github.com/rebelchris/astro-static-tweet#readme",
             "text": "Learn more about @rebelchris/astro-static-tweet"
+        },
+        "downloads": 29,
+        "badges": []
+    },
+    {
+        "slug": "@lloydjatkinson/astro-snipcart-design-system",
+        "title": "@lloydjatkinson/astro-snipcart-design-system",
+        "description": "This is [an unofficial template](#how-is-this-different-from-the-official-component-template) meant to ease the development of components for [Astro](https://astro.build/) that are intended for distribution. It does so by providing you with:",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@lloydjatkinson/astro-snipcart-design-system",
+            "text": "View @lloydjatkinson/astro-snipcart-design-system on NPM"
+        },
+        "url": {
+            "href": "https://www.npmjs.com/package/@lloydjatkinson/astro-snipcart-design-system",
+            "text": "View @lloydjatkinson/astro-snipcart-design-system on NPM"
         },
         "downloads": 28,
         "badges": []
@@ -4099,7 +4073,7 @@
             "href": "https://www.npmjs.com/package/@jcha0713/astro-notion",
             "text": "View @jcha0713/astro-notion on NPM"
         },
-        "downloads": 27,
+        "downloads": 28,
         "badges": []
     },
     {
@@ -4123,7 +4097,7 @@
             "href": "https://github.com/Destiner/astro-head#readme",
             "text": "Learn more about astro-head"
         },
-        "downloads": 27,
+        "downloads": 28,
         "badges": []
     },
     {
@@ -4212,7 +4186,7 @@
             "href": "https://www.npmjs.com/package/astro-php",
             "text": "View astro-php on NPM"
         },
-        "downloads": 24,
+        "downloads": 25,
         "badges": []
     },
     {
@@ -4235,7 +4209,7 @@
             "href": "https://github.com/warpsio/astro-headers",
             "text": "Learn more about astro-headers"
         },
-        "downloads": 23,
+        "downloads": 24,
         "badges": []
     },
     {
@@ -4258,7 +4232,7 @@
             "href": "https://github.com/astro-community/experiments#readme",
             "text": "Learn more about @astropub/experiments"
         },
-        "downloads": 23,
+        "downloads": 24,
         "badges": []
     },
     {
@@ -4305,6 +4279,29 @@
         "badges": []
     },
     {
+        "slug": "astro-localization",
+        "title": "astro-localization",
+        "description": "Localization utils for astro",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/warpsio/astro-localization",
+            "text": "View the astro-localization source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-localization",
+            "text": "View astro-localization on NPM"
+        },
+        "url": {
+            "href": "https://github.com/warpsio/astro-localization",
+            "text": "Learn more about astro-localization"
+        },
+        "downloads": 22,
+        "badges": []
+    },
+    {
         "slug": "astro-windicss",
         "title": "astro-windicss",
         "description": "Windicss + Astro integrations",
@@ -4328,53 +4325,6 @@
         "badges": []
     },
     {
-        "slug": "astrojs-cloudflare-node",
-        "title": "astrojs-cloudflare-node",
-        "description": "Deploy your site to cloudflare workers or cloudflare pages",
-        "categories": [
-            "css+ui",
-            "adapters"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/withastro/astro",
-            "text": "View the astrojs-cloudflare-node source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astrojs-cloudflare-node",
-            "text": "View astrojs-cloudflare-node on NPM"
-        },
-        "url": {
-            "href": "https://docs.astro.build/en/guides/integrations-guide/cloudflare/",
-            "text": "Learn more about astrojs-cloudflare-node"
-        },
-        "downloads": 21,
-        "badges": []
-    },
-    {
-        "slug": "astro-localization",
-        "title": "astro-localization",
-        "description": "Localization utils for astro",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/warpsio/astro-localization",
-            "text": "View the astro-localization source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-localization",
-            "text": "View astro-localization on NPM"
-        },
-        "url": {
-            "href": "https://github.com/warpsio/astro-localization",
-            "text": "Learn more about astro-localization"
-        },
-        "downloads": 21,
-        "badges": []
-    },
-    {
         "slug": "astro-lottie",
         "title": "astro-lottie",
         "description": "Lottie library support for astro",
@@ -4394,7 +4344,7 @@
             "href": "https://github.com/warpsio/astro-lottie",
             "text": "Learn more about astro-lottie"
         },
-        "downloads": 21,
+        "downloads": 22,
         "badges": []
     },
     {
@@ -4417,7 +4367,7 @@
             "href": "https://github.com/trashhalo/astro-command#readme",
             "text": "Learn more about astro-command"
         },
-        "downloads": 20,
+        "downloads": 21,
         "badges": []
     },
     {
@@ -4440,7 +4390,30 @@
             "href": "https://github.com/warpsio/astro-sections",
             "text": "Learn more about astro-sections"
         },
-        "downloads": 19,
+        "downloads": 20,
+        "badges": []
+    },
+    {
+        "slug": "astro-utils",
+        "title": "astro-utils",
+        "description": "Various utils for astro",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/warpsio/astro-utils",
+            "text": "View the astro-utils source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-utils",
+            "text": "View astro-utils on NPM"
+        },
+        "url": {
+            "href": "https://github.com/warpsio/astro-utils",
+            "text": "Learn more about astro-utils"
+        },
+        "downloads": 20,
         "badges": []
     },
     {
@@ -4485,6 +4458,25 @@
         "badges": []
     },
     {
+        "slug": "astro-plain",
+        "title": "astro-plain",
+        "description": "Generic, batteries-included prototype for Astro pages",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-plain",
+            "text": "View astro-plain on NPM"
+        },
+        "url": {
+            "href": "https://github.com/johnhenry/lib/js/astro-plain/0.0.6#readme",
+            "text": "Learn more about astro-plain"
+        },
+        "downloads": 19,
+        "badges": []
+    },
+    {
         "slug": "astro-script",
         "title": "astro-script",
         "description": "A simple script management component for Astro",
@@ -4508,68 +4500,22 @@
         "badges": []
     },
     {
-        "slug": "astro-netlify-components",
-        "title": "astro-netlify-components",
-        "description": "Astro components for Netlify",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/seanmcp/astro-netlify-components",
-            "text": "View the astro-netlify-components source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-netlify-components",
-            "text": "View astro-netlify-components on NPM"
-        },
-        "url": {
-            "href": "https://github.com/seanmcp/astro-netlify-components#readme",
-            "text": "Learn more about astro-netlify-components"
-        },
-        "downloads": 18,
-        "badges": []
-    },
-    {
-        "slug": "astro-plain",
-        "title": "astro-plain",
-        "description": "Generic, batteries-included prototype for Astro pages",
+        "slug": "@ryandejaegher/my-astro-component",
+        "title": "@ryandejaegher/my-astro-component",
+        "description": "This is an example package, exported as `@example/my-component`. It consists of two Astro components, **Button** and **Heading**.",
         "categories": [
             "css+ui"
         ],
         "official": false,
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-plain",
-            "text": "View astro-plain on NPM"
+            "href": "https://www.npmjs.com/package/@ryandejaegher/my-astro-component",
+            "text": "View @ryandejaegher/my-astro-component on NPM"
         },
         "url": {
-            "href": "https://github.com/johnhenry/lib/js/astro-plain/0.0.6#readme",
-            "text": "Learn more about astro-plain"
+            "href": "https://www.npmjs.com/package/@ryandejaegher/my-astro-component",
+            "text": "View @ryandejaegher/my-astro-component on NPM"
         },
-        "downloads": 18,
-        "badges": []
-    },
-    {
-        "slug": "astro-utils",
-        "title": "astro-utils",
-        "description": "Various utils for astro",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/warpsio/astro-utils",
-            "text": "View the astro-utils source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-utils",
-            "text": "View astro-utils on NPM"
-        },
-        "url": {
-            "href": "https://github.com/warpsio/astro-utils",
-            "text": "Learn more about astro-utils"
-        },
-        "downloads": 16,
+        "downloads": 17,
         "badges": []
     },
     {
@@ -4592,7 +4538,7 @@
             "href": "https://astro.build",
             "text": "Learn more about agnosticui-astro"
         },
-        "downloads": 14,
+        "downloads": 15,
         "badges": []
     },
     {
@@ -4735,6 +4681,30 @@
         "badges": []
     },
     {
+        "slug": "@astropub/contentful",
+        "title": "@astropub/contentful",
+        "description": "Use Contentful in Astro",
+        "categories": [
+            "css+ui",
+            "performance+seo"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/astro-community/contentful",
+            "text": "View the @astropub/contentful source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@astropub/contentful",
+            "text": "View @astropub/contentful on NPM"
+        },
+        "url": {
+            "href": "https://github.com/astro-community/contentful",
+            "text": "Learn more about @astropub/contentful"
+        },
+        "downloads": 11,
+        "badges": []
+    },
+    {
         "slug": "sifra",
         "title": "sifra",
         "description": "A toolkit for writing interactive tutorials",
@@ -4804,25 +4774,25 @@
         "badges": []
     },
     {
-        "slug": "@astropub/contentful",
-        "title": "@astropub/contentful",
-        "description": "Use Contentful in Astro",
+        "slug": "astro-convert",
+        "title": "astro-convert",
+        "description": "🫶 AstroJS convert utilities. Convert your files automatically.",
         "categories": [
             "css+ui",
             "performance+seo"
         ],
         "official": false,
         "repoUrl": {
-            "href": "https://github.com/astro-community/contentful",
-            "text": "View the @astropub/contentful source code"
+            "href": "https://github.com/Lightrix/astro-convert",
+            "text": "View the astro-convert source code"
         },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/@astropub/contentful",
-            "text": "View @astropub/contentful on NPM"
+            "href": "https://www.npmjs.com/package/astro-convert",
+            "text": "View astro-convert on NPM"
         },
         "url": {
-            "href": "https://github.com/astro-community/contentful",
-            "text": "Learn more about @astropub/contentful"
+            "href": "https://github.com/Lightrix/astro-convert#readme",
+            "text": "Learn more about astro-convert"
         },
         "downloads": 10,
         "badges": []
@@ -4851,52 +4821,26 @@
         "badges": []
     },
     {
-        "slug": "astrojs-cloudflare",
-        "title": "astrojs-cloudflare",
-        "description": "Deploy your site to cloudflare pages functions",
+        "slug": "astro-div",
+        "title": "astro-div",
+        "description": "It's only a <div />",
         "categories": [
-            "css+ui",
-            "adapters"
+            "css+ui"
         ],
         "official": false,
         "repoUrl": {
-            "href": "https://github.com/withastro/astro",
-            "text": "View the astrojs-cloudflare source code"
+            "href": "https://github.com/mzaini30/astro-div",
+            "text": "View the astro-div source code"
         },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astrojs-cloudflare",
-            "text": "View astrojs-cloudflare on NPM"
+            "href": "https://www.npmjs.com/package/astro-div",
+            "text": "View astro-div on NPM"
         },
         "url": {
-            "href": "https://docs.astro.build/en/guides/integrations-guide/cloudflare/",
-            "text": "Learn more about astrojs-cloudflare"
+            "href": "https://github.com/mzaini30/astro-div#readme",
+            "text": "Learn more about astro-div"
         },
-        "downloads": 9,
-        "badges": []
-    },
-    {
-        "slug": "astro-partytown-resolveurl-2",
-        "title": "astro-partytown-resolveurl-2",
-        "description": "Astro + Partytown integration",
-        "categories": [
-            "css+ui",
-            "analytics",
-            "performance+seo"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/withastro/astro",
-            "text": "View the astro-partytown-resolveurl-2 source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-partytown-resolveurl-2",
-            "text": "View astro-partytown-resolveurl-2 on NPM"
-        },
-        "url": {
-            "href": "https://docs.astro.build/en/guides/integrations-guide/partytown/",
-            "text": "Learn more about astro-partytown-resolveurl-2"
-        },
-        "downloads": 9,
+        "downloads": 10,
         "badges": []
     },
     {
@@ -4923,56 +4867,9 @@
         "badges": []
     },
     {
-        "slug": "astro-convert",
-        "title": "astro-convert",
-        "description": "🫶 AstroJS convert utilities. Convert your files automatically.",
-        "categories": [
-            "css+ui",
-            "performance+seo"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/Lightrix/astro-convert",
-            "text": "View the astro-convert source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-convert",
-            "text": "View astro-convert on NPM"
-        },
-        "url": {
-            "href": "https://github.com/Lightrix/astro-convert#readme",
-            "text": "Learn more about astro-convert"
-        },
-        "downloads": 9,
-        "badges": []
-    },
-    {
-        "slug": "astro-div",
-        "title": "astro-div",
-        "description": "It's only a <div />",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/mzaini30/astro-div",
-            "text": "View the astro-div source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-div",
-            "text": "View astro-div on NPM"
-        },
-        "url": {
-            "href": "https://github.com/mzaini30/astro-div#readme",
-            "text": "Learn more about astro-div"
-        },
-        "downloads": 9,
-        "badges": []
-    },
-    {
-        "slug": "astro-markdown-cms",
-        "title": "astro-markdown-cms",
-        "description": "An Astro Integration to provide a Flat-File CMS",
+        "slug": "astro-space-agency",
+        "title": "astro-space-agency",
+        "description": "Astro Space Agency is a component library for withastro/astro with spaceship building in mind",
         "categories": [
             "css+ui"
         ],
@@ -4993,96 +4890,26 @@
         "badges": []
     },
     {
-        "slug": "astro-github",
-        "title": "astro-github",
-        "description": "Showing the Github Stars badge on Astro",
+        "slug": "astros-style",
+        "title": "astros-style",
+        "description": "Style for astros theme",
         "categories": [
             "css+ui"
         ],
         "official": false,
         "repoUrl": {
-            "href": "https://github.com/mzaini30/astro-github",
-            "text": "View the astro-github source code"
+            "href": "https://github.com/warpsio/astros-style",
+            "text": "View the astros-style source code"
         },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-github",
-            "text": "View astro-github on NPM"
+            "href": "https://www.npmjs.com/package/astros-style",
+            "text": "View astros-style on NPM"
         },
         "url": {
-            "href": "https://github.com/mzaini30/astro-github#readme",
-            "text": "Learn more about astro-github"
+            "href": "https://github.com/warpsio/astros-style",
+            "text": "Learn more about astros-style"
         },
-        "downloads": 7,
-        "badges": []
-    },
-    {
-        "slug": "astro-pandoc",
-        "title": "astro-pandoc",
-        "description": "Astro component for using pandoc to convert content. This allows you to embed any format pandoc supports.  - Supported formats https://pandoc.org/MANUAL.html#general-options - [Demo](https://github.com/trashhalo/astro-pandoc/blob/main/src/components/Demo.",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/trashhalo/astro-pandoc",
-            "text": "View the astro-pandoc source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-pandoc",
-            "text": "View astro-pandoc on NPM"
-        },
-        "url": {
-            "href": "https://github.com/trashhalo/astro-pandoc#readme",
-            "text": "Learn more about astro-pandoc"
-        },
-        "downloads": 7,
-        "badges": []
-    },
-    {
-        "slug": "astro-smartlook",
-        "title": "astro-smartlook",
-        "description": "Smartlook component for Astro",
-        "categories": [
-            "css+ui",
-            "analytics"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/COQUARD-Cyrille-Freelance/astro-smartlook",
-            "text": "View the astro-smartlook source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-smartlook",
-            "text": "View astro-smartlook on NPM"
-        },
-        "url": {
-            "href": "https://github.com/COQUARD-Cyrille-Freelance/astro-smartlook#readme",
-            "text": "Learn more about astro-smartlook"
-        },
-        "downloads": 6,
-        "badges": []
-    },
-    {
-        "slug": "astro-blog",
-        "title": "astro-blog",
-        "description": "Collection of utils for blogging with astro",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "repoUrl": {
-            "href": "https://github.com/warpsio/astro-blog",
-            "text": "View the astro-blog source code"
-        },
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-blog",
-            "text": "View astro-blog on NPM"
-        },
-        "url": {
-            "href": "https://github.com/warpsio/astro-blog",
-            "text": "Learn more about astro-blog"
-        },
-        "downloads": 7,
+        "downloads": 8,
         "badges": []
     },
     {
@@ -5109,24 +4936,43 @@
         "badges": []
     },
     {
-        "slug": "astros-style",
-        "title": "astros-style",
-        "description": "Style for astros theme",
+        "slug": "astro-blog",
+        "title": "astro-blog",
+        "description": "Collection of utils for blogging with astro",
         "categories": [
             "css+ui"
         ],
         "official": false,
         "repoUrl": {
-            "href": "https://github.com/warpsio/astros-style",
-            "text": "View the astros-style source code"
+            "href": "https://github.com/warpsio/astro-blog",
+            "text": "View the astro-blog source code"
         },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astros-style",
-            "text": "View astros-style on NPM"
+            "href": "https://www.npmjs.com/package/astro-blog",
+            "text": "View astro-blog on NPM"
         },
         "url": {
-            "href": "https://github.com/warpsio/astros-style",
-            "text": "Learn more about astros-style"
+            "href": "https://github.com/warpsio/astro-blog",
+            "text": "Learn more about astro-blog"
+        },
+        "downloads": 7,
+        "badges": []
+    },
+    {
+        "slug": "astro-control",
+        "title": "astro-control",
+        "description": "Utility components for more ergonomic Astro rendering.",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-control",
+            "text": "View astro-control on NPM"
+        },
+        "url": {
+            "href": "https://www.npmjs.com/package/astro-control",
+            "text": "View astro-control on NPM"
         },
         "downloads": 7,
         "badges": []
@@ -5155,25 +5001,6 @@
         "badges": []
     },
     {
-        "slug": "astro-control",
-        "title": "astro-control",
-        "description": "Utility components for more ergonomic Astro rendering.",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-control",
-            "text": "View astro-control on NPM"
-        },
-        "url": {
-            "href": "https://www.npmjs.com/package/astro-control",
-            "text": "View astro-control on NPM"
-        },
-        "downloads": 6,
-        "badges": []
-    },
-    {
         "slug": "@m4rrc0/astro-fetch-ahead",
         "title": "@m4rrc0/astro-fetch-ahead",
         "description": "Astro integration to do async stuff before the actual build",
@@ -5195,5 +5022,26 @@
         },
         "downloads": 5,
         "badges": []
+    },
+    {
+        "slug": "@caisy/rich-text-astro-renderer",
+        "title": "@caisy/rich-text-astro-renderer",
+        "description": "This is a template for an Astro component library. Use this template for writing components to use in multiple projects or publish to NPM.",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/@caisy/rich-text-astro-renderer",
+            "text": "View @caisy/rich-text-astro-renderer on NPM"
+        },
+        "url": {
+            "href": "https://www.npmjs.com/package/@caisy/rich-text-astro-renderer",
+            "text": "View @caisy/rich-text-astro-renderer on NPM"
+        },
+        "downloads": 0,
+        "badges": [
+            "new"
+        ]
     }
 ]

--- a/src/data/integrations.json
+++ b/src/data/integrations.json
@@ -4573,25 +4573,6 @@
         "badges": []
     },
     {
-        "slug": "@ryandejaegher/my-astro-component",
-        "title": "@ryandejaegher/my-astro-component",
-        "description": "This is an example package, exported as `@example/my-component`. It consists of two Astro components, **Button** and **Heading**.",
-        "categories": [
-            "css+ui"
-        ],
-        "official": false,
-        "npmUrl": {
-            "href": "https://www.npmjs.com/package/@ryandejaegher/my-astro-component",
-            "text": "View @ryandejaegher/my-astro-component on NPM"
-        },
-        "url": {
-            "href": "https://www.npmjs.com/package/@ryandejaegher/my-astro-component",
-            "text": "View @ryandejaegher/my-astro-component on NPM"
-        },
-        "downloads": 16,
-        "badges": []
-    },
-    {
         "slug": "agnosticui-astro",
         "title": "agnosticui-astro",
         "description": "Astro + AgnosticUI integration",
@@ -4989,9 +4970,9 @@
         "badges": []
     },
     {
-        "slug": "astro-space-agency",
-        "title": "astro-space-agency",
-        "description": "Astro Space Agency is a component library for withastro/astro with spaceship building in mind",
+        "slug": "astro-markdown-cms",
+        "title": "astro-markdown-cms",
+        "description": "An Astro Integration to provide a Flat-File CMS",
         "categories": [
             "css+ui"
         ],
@@ -5012,27 +4993,73 @@
         "badges": []
     },
     {
-        "slug": "astro-cloudflare",
-        "title": "astro-cloudflare",
-        "description": "Deploy your site to cloudflare pages functions",
+        "slug": "astro-github",
+        "title": "astro-github",
+        "description": "Showing the Github Stars badge on Astro",
         "categories": [
-            "css+ui",
-            "adapters"
+            "css+ui"
         ],
         "official": false,
         "repoUrl": {
-            "href": "https://github.com/withastro/astro",
-            "text": "View the astro-cloudflare source code"
+            "href": "https://github.com/mzaini30/astro-github",
+            "text": "View the astro-github source code"
         },
         "npmUrl": {
-            "href": "https://www.npmjs.com/package/astro-cloudflare",
-            "text": "View astro-cloudflare on NPM"
+            "href": "https://www.npmjs.com/package/astro-github",
+            "text": "View astro-github on NPM"
         },
         "url": {
-            "href": "https://docs.astro.build/en/guides/integrations-guide/cloudflare/",
-            "text": "Learn more about astro-cloudflare"
+            "href": "https://github.com/mzaini30/astro-github#readme",
+            "text": "Learn more about astro-github"
         },
         "downloads": 7,
+        "badges": []
+    },
+    {
+        "slug": "astro-pandoc",
+        "title": "astro-pandoc",
+        "description": "Astro component for using pandoc to convert content. This allows you to embed any format pandoc supports.  - Supported formats https://pandoc.org/MANUAL.html#general-options - [Demo](https://github.com/trashhalo/astro-pandoc/blob/main/src/components/Demo.",
+        "categories": [
+            "css+ui"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/trashhalo/astro-pandoc",
+            "text": "View the astro-pandoc source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-pandoc",
+            "text": "View astro-pandoc on NPM"
+        },
+        "url": {
+            "href": "https://github.com/trashhalo/astro-pandoc#readme",
+            "text": "Learn more about astro-pandoc"
+        },
+        "downloads": 7,
+        "badges": []
+    },
+    {
+        "slug": "astro-smartlook",
+        "title": "astro-smartlook",
+        "description": "Smartlook component for Astro",
+        "categories": [
+            "css+ui",
+            "analytics"
+        ],
+        "official": false,
+        "repoUrl": {
+            "href": "https://github.com/COQUARD-Cyrille-Freelance/astro-smartlook",
+            "text": "View the astro-smartlook source code"
+        },
+        "npmUrl": {
+            "href": "https://www.npmjs.com/package/astro-smartlook",
+            "text": "View astro-smartlook on NPM"
+        },
+        "url": {
+            "href": "https://github.com/COQUARD-Cyrille-Freelance/astro-smartlook#readme",
+            "text": "Learn more about astro-smartlook"
+        },
+        "downloads": 6,
         "badges": []
     },
     {


### PR DESCRIPTION
Currently on the integrations page for adapters there are 4 instances of cloudflare adapters (astro-cloudflare, astro-cloudflare-node, astro-js-cloudflare), all linking to the main repo and they should probably removed in favour of the `@astrojs/cloudflare` package.