### PR TITLE
Link fixes

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -24,6 +24,7 @@ export const prerender = true
 				<p class="body-large mt-3 mb-2 lg:text-3xl">Houston, we have a problem.</p>
 				<p class="body lg:body-large">
 					We couldn’t find that link.<br class="sm:hidden" /> Check the address or <a
+						href="/"
 						class="link-underline border-astro-pink-light text-astro-pink-light">head back home</a
 					>.
 				</p>

--- a/src/pages/_components/ContentFirstFast.astro
+++ b/src/pages/_components/ContentFirstFast.astro
@@ -8,10 +8,10 @@ import LandingSectionText from "./LandingSectionText.astro"
 		<Fragment slot="title">Content-focused</Fragment>
 		<Fragment slot="body">
 			Astro was designed for your content. Fetch data from any <a
-				class="link"
+				class="link-underline"
 				href="https://docs.astro.build/en/guides/cms/">CMS</a
 			> or work locally with
-			<a class="link" href="https://docs.astro.build/en/guides/content-collections/"
+			<a class="link-underline" href="https://docs.astro.build/en/guides/content-collections/"
 				>type-safe Markdown and MDX</a
 			> APIs.
 		</Fragment>

--- a/src/pages/_components/FullSpeedAhead.astro
+++ b/src/pages/_components/FullSpeedAhead.astro
@@ -12,8 +12,8 @@ import LandingSectionText from "./LandingSectionText.astro"
 		<Fragment slot="title">Full speed</Fragment>
 		<Fragment slot="body">
 			Astro optimizes your website like no other framework can. Leverage Astro's unique
-			<a href="#" class="link">zero-JS frontend architecture</a> to unlock higher conversion rates with
-			better SEO.
+			<a href="#" class="link-underline">zero-JS frontend architecture</a> to unlock higher conversion
+			rates with better SEO.
 		</Fragment>
 	</LandingSectionText>
 

--- a/src/pages/_components/FullSpeedAhead.astro
+++ b/src/pages/_components/FullSpeedAhead.astro
@@ -12,8 +12,9 @@ import LandingSectionText from "./LandingSectionText.astro"
 		<Fragment slot="title">Full speed</Fragment>
 		<Fragment slot="body">
 			Astro optimizes your website like no other framework can. Leverage Astro's unique
-			<a href="#" class="link-underline">zero-JS frontend architecture</a> to unlock higher conversion
-			rates with better SEO.
+			<a href="https://docs.astro.build/en/concepts/islands/" class="link-underline"
+				>zero-JS frontend architecture</a
+			> to unlock higher conversion rates with better SEO.
 		</Fragment>
 	</LandingSectionText>
 


### PR DESCRIPTION
- Add underline to links in homepage sections
- Add `href` to homepage and 404 page links that were missing