### PR TITLE
quick update to the Astro Shopify demo URL

### DIFF
--- a/src/content/themes/astro-shopify.md
+++ b/src/content/themes/astro-shopify.md
@@ -12,7 +12,7 @@ author:
 categories:
   - "ecommerce"
 repoUrl: "https://github.com/thomasKn/astro-shopify"
-demoUrl: "https://astro-shopify.gatto.dev"
+demoUrl: "https://astro-shopify.frontvibe.com/"
 stars: 100
 tools:
   - "tailwind"


### PR DESCRIPTION
Updating the demo URL, the author reached out on Discord with a new demo URL for the catalog page