### PR TITLE
validate submission images on backend

### DIFF
--- a/netlify/functions/submit-showcase/index.ts
+++ b/netlify/functions/submit-showcase/index.ts
@@ -67,14 +67,19 @@ export const handler: Handler = async (event) => {
         return errorRedirect('Website URL required')
     }
 
+    const images = form
+        .getAll('previewImage')
+        .filter((value): value is File => value instanceof File)
+    if (!images.length) {
+        return errorRedirect('One or more images required')
+    }
+
     let message: DiscordWebhookMessage
     try {
         message = await executeDiscordWebhook(env.DISCORD_WEBHOOK_URL, {
             threadId: env.DISCORD_WEBHOOK_THREAD_ID,
             content: 'New showcase submission!',
-            files: form
-                .getAll('previewImage')
-                .filter((value): value is File => value instanceof File)
+            files: images
         })
     } catch (error: unknown) {
         return errorRedirect(
@@ -103,7 +108,9 @@ export const handler: Handler = async (event) => {
     })
 
     if (!image) {
-        return errorRedirect('No image')
+        return errorRedirect(
+            'No images found in the submission. This is a bug, please report it in the Astro discord!'
+        )
     }
 
     const siteData: ShowcaseSite = {

--- a/netlify/functions/submit-theme/index.ts
+++ b/netlify/functions/submit-theme/index.ts
@@ -56,14 +56,19 @@ export const handler: Handler = async (event) => {
         return redirect('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
     }
 
+    const submittedImages = form
+        .getAll('previewImage')
+        .filter((value): value is File => value instanceof File)
+    if (!submittedImages.length) {
+        return errorRedirect('One or more images required')
+    }
+
     let message: DiscordWebhookMessage
     try {
         message = await executeDiscordWebhook(env.DISCORD_WEBHOOK_URL, {
             threadId: env.DISCORD_WEBHOOK_THREAD_ID,
             content: 'New theme submission!',
-            files: form
-                .getAll('images')
-                .filter((value): value is File => value instanceof File)
+            files: submittedImages
         })
     } catch (error: unknown) {
         return errorRedirect(


### PR DESCRIPTION
Some submissions were getting through without being stopped by browser HTML validation. Added a new backend check for images to prevent this
