### PR TITLE
Notification banner a11y fixes

### DIFF
--- a/src/components/NotificationBanner.astro
+++ b/src/components/NotificationBanner.astro
@@ -13,7 +13,8 @@ const { uid } = Astro.props
 >
 	<slot />
 	<button class="absolute h-full aspect-square right-0 top-0 flex items-center justify-center">
-		<XIcon class="h-5" />
+		<span class="sr-only">Hide banner</span>
+		<XIcon class="h-5" aria-hidden="true" />
 	</button>
 </aside>
 

--- a/src/components/NotificationBanner.astro
+++ b/src/components/NotificationBanner.astro
@@ -9,7 +9,7 @@ const { uid } = Astro.props
 <aside
 	id="notification-banner"
 	data-uid={uid}
-	class="relative w-full noise-underlay bg-blue-purple-gradient text-center body py-2"
+	class="relative w-full noise-underlay bg-blue-purple-gradient text-white text-center body py-2"
 >
 	<slot />
 	<button class="absolute h-full aspect-square right-0 top-0 flex items-center justify-center">

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -51,7 +51,7 @@ module.exports = {
 				"astro-hover": "#E8C4F9",
 			},
 			backgroundImage: {
-				"blue-purple-gradient": "linear-gradient(83.21deg, #3245FF 0%, #BC52EE 100%)",
+				"blue-purple-gradient": "linear-gradient(83.21deg, #3245FF 0%, #B845ED 100%)",
 				"blue-green-gradient": "linear-gradient(247.23deg, #4AF2C8 0%, #2F4CB3 100%)",
 				"red-pink-gradient": "linear-gradient(66.77deg, #D83333 0%, #F041FF 100%)",
 				"orange-yellow-gradient": "linear-gradient(266.93deg, #F8E42E 0%, #FF7D54 100%)",


### PR DESCRIPTION
- Adds an accessible label reading “Hide Banner” to the X icon button in the notification banner

- Tweaks the colour contrast which was technically failing WCAG AA contrast requirements. New version on the left, old version on the right:

    <img width="1195" alt="image" src="https://user-images.githubusercontent.com/357379/223831973-15152460-84d9-4ea2-94f2-da418f09a123.png">

    (The gradient change is equivalent to changing lightness in the HLS colour from 63% to 60%)
