### PR TITLE
Run formatter as part of data generation workflow

### DIFF
--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -27,6 +27,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Format generated files
+        run: pnpm format
+
       - name: Create Pull Request
         id: createpr
         uses: peter-evans/create-pull-request@v4
@@ -56,6 +59,9 @@ jobs:
         run: pnpm run update:showcase
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Format generated files
+        run: pnpm format
 
       - name: Create Pull Request
         id: createpr


### PR DESCRIPTION
It’s hard to write Markdown frontmatter exactly as Prettier desires (`gray-matter` is unmaintained and uses an outdated version of `js-yaml` without support for `quotingType: '"'` for example), so this PR takes the easy route and just runs the formatter after showcase, theme, or integration generation is complete.