### PR TITLE
fix: :bug: page content can be scrolled with the mobile menu open

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -27,5 +27,7 @@ import MenuIcon from "~/icons/MenuIcon.jsx"
 		button: document.querySelector("#astro-header-drawer-button") as HTMLElement,
 		content: document.querySelector("#astro-header-drawer") as HTMLElement,
 		animated: true,
+		/** matches the `lg:hidden` class above */
+		closeAt: 1024,
 	})
 </script>

--- a/src/components/HeaderDrawerContent.astro
+++ b/src/components/HeaderDrawerContent.astro
@@ -15,7 +15,7 @@ import SocialLinks from "./SocialLinks.astro"
 	<details class="group">
 		<summary class="link flex cursor-pointer list-none items-center justify-between">
 			Resources
-			<ChevronIcon class="inline-block -rotate-180 transition-transform group-open:rotate-0" />
+			<ChevronIcon class="inline-block rotate-0 transition-transform group-open:-rotate-180" />
 		</summary>
 		<div class="mt-4 flex flex-col gap-4 text-2xl font-light">
 			<a href="/themes/" class="link flex items-center gap-4">

--- a/src/components/HeaderDrawerContent.astro
+++ b/src/components/HeaderDrawerContent.astro
@@ -8,7 +8,7 @@ import SocialLinks from "./SocialLinks.astro"
 
 <nav
 	aria-label="Primary"
-	class="heading-3 flex flex-col divide-y divide-astro-gray-500 text-left [&>*]:p-6"
+	class="heading-3 flex flex-col divide-y divide-astro-gray-500 text-left [&>*]:p-6 pb-12"
 >
 	<a href="https://docs.astro.build/" class="link"> Docs</a>
 	<a href="/showcase/" class="link"> Showcase</a>

--- a/src/helpers/disclosure.ts
+++ b/src/helpers/disclosure.ts
@@ -4,13 +4,25 @@ export function createDisclosure({
 	button,
 	content,
 	animated = false,
+	closeAt = -1,
 }: {
 	button: HTMLElement
 	content: HTMLElement
 	animated?: boolean
+	closeAt?: number
 }) {
 	if (content.id) {
 		button.setAttribute("aria-controls", content.id)
+	}
+
+	if (closeAt > 0) {
+		const mediaQuery = window.matchMedia(`(min-width: ${closeAt}px)`)
+
+		mediaQuery.addEventListener("change", (event: MediaQueryListEvent) => {
+			if (event.matches) {
+				setVisible(false)
+			}
+		})
 	}
 
 	const [visible, setVisible] = createSignal(false)

--- a/src/helpers/disclosure.ts
+++ b/src/helpers/disclosure.ts
@@ -25,6 +25,10 @@ export function createDisclosure({
 		if (!visible() && !animated) {
 			content.style.display = "none"
 		}
+		/* make sure page scrolling is disabled when the menu is open */
+		if (visible()) {
+			document.documentElement.classList.add("disclosure-open")
+		}
 
 		// run after an animation frame to let the element start at the leave state
 		requestAnimationFrame(() => {
@@ -42,6 +46,7 @@ export function createDisclosure({
 		content.addEventListener("transitionend", () => {
 			if (!visible()) {
 				content.style.display = "none"
+				document.documentElement.classList.remove("disclosure-open")
 			}
 		})
 	}

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -23,7 +23,7 @@ const { ...head } = Astro.props
 	</head>
 	<body>
 		<div class="isolate flex min-h-screen flex-col">
-			<div class="sticky top-0 z-20">
+			<div id="nav" class="sticky top-0 z-20 max-h-screen overflow-y-auto">
 				<Header>
 					<HeaderNav />
 					<HeaderDrawerContent slot="drawer" />
@@ -43,5 +43,13 @@ const { ...head } = Astro.props
 				<Footer />
 			</div>
 		</div>
-	</body>
+	</body><style>
+		:root.disclosure-open {
+			overflow-y: hidden;
+		}
+
+		:root.disclosure-open #nav {
+			overflow-y: auto;
+		}
+	</style>
 </html>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -23,7 +23,7 @@ const { ...head } = Astro.props
 	</head>
 	<body>
 		<div class="isolate flex min-h-screen flex-col">
-			<div id="nav" class="sticky top-0 z-20 max-h-screen overflow-y-auto">
+			<div id="nav" class="sticky top-0 z-20 max-h-screen">
 				<Header>
 					<HeaderNav />
 					<HeaderDrawerContent slot="drawer" />
@@ -43,13 +43,14 @@ const { ...head } = Astro.props
 				<Footer />
 			</div>
 		</div>
-	</body><style>
-		:root.disclosure-open {
-			overflow-y: hidden;
-		}
+		<style>
+			:root.disclosure-open {
+				overflow-y: hidden;
+			}
 
-		:root.disclosure-open #nav {
-			overflow-y: auto;
-		}
-	</style>
+			:root.disclosure-open #nav {
+				overflow-y: auto;
+			}
+		</style>
+	</body>
 </html>


### PR DESCRIPTION
[x] blocks page scrolling when the menu is open
[x] allows the mobile menu to scroll vertically
[x] automatically closes the menu when the window is resized past 1024px