### PR TITLE
Use `setup-chrome` action to ensure Chromium is available

### DIFF
--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -48,6 +48,9 @@ jobs:
       - name: Check out code using Git
         uses: actions/checkout@v3
 
+      - name: Setup Chromium
+        uses: browser-actions/setup-chrome@v1
+
       - name: Install Tools & Dependencies
         uses: ./.github/actions/install
 


### PR DESCRIPTION
Second attempt at addressing the Puppeteer in GH Actions issue. Might replace #631 if successful.