### PR TITLE
a11y fixes

### DIFF
--- a/src/components/forms/ImageInput.tsx
+++ b/src/components/forms/ImageInput.tsx
@@ -35,7 +35,7 @@ export default function ImageInput(props: {
                             {props.required && (
                                 <span
                                     class="text-red-500 text-base align-text-top"
-                                    aria-hidden
+                                    aria-hidden="true"
                                 >
                                     *
                                 </span>
@@ -75,7 +75,7 @@ export default function ImageInput(props: {
                             {props.required && (
                                 <span
                                     class="text-red-500 text-base align-text-top"
-                                    aria-hidden
+                                    aria-hidden="true"
                                 >
                                     *
                                 </span>

--- a/src/components/forms/TagInput.tsx
+++ b/src/components/forms/TagInput.tsx
@@ -92,7 +92,7 @@ export function TagSelect({ options, ...props }: TagSelectProps) {
                                 <option key={index}>{option}</option>
                             ))}
                     </select>
-                    <span class="absolute right-0 select-none" aria-hidden>
+                    <span class="absolute right-0 select-none" aria-hidden="true">
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
                             width="16"

--- a/src/pages/themes/details/[slug].astro
+++ b/src/pages/themes/details/[slug].astro
@@ -230,7 +230,7 @@ const netlifyUrl =
                                         href={href}
                                         target="_blank"
                                         rel="noopener noreferrer"
-                                        class="text-primary-500 hover:underline flex items-center gap-0.5"
+                                        class="text-primary-600 hover:underline flex items-center gap-0.5"
                                     >
                                         <Icon
                                             name="heroicons-outline:link"

--- a/src/pages/themes/details/[slug].astro
+++ b/src/pages/themes/details/[slug].astro
@@ -235,7 +235,7 @@ const netlifyUrl =
                                         <Icon
                                             name="heroicons-outline:link"
                                             size={18}
-                                            aria-hidden=""
+                                            aria-hidden="true"
                                             class="opacity-50"
                                         />{' '}
                                         {text}


### PR DESCRIPTION
- Add explicit true value to `aria-hidden` where missing

- Fix color contrast of links on [theme pages](https://deploy-preview-545--astro-www-2.netlify.app/themes/details/portfolio/)
    | Before | After |
    |---|---|
    | <img width="174" alt="image" src="https://user-images.githubusercontent.com/357379/220596621-923ccf28-1e29-4cca-ad11-0700b90ebac8.png"> | <img width="177" alt="image" src="https://user-images.githubusercontent.com/357379/220596653-bb6541cc-d673-4aaf-baca-98f6a5aa05db.png"> |

Also noticing that the Quill editor we’re using for the theme submission form is missing accessible labelling for its toolbar. There’s been [an open PR to fix that on their end](https://github.com/quilljs/quill/pull/3639) for nearly 6 months but seems maybe they’re not interested. Might be good to re-evaluate choice of text editor for the new site to see if there’s a more accessible alternative?
