### PR TITLE
Ensure headings are in a sequentially descending order

### DIFF
--- a/src/components/CatalogSubmitCallout.astro
+++ b/src/components/CatalogSubmitCallout.astro
@@ -13,7 +13,7 @@ const { title, body, cta, ...attrs } = Astro.props
 ---
 
 <SidebarPanel alt {...attrs}>
-	<h4 class="heading-4">{title}</h4>
+	<h2 class="heading-4">{title}</h2>
 	<p class="mt-2 mb-6">
 		<slot />
 	</p>

--- a/src/components/SearchFilter.astro
+++ b/src/components/SearchFilter.astro
@@ -48,7 +48,7 @@ const resetHref =
 	</div>
 	<div class="py-6">
 		<div class="flex items-end justify-between">
-			<h3 class="heading-4">Filter</h3>
+			<h2 class="heading-4">Filter</h2>
 			{
 				resetHref && (
 					<a href={resetHref} class="text-sm underline">

--- a/src/pages/integrations/[...page].astro
+++ b/src/pages/integrations/[...page].astro
@@ -138,6 +138,7 @@ const integrations = page.data
 		{
 			integrations.length > 0 ? (
 				<div class="flex flex-col items-center gap-8 pb-10 sm:pb-12 md:gap-10 md:pb-16 lg:gap-12 lg:pb-20">
+					<h2 class="sr-only">Integrations</h2>
 					<CardGrid class="w-full max-w-screen-2xl pt-8 sm:grid-cols-2 sm:px-4 lg:px-8 lg:pt-10 xl:grid-cols-3 xl:px-10">
 						{integrations.map((integration) => (
 							<IntegrationCard integration={integration} />

--- a/src/pages/themes/[...page].astro
+++ b/src/pages/themes/[...page].astro
@@ -160,6 +160,7 @@ const themes = page.data
 		{
 			themes.length > 0 ? (
 				<div class="flex flex-col items-center gap-8 pb-10 sm:pb-12 md:gap-10 md:pb-16 lg:gap-12 lg:pb-20">
+					<h2 class="sr-only">Themes</h2>
 					<CardGrid class="w-full max-w-screen-2xl pt-8 sm:grid-cols-2 sm:px-4 md:px-8 lg:px-10 lg:pt-10 xl:grid-cols-3">
 						{themes.map((theme) => (
 							<ThemeCard theme={theme} />


### PR DESCRIPTION
Reworks the integrations and themes catalogue hierarchy so that there is a logical progression of heading levels.