### PR TITLE
allowing the browser to load the ExampleShowcase component on idle

### DIFF
--- a/src/pages/_components/ContentFirstFast.astro
+++ b/src/pages/_components/ContentFirstFast.astro
@@ -18,7 +18,7 @@ import LandingSectionText from "./LandingSectionText.astro"
 	</LandingSectionText>
 	<div class="relative mt-12 flex w-full items-center">
 		<div class="w-full overflow-hidden">
-			<ExampleShowcase client:visible />
+			<ExampleShowcase client:idle />
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
Using `client:idle` here so the JS request and hydration doesn't trigger while the page is scrolling

This is a pretty minor perf difference, but while profiling scrolling on older android devices I noticed this `client:visible` hydration was occasionally making a big enough hit here to drop a couple frames during scroll