### PR TITLE
feat: adds Deploy to Netlify buttons for free themes

### DIFF
--- a/src/components/ThemeCard.astro
+++ b/src/components/ThemeCard.astro
@@ -10,8 +10,6 @@ export interface Props {
 }
 
 const { theme } = Astro.props as Props
-
-const stars = theme.stars
 ---
 
 <article class:list={["flex flex-col bg-neutral-50", neonOutlineCardStyle]}>

--- a/src/pages/themes/details/[slug].astro
+++ b/src/pages/themes/details/[slug].astro
@@ -120,7 +120,7 @@ const { theme } = Astro.props
                 <p class="pt-1 md:pt-3">{theme.description}</p>
 
                 {
-                    theme.tags?.length > 0 && (
+                    theme.tags.length > 0 && (
                         <div class="py-2 md:py-4 flex flex-wrap gap-4 md:gap-6">
                             {theme.tags.map((tag) => (
                                 <Icon
@@ -182,7 +182,7 @@ const { theme } = Astro.props
             }
 
             {
-                theme.keywords?.length > 0 && (
+                theme.keywords.length > 0 && (
                     <section>
                         <h2 class="text-lg font-medium mb-2">Features</h2>
                         <ul class="flex flex-wrap gap-2">
@@ -197,7 +197,7 @@ const { theme } = Astro.props
             }
 
             {
-                theme.links?.length > 0 && (
+                theme.links.length > 0 && (
                     <section>
                         <h2 class="text-lg font-medium mb-2">Links</h2>
                         <ul class="flex flex-wrap gap-3 md:gap-4">

--- a/src/pages/themes/details/[slug].astro
+++ b/src/pages/themes/details/[slug].astro
@@ -35,7 +35,7 @@ const { theme } = Astro.props
 const netlifyUrl =
     theme.repoUrl &&
     typeof theme.stars !== 'undefined' &&
-    `https://app.netlify.com/start/deploy?repository=${theme.repoUrl}`
+    `https://app.netlify.com/start/deploy?repository=${theme.repoUrl.href}`
 ---
 
 <Layout image={theme.image} title={theme.title} description={theme.description}>

--- a/src/pages/themes/details/[slug].astro
+++ b/src/pages/themes/details/[slug].astro
@@ -31,6 +31,11 @@ const placeholderClass = clsx(`
 `)
 
 const { theme } = Astro.props
+
+const netlifyUrl =
+    theme.repoUrl &&
+    typeof theme.stars !== 'undefined' &&
+    `https://app.netlify.com/start/deploy?repository=${theme.repoUrl}`
 ---
 
 <Layout image={theme.image} title={theme.title} description={theme.description}>
@@ -134,7 +139,7 @@ const { theme } = Astro.props
                     )
                 }
 
-                <div class="flex flex-wrap gap-4">
+                <div class="flex flex-wrap gap-4 items-center justify-center md:justify-start">
                     <Button
                         external
                         href={theme.buyUrl?.href || theme.repoUrl.href}
@@ -167,6 +172,24 @@ const { theme } = Astro.props
                                     aria-hidden="true"
                                 />
                             </Button>
+                        )
+                    }
+                    {
+                        netlifyUrl && (
+                            <a
+                                href={netlifyUrl}
+                                target="_blank"
+                                rel="noopener"
+                                aria-label={`Deploy ${theme.title} to Netlify`}
+                            >
+                                <img
+                                    src="https://www.netlify.com/img/deploy/button.svg"
+                                    alt="Deploy to Netlify"
+                                    title="Deploy to Netlify"
+                                    width="146"
+                                    height="32"
+                                />
+                            </a>
                         )
                     }
                 </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ export const ThemeSchema = z.object({
     description: z.string(),
     fullDescription: z.string().optional(),
     image: ImageMetadataSchema,
-    images: z.array(ImageMetadataSchema).optional(),
+    images: z.array(ImageMetadataSchema).default([]),
     author: LinkSchema.extend({
         avatar: z.string().url().or(z.string().startsWith('/assets/themes/avatars/')).optional()
     }).optional(),
@@ -93,12 +93,12 @@ export const ThemeSchema = z.object({
     demoUrl: LinkSchema.optional(),
     npmUrl: LinkSchema.optional(),
     buyUrl: LinkSchema.optional(),
-    links: z.array(LinkSchema).optional(),
+    links: z.array(LinkSchema).default([]),
     official: z.boolean().optional(),
     stars: z.number().min(0).optional(),
     featured: z.number().min(1).optional(),
-    tags: z.array(ThemeTagSchema).optional(),
-    keywords: z.array(z.string()).optional()
+    tags: z.array(ThemeTagSchema).default([]),
+    keywords: z.array(z.string()).default([])
 })
 export type Theme = z.infer<typeof ThemeSchema>
 


### PR DESCRIPTION
For themes with public repos (all free themes), a Deploy to Netlify button is included on the theme details page in additions to our Get Started & Live Demo links