### PR TITLE
Add skip to content link

### DIFF
--- a/src/components/HeaderNav.astro
+++ b/src/components/HeaderNav.astro
@@ -1,15 +1,12 @@
 ---
 import AstroLogo from "./AstroLogo.astro"
 import ResourcesMenu from "./ResourcesMenu.astro"
-import SkipLink from "./SkipLink.astro"
 import SocialLinks from "./SocialLinks.astro"
 ---
 
 <a href="/" title="Home" data-home-link>
 	<AstroLogo />
 </a>
-
-<SkipLink />
 
 <script>
 	import { getElement } from "~/helpers/dom.js"

--- a/src/components/HeaderNav.astro
+++ b/src/components/HeaderNav.astro
@@ -1,12 +1,15 @@
 ---
 import AstroLogo from "./AstroLogo.astro"
 import ResourcesMenu from "./ResourcesMenu.astro"
+import SkipLink from "./SkipLink.astro"
 import SocialLinks from "./SocialLinks.astro"
 ---
 
 <a href="/" title="Home" data-home-link>
 	<AstroLogo />
 </a>
+
+<SkipLink />
 
 <script>
 	import { getElement } from "~/helpers/dom.js"

--- a/src/components/SkipLink.astro
+++ b/src/components/SkipLink.astro
@@ -1,6 +1,6 @@
 <a
 	href="#main"
-	class="button-base bg-astro-gray-100 text-astro-gray-700 skip-link outline-astro-pink z-50 font-bold outline outline-[3px] outline-offset-0 drop-shadow-2xl"
+	class="button-base bg-white text-astro-gray-700 skip-link outline-astro-pink z-50 font-bold outline outline-[3px] outline-offset-0 drop-shadow-2xl"
 >
 	Skip to content
 </a>
@@ -9,7 +9,6 @@
 	.skip-link {
 		left: calc(50% - 100px);
 		position: absolute;
-		bottom: 100;
 		transform: translateY(-200%);
 		transition: none;
 	}

--- a/src/components/SkipLink.astro
+++ b/src/components/SkipLink.astro
@@ -1,6 +1,6 @@
 <a
 	href="#main"
-	class="button-base bg-white text-astro-gray-700 skip-link outline-astro-pink z-50 font-bold outline outline-[3px] outline-offset-0 drop-shadow-2xl"
+	class="mt-3 button-base bg-white text-astro-gray-700 skip-link outline-astro-pink z-50 font-bold outline outline-[3px] outline-offset-0 drop-shadow-2xl"
 >
 	Skip to content
 </a>

--- a/src/components/SkipLink.astro
+++ b/src/components/SkipLink.astro
@@ -1,0 +1,20 @@
+<a
+	href="#main"
+	class="button-base bg-astro-gray-100 text-astro-gray-700 skip-link outline-astro-pink z-50 font-bold outline outline-[3px] outline-offset-0 drop-shadow-2xl"
+>
+	Skip to content
+</a>
+
+<style>
+	.skip-link {
+		left: calc(50% - 100px);
+		position: absolute;
+		bottom: 100;
+		transform: translateY(-200%);
+		transition: none;
+	}
+
+	.skip-link:focus {
+		transform: translateY(0);
+	}
+</style>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -32,7 +32,7 @@ const { ...head } = Astro.props
 				<hr class="border-astro-gray-500" />
 			</div>
 
-			<main class="noise-container z-10 flex flex-1 flex-col">
+			<main id="main" class="noise-container z-10 flex flex-1 flex-col">
 				<div class="noise"></div>
 				<slot />
 			</main>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -5,6 +5,7 @@ import Header from "~/components/Header.astro"
 import HeaderDrawerContent from "~/components/HeaderDrawerContent.astro"
 import HeaderNav from "~/components/HeaderNav.astro"
 import NotificationBanner from "~/components/NotificationBanner.astro"
+import SkipLink from "~/components/SkipLink.astro"
 
 export type Props = HeadProps
 
@@ -20,6 +21,7 @@ const { ...head } = Astro.props
 		<BaseHead {...head} />
 	</head>
 	<body>
+		<SkipLink />
 		<div class="isolate flex min-h-screen flex-col overflow-x-hidden">
 			<NotificationBanner uid="astro-210">
 				<a href="/blog/astro-210/">Astro version 2.1 just shipped!</a>


### PR DESCRIPTION
Adds a "Skip to content" link!
 
Note: 
- Couldn't find a good way to vertically align with the navbar, it would depend on some calculations that would not work depending on if the notification bar is visible or not.
- Base white button used custom gradient/background styles that were incompatible with transform/drop-shadow for some reason a Tailwind noob can't understand, therefore I "forked" them. Also, removed the transition to avoid a super animated skip link, removing `transition: none` brings it back if we want.