### PR TITLE
fix: showcase page mobile view overflow

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -22,7 +22,7 @@ const { ...head } = Astro.props
 		<BaseHead {...head} />
 	</head>
 	<body>
-		<div class="isolate flex min-h-screen flex-col">
+		<div class="isolate flex min-h-screen flex-col overflow-x-hidden">
 			<div id="nav" class="sticky top-0 z-20 max-h-screen">
 				<Header>
 					<HeaderNav />


### PR DESCRIPTION
## Description 🗒️

Showcase page has responsive issues with mobile view because of the background image overflowing on the x-axis. I fixed it with this merge request by adding hiding the overflow on the x-axis.

fix: #569

## Screenshots 📷

<img width="1512" alt="CleanShot 2023-03-07 at 17 05 16@2x" src="https://user-images.githubusercontent.com/31426677/223592499-0ffc4a14-67f2-4d8b-9d09-ceca4b7c7ac3.png">

Before

<img width="1512" alt="CleanShot 2023-03-07 at 17 05 56@2x" src="https://user-images.githubusercontent.com/31426677/223592595-b827c764-91e5-4ecd-a352-f7fa668305ed.png">

After
