### PR TITLE
Use backticks to preserve CLI flag double-hyphen

### DIFF
--- a/src/content/blog/astro-210.mdx
+++ b/src/content/blog/astro-210.mdx
@@ -18,7 +18,7 @@ We just released Astro 2.1, featuring:
 
 - **[Built-in Image Support](#built-in-image-support)**: (experimental) Automatic image optimization is landing in Astro core.
 - **[Markdoc Integration](#markdoc-integration)**: (experimental) A new content format from Stripe, optimized for large projects.
-- **[astro check -​-watch](#astro-check-watch)**: Use this flag to type check your `.astro` files during development.
+- **[`astro check --watch`](#astro-check-watch)**: Use this flag to type check your `.astro` files during development.
 - **[Inferred types for dynamic routes](#inferred-types-for-dynamic-routes)**: Get the params and props without defining the types twice.
 
 Astro 2.1 is available on npm today. Run `npm i astro@latest` to upgrade an existing project or run `npm create astro` in the terminal to start something new.

--- a/src/content/blog/astro-210.mdx
+++ b/src/content/blog/astro-210.mdx
@@ -18,7 +18,7 @@ We just released Astro 2.1, featuring:
 
 - **[Built-in Image Support](#built-in-image-support)**: (experimental) Automatic image optimization is landing in Astro core.
 - **[Markdoc Integration](#markdoc-integration)**: (experimental) A new content format from Stripe, optimized for large projects.
-- **[astro check --watch](#astro-check-watch)**: Use this flag to type check your `.astro` files during development.
+- **[astro check -​-watch](#astro-check-watch)**: Use this flag to type check your `.astro` files during development.
 - **[Inferred types for dynamic routes](#inferred-types-for-dynamic-routes)**: Get the params and props without defining the types twice.
 
 Astro 2.1 is available on npm today. Run `npm i astro@latest` to upgrade an existing project or run `npm create astro` in the terminal to start something new.


### PR DESCRIPTION
The double dash `--watch` was getting converted to an em-dash. ~~Putting a zero-width space between them breaks that up and~~ Wrapping in backticks makes the switch appear ~~(at least visually)~~ as two dashes.

Before:

<img width="616" alt="CleanShot 2023-04-03 at 15 57 12@2x" src="https://user-images.githubusercontent.com/353790/229614812-73556913-bcf7-48fd-b54d-7083454f85cd.png">

After:

<img width="633" alt="CleanShot 2023-04-03 at 17 03 53@2x" src="https://user-images.githubusercontent.com/353790/229627164-4812eba3-642c-4f6a-8f7f-d648cc3038c3.png">

