### PR TITLE
Add partnerships link

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -18,6 +18,7 @@
 # One-off shortcuts
 /v0.21                  /blog/astro-021-release/  301
 /hack                   https://astroinc.notion.site/FRIDAY-Astro-1-0-Hackathon-9fb3499b375e4b01b88b080fd918b184
+/partnerships           https://astroinc.notion.site/Partner-with-Astro-b05cfd5dcf4248dcbea4a2d81554efed
 
 # Themes catalog shortcuts
 /resources/image-templates https://www.figma.com/community/file/1182357255394426899

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -21,6 +21,10 @@ const links: Link[] = [
         text: 'Press'
     },
     {
+        href: '/partnerships',
+        text: 'Partnerships'
+    },
+    {
         href: '/privacy',
         text: 'Privacy Policy'
     },


### PR DESCRIPTION
- Add a `/partnerships` redirect to Notion

- Add this link to the site footer:
    <img width="709" alt="image" src="https://user-images.githubusercontent.com/357379/219055103-f2fac7e9-1ab1-428f-a020-7470eabf025b.png">
