### PR TITLE
fix: lazy validate env variables in the theme submit route

### DIFF
--- a/src/pages/themes/submit/index.astro
+++ b/src/pages/themes/submit/index.astro
@@ -86,8 +86,10 @@ if (Astro.request.method === "POST") {
 	}
 
 	try {
-		const message = await executeDiscordWebhook(env.SUBMISSION_DISCORD_WEBHOOK_URL, {
-			threadId: env.SUBMISSION_DISCORD_WEBHOOK_THREAD_ID,
+		const { SUBMISSION_DISCORD_WEBHOOK_URL, SUBMISSION_DISCORD_WEBHOOK_THREAD_ID } = env()
+		
+		const message = await executeDiscordWebhook(SUBMISSION_DISCORD_WEBHOOK_URL, {
+			threadId: SUBMISSION_DISCORD_WEBHOOK_THREAD_ID,
 			content: `**New theme submission!**`,
 			files: [result.data.featuredImage, ...result.data.additionalImages],
 		})
@@ -123,8 +125,8 @@ if (Astro.request.method === "POST") {
 			theme.repoUrl = result.data.themeUrl
 		}
 
-		await editDiscordWebhookMessage(env.SUBMISSION_DISCORD_WEBHOOK_URL, message.id, {
-			threadId: env.SUBMISSION_DISCORD_WEBHOOK_THREAD_ID,
+		await editDiscordWebhookMessage(SUBMISSION_DISCORD_WEBHOOK_URL, message.id, {
+			threadId: SUBMISSION_DISCORD_WEBHOOK_THREAD_ID,
 			files: [
 				new File(
 					[

--- a/src/process-env.ts
+++ b/src/process-env.ts
@@ -5,13 +5,15 @@ const schema = z.object({
 	SUBMISSION_DISCORD_WEBHOOK_THREAD_ID: z.string(),
 })
 
-const result = schema.safeParse(import.meta.env)
-if (!result.success) {
-	throw new Error(
-		`Missing environment variables: ${result.error.issues
-			.map((issue) => issue.path.join("."))
-			.join(", ")}`,
-	)
-}
+export function env() {
+	const result = schema.safeParse(import.meta.env)
+	if (!result.success) {
+		throw new Error(
+			`Missing environment variables: ${result.error.issues
+				.map((issue) => issue.path.join("."))
+				.join(", ")}`,
+		)
+	}
 
-export const env = result.data
+	return result.data
+}


### PR DESCRIPTION
This moves the check for `DISCORD_` environment variables to a runtime check when the form is submitted

## Why?

Netlify PR preview builds from community members won't include private environment variables, breaking the build immediately