### PR TITLE
Add camo.githubusercontent.com to showcase script block list

### DIFF
--- a/scripts/update-showcase.mjs
+++ b/scripts/update-showcase.mjs
@@ -379,7 +379,7 @@ const scraper = new ShowcaseScraper({
 	blockedOrigins: [
 		"https://github.com",
 		"https://user-images.githubusercontent.com",
-		"https://camo.githubusercontent.com"
+		"https://camo.githubusercontent.com",
 		"https://astro.build",
 	],
 })

--- a/scripts/update-showcase.mjs
+++ b/scripts/update-showcase.mjs
@@ -379,6 +379,7 @@ const scraper = new ShowcaseScraper({
 	blockedOrigins: [
 		"https://github.com",
 		"https://user-images.githubusercontent.com",
+		"https://camo.githubusercontent.com"
 		"https://astro.build",
 	],
 })


### PR DESCRIPTION
This PR adds an additional URL to the list of origins disallowed in the showcase update script.