### PR TITLE
fix: scroll on the Press page deep link

### DIFF
--- a/src/pages/press/index.astro
+++ b/src/pages/press/index.astro
@@ -125,10 +125,5 @@ const socialLinks = [
 			class="noise-underlay absolute right-0 top-[-150px] h-[800px] w-[70vw] translate-x-2/3 bg-orange-yellow-gradient opacity-30 mask-radial-gradient"
 		>
 		</div>
-
-		<div
-			class="noise-underlay absolute inset-x-0 bottom-0 h-[50vw] translate-y-3/4 bg-blue-green-gradient mask-radial-gradient"
-		>
-		</div>
 	</div>
 </MainLayout>


### PR DESCRIPTION
Fixing a crazy style bug when linking to `/press/#assets` in the best way possible, deleting the offending background glow!

I couldn't actually tell why this bug exists, but when deep linking to the `#assets` ID the page wrapper seems to not have the `position: relative` style actually applied, preventing the bottom glow from using absolute positioning to crop off

It feels a lot like a corner case rendering bug where the browser would have needed to make an extra pass on the render tree to update positioning.  Can't confirm that though, best I can tell the `relative` style is applied in devtools **and** toggling it on/off in place fixes the bug.  It really is just not being accounted for at render time for some reason :shrug: