### PR TITLE
Configure size-adjusted fallback fonts to reduce CLS

### DIFF
--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -30,3 +30,25 @@
 	font-stretch: wider;
 	font-display: swap;
 }
+
+/* == FALLBACK FONT CONFIG == */
+@font-face {
+	font-family: md-io-fallback;
+	src: local("Courier New");
+	line-gap-override: 7%;
+}
+
+@font-face {
+	font-family: obviously-regular-fallback;
+	src: local("Verdana");
+	size-adjust: 112%;
+	line-gap-override: 19%;
+}
+
+@font-face {
+	font-family: obviously-wide-fallback;
+	src: local("Arial Black");
+	size-adjust: 134%;
+	ascent-override: 96%;
+	descent-override: 27%;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -22,9 +22,9 @@ module.exports = {
 			},
 			fontFamily: {
 				sans: ["InterVariable", "sans-serif"],
-				mono: [`"MD IO 0.5"`, "monospace"],
-				obviously: ["Obviously", "sans-serif"],
-				"obviously-wide": `"Obviously Wide", "sans-serif"`,
+				mono: [`"MD IO 0.5"`, "md-io-fallback", "monospace"],
+				obviously: ["Obviously", "obviously-regular-fallback", "sans-serif"],
+				"obviously-wide": [`"Obviously Wide", "obviously-wide-fallback", "sans-serif"`],
 			},
 			colors: {
 				black: "#17191E",


### PR DESCRIPTION
This configures manually adjusted fallback font definitions using common system fonts to help reduce CLS in browsers that support it. `size-adjust` doesn’t have amazing [browser support](https://caniuse.com/mdn-css_at-rules_font-face_size-adjust) just yet, but it’s a safe progressive enhancement that benefits people who are using those browsers.

I used this handy comparison tool to tweak these values: https://screenspan.net/fallback

### Before

https://user-images.githubusercontent.com/357379/223765055-982698b4-0a58-4ca9-97b2-067f812fda1d.mp4

### After

https://user-images.githubusercontent.com/357379/223765644-ffc8d11c-bb90-439e-af23-b234637fe4a5.mp4

