### PR TITLE
Mention Feedback Fish in privacy policy

### DIFF
--- a/src/pages/privacy.mdx
+++ b/src/pages/privacy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Privacy Policy
-updated_date: Sep 13, 2022
+updated_date: Mar 1, 2023
 description: Astro's privacy policy
 header: |
   In addition to this Privacy Policy, Astro also has [Terms of Service](/terms).
@@ -9,7 +9,7 @@ header: |
 import Layout from '../layouts/Legal.astro'
 import Panel from '../components/Panel.astro'
 
-<Layout title="Privacy Policy" description="Astro's privacy policy" updated_date="Sep 13, 2022">
+<Layout title="Privacy Policy" description="Astro's privacy policy" updated_date="Mar 1, 2023">
 
 *In addition to this Privacy Policy, Astro also has [Terms of Service](/terms).*
 

--- a/src/pages/privacy.mdx
+++ b/src/pages/privacy.mdx
@@ -59,6 +59,8 @@ We want to process as little personal information as possible when you use our w
 
 The purpose of us using this software is to understand our website traffic in the most privacy-friendly way possible so that we can continually improve our website and business. The lawful basis as per the GDPR is "Article 6(1)(f); where our legitimate interests are to improve our website and business continually." As per the explanation, no personal data is stored over time.
 
+When you choose to submit feedback on the docs site, we store your message using the [Feedback Fish](https://feedback.fish/) service. This enables us to gather helpful feedback and improve our documentation.
+
 ### Security
 
 We understand that the security of your data is important. We provide reasonable administrative, technical, and physical security controls to protect your personal information from unauthorized access, disclosure, modification, or unauthorized destruction. However, despite our efforts, no security controls are 100% effective and Astro cannot ensure or warrant the security of your data.


### PR DESCRIPTION
Adds a brief mention that we use Feedback Fish to collect docs feedback.