### PR TITLE
Stop incorrect color contrast error being reported

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -6,7 +6,7 @@ import HeroCard from './HeroCard.astro'
 import Starfield from './Starfield.astro'
 ---
 
-<section class="pt-24 pb-8 overflow-hidden relative bg-purple-800 z-10">
+<section class="pt-24 pb-8 overflow-hidden relative bg-primary-800 z-10">
     <Starfield />
     <div class="mx-auto max-w-7xl px-4 sm:px-6">
         <div class="lg:grid lg:grid-cols-12 mx-auto lg:gap-16 justify-center">

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -7,8 +7,7 @@ export type Props = Partial<MaxWidthProps>
 const { ...props } = Astro.props as Props
 ---
 
-<div class="relative pt-20 pb-12 md:pt-24 md:pb-16 lg:pb-20">
-
+<div class="relative pt-20 pb-12 md:pt-24 md:pb-16 lg:pb-20 bg-primary-800 z-10">
     <Starfield subtle />
     <MaxWidth as="section" {...props}>
             <h1


### PR DESCRIPTION
Applies the same fix as d641e62 to pages beyond the home page.