### PR TITLE
Fix misleading score transformation

### DIFF
--- a/src/pages/_components/CoreWebVitalsGraphItem.astro
+++ b/src/pages/_components/CoreWebVitalsGraphItem.astro
@@ -4,7 +4,6 @@ export interface Props {
 	score: number
 	glow?: boolean
 }
-const scoreWidth = (Astro.props.score - 33) * (100 / (100 - 33))
 ---
 
 <div
@@ -21,7 +20,7 @@ const scoreWidth = (Astro.props.score - 33) * (100 / (100 - 33))
 	>
 		<div
 			class="noise-underlay relative flex h-8 rounded bg-astro-gray-400 group-data-[glow]:bg-blue-green-gradient"
-			style={{ width: scoreWidth + "%" }}
+			style={{ width: Astro.props.score + "%" }}
 		>
 		</div>
 		<p class="flex-shrink-0 pr-2 font-mono text-xl group-data-[glow]:text-white">


### PR DESCRIPTION
The old version weights the scores such that the performance of non-Astro frameworks is understated. Change rebases this scale to 0 which does generate a bit of "dead space" but more accurately shows the relative difference between the scores.
