### PR TITLE
Adding back a few vanity redirects and fixing 404 canonical

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -3,7 +3,6 @@
 /play/*                 https://play.astro.build/play/:splat  200
 /company                /careers/ 301
 /partnerships           https://astroinc.notion.site/Partner-with-Astro-b05cfd5dcf4248dcbea4a2d81554efed
-/partnerships
 /fonts/*                https://fonts-cdn.astro.build/:splat 200
 
 # Common GitHub destinations

--- a/public/_redirects
+++ b/public/_redirects
@@ -3,6 +3,7 @@
 /play/*                 https://play.astro.build/play/:splat  200
 /company                /careers/ 301
 /partnerships           https://astroinc.notion.site/Partner-with-Astro-b05cfd5dcf4248dcbea4a2d81554efed
+/partnerships
 /fonts/*                https://fonts-cdn.astro.build/:splat 200
 
 # Common GitHub destinations
@@ -21,3 +22,6 @@
 # One-off shortcuts
 /v0.21                  /blog/astro-021-release/  301
 /hack                   https://astroinc.notion.site/FRIDAY-Astro-1-0-Hackathon-9fb3499b375e4b01b88b080fd918b184
+
+# Themes catalog shortcuts
+/resources/image-templates https://www.figma.com/community/file/1182357255394426899

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -11,7 +11,7 @@ export type Props = {
 	title?: string
 	description?: string
 	image?: { src: string; alt: string }
-	canonicalURL?: URL
+	canonicalURL?: URL | null
 	pageType?: "website" | "article"
 }
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -74,7 +74,7 @@ const groups: LinkGroup[] = [
 				text: "Careers",
 			},
 			{
-				href: "https://www.notion.so/Partner-with-Astro-b05cfd5dcf4248dcbea4a2d81554efed",
+				href: "/partnerships/",
 				text: "Partner with us!",
 			},
 		],

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -8,7 +8,7 @@ export type SEOMetadata = {
 	title: string
 	description: string
 	image: Image
-	canonicalURL?: URL | string
+	canonicalURL?: URL | string | null
 	locale?: string
 }
 export type OpenGraph = Partial<SEOMetadata> & {
@@ -58,14 +58,14 @@ const ensureTrailingSlash = (url: string | URL) => url.toString().replace(/\/$/,
 
 <!-- Page Metadata -->
 <meta name="generator" content={Astro.generator} />
-<link rel="canonical" href={ensureTrailingSlash(canonicalURL)} />
+{canonicalURL && <link rel="canonical" href={ensureTrailingSlash(canonicalURL)} />}
 <title>{title}</title>
 <meta name="description" content={description} />
 
 <!-- OpenGraph Tags -->
 <meta property="og:title" content={og.title} />
 <meta property="og:type" content={og.type} />
-<meta property="og:url" content={ensureTrailingSlash(og.canonicalURL)} />
+{og.canonicalURL && <meta property="og:url" content={ensureTrailingSlash(og.canonicalURL)} />}
 <meta property="og:locale" content={og.locale} />
 <meta property="og:description" content={og.description} />
 <meta property="og:site_name" content={og.name} />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,7 +5,7 @@ import FailHouston from "./_assets/fail-houston.webp"
 export const prerender = true
 ---
 
-<MainLayout title="Page not found">
+<MainLayout title="Page not found" canonicalURL={null}>
 	<section
 		class="grid-container relative overflow-hidden py-12 sm:py-16 md:py-20 lg:py-24 xl:py-28"
 	>

--- a/src/pages/themes/submit/_components/BestPractices.astro
+++ b/src/pages/themes/submit/_components/BestPractices.astro
@@ -12,7 +12,7 @@ import ExternalLinkIcon from "~/icons/ExternalLinkIcon.jsx"
 	</ul>
 	<p>Looking for inspiration for your theme's preview images? Check out our image templates:</p>
 	<a
-		href="https://www.figma.com/community/file/1182357255394426899"
+		href="/resources/image-templates/"
 		target="_blank"
 		class="button-primary button-small"
 	>


### PR DESCRIPTION
Pulling back over a couple vanity URLs that we weren't using but were supported in the previous site

This also updates the 404 page to make sure it never includes a canonical URL