### PR TITLE
Fix: accessible-astro-components URL change

### DIFF
--- a/src/content/integrations/accessible-astro-components.md
+++ b/src/content/integrations/accessible-astro-components.md
@@ -10,6 +10,6 @@ npmUrl: "https://www.npmjs.com/package/accessible-astro-components"
 image: "/assets/integrations/accessible-astro-components.png"
 repoUrl: "https://github.com/markteekman/accessible-astro-components"
 featured: 16
-homepageUrl: "https://components.accessible-astro.dev/"
+homepageUrl: "https://accessible-astro.dev/accessible-components/"
 downloads: 994
 ---


### PR DESCRIPTION
Was just randomly browsing the integrations and found that they changed the URL.