### PR TITLE
Bumping blog font size to 18px on large screens

### DIFF
--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -1,6 +1,7 @@
 @layer components {
 	.prose {
-		@apply body mx-auto w-full max-w-prose leading-7 tracking-wide text-astro-gray-200 lg:text-lg;
+		@apply body mx-auto w-full max-w-prose tracking-wide text-astro-gray-200 lg:text-lg;
+		line-height: 1.75em;
 	}
 
 	.prose > p {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -1,6 +1,6 @@
 @layer components {
 	.prose {
-		@apply body mx-auto w-full max-w-prose leading-7 tracking-wide text-astro-gray-200;
+		@apply body mx-auto w-full max-w-prose leading-7 tracking-wide text-astro-gray-200 lg:text-lg;
 	}
 
 	.prose > p {


### PR DESCRIPTION
Increasing our prose font size from 16px to 18px on screens above 1024px wide