### PR TITLE
:bug: Fixes a click handler loop in the mobile menu

### DIFF
--- a/src/helpers/disclosure.ts
+++ b/src/helpers/disclosure.ts
@@ -77,7 +77,9 @@ export function createDisclosure({
 	const handleFocusLost = (event: FocusEvent) => {
 		// close the menu when losing focus from it
 		if (content.contains(event.target as Node)) return
-		setVisible(false)
+		// ignore if the new target is the button, it's click handler will handle it
+		if (event.target === button) return
+		event.stopPropagation()
 	}
 
 	const handleClickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
In the mobile menu, if you click on the Resources dropdown then try to close the menu both elements end up handling the event and call `setVisible(!visible())` twice, flipping it to closed and then back open immediately

This updates the focus-lost handler to ignore the even if the mobile menu button is the new focus target