### PR TITLE
Fix update-showcase script

### DIFF
--- a/scripts/update-showcase.mjs
+++ b/scripts/update-showcase.mjs
@@ -143,7 +143,7 @@ class ShowcaseScraper {
      repository(owner: "${this.#org}", name: "${this.#repo}") {
        discussion(number: ${this.#discussion}) {
          bodyHTML
-         comments(first: ${first}, after: ${after || "null"}) {
+         comments(first: ${first}, after: ${after ? '"' + after + '"' : "null"}) {
            pageInfo {
              startCursor
              endCursor


### PR DESCRIPTION
Escape the `after` query parameter in the graphql query that fetches discussion comments in the showcase script. We just hit a case where the value contains `=` and that is causing errors. This wraps the value in quotes to avoid that.

Triggered a run from this branch here: https://github.com/withastro/astro.build/actions/runs/5112550826/jobs/9190722693

Seems to be working as expected.