### PR TITLE
Fix link typo in 2.5 blog post

### DIFF
--- a/src/content/blog/astro-250.mdx
+++ b/src/content/blog/astro-250.mdx
@@ -188,7 +188,7 @@ Now you can use `client:click` on any of your framework components with full typ
 <Counter client:click />
 ```
 
-See the [client directives documentation](https://docs.astro/build/en/reference/directives-reference/#custom-client-directives) to learn how to build these types of integrations.
+See the [client directives documentation](https://docs.astro.build/en/reference/directives-reference/#custom-client-directives) to learn how to build these types of integrations.
 
 ## HTML minification
 


### PR DESCRIPTION
Link typo to client directives docs