### PR TITLE
Update `peter-evans/create-pull-request` to v4

### DIFF
--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Create Pull Request
         id: createpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           branch: ci/docgen-integrations
           token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Create Pull Request
         id: createpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           branch: ci/docgen-showcase
           token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the [create-pull-request GH action](https://github.com/peter-evans/create-pull-request) to latest just in case that’s the source of our troubles. No major changes in v4 per [their changelog](https://github.com/peter-evans/create-pull-request/blob/main/docs/updating.md).