### PR TITLE
Fix a11y in showcase submit component

### DIFF
--- a/src/pages/showcase/[...page].astro
+++ b/src/pages/showcase/[...page].astro
@@ -54,7 +54,11 @@ const description = "Explore what's possible with Astro and get inspired for you
 						<li class:list={{ "md:col-span-2 md:row-span-2": site.data.highlight }}>
 							<ShowcaseCard site={site} />
 						</li>
-						{i === 5 && <SubmitSite class="md:col-span-2 lg:col-span-3" />}
+						{i === 5 && (
+							<li class="md:col-span-2 lg:col-span-3">
+								<SubmitSite />
+							</li>
+						)}
 					</>
 				))
 			}

--- a/src/pages/showcase/_components/SubmitSite.astro
+++ b/src/pages/showcase/_components/SubmitSite.astro
@@ -22,6 +22,7 @@ const { class: className, ...attrs } = Astro.props
 			class="h-16 w-auto"
 			loading="lazy"
 			decoding="async"
+			alt=""
 		/>
 		<h2 class="heading-4 lg:whitespace-nowrap">Submit your site</h2>
 	</div>


### PR DESCRIPTION
- Adds `alt=""` to mark Houston as decorative

- Wraps the submit component in `<li>` as it’s inside `<ul>`.

  Not sure if there‘s a better way given I think the intent was for this `<aside>` to be outside of the list flow. Maybe if the `<ul>` had `display: contents`, the `<aside>` could follow `<ul>` and the `<aside>` and all the `<li>`s follow the grid of a wrapper component? But I seem to remember `display: contents` messing up list item ARIA role maybe? So went with this simple solution — NWTWWHB!