### PR TITLE
Fix: Use the font-family name defined in @font-face declaration Inter Variable

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -21,7 +21,7 @@ module.exports = {
 				lg: "0px 25px 7px rgba(24, 24, 27, 0.01), 0px 16px 6px rgba(24, 24, 27, 0.04), 0px 9px 5px rgba(24, 24, 27, 0.15), 0px 4px 4px rgba(24, 24, 27, 0.26), 0px 1px 2px rgba(24, 24, 27, 0.29), 0px 0px 0px rgba(24, 24, 27, 0.3);",
 			},
 			fontFamily: {
-				sans: ["InterVariable", "sans-serif"],
+				sans: ["Inter Variable", "sans-serif"],
 				mono: [`"MDIO"`, "md-io-fallback", "monospace"],
 				obviously: ["Obviously", "obviously-regular-fallback", "sans-serif"],
 				"obviously-wide": [`"Obviously Wide", "obviously-wide-fallback", "sans-serif"`],


### PR DESCRIPTION
Inter Variable is currently not being utilized due to a space missing in the font-family name.

@font-face declarations: https://astro.build/_astro/404.2624b2aa.css

Fixes Inter Variable not being used, which is shipped, but currently not being utilized.

https://astro.build/_astro/inter-latin-wght-normal.450f3ba4.woff2

---


[Video Showing Before and After](https://github.com/withastro/astro.build/assets/20273871/ac1a3279-fb0a-467f-b25c-1fe6917e5167)


![CleanShot 2023-08-19 at 17 16 11@2x](https://github.com/withastro/astro.build/assets/20273871/6ba49ef8-b51c-48fd-a946-51b2107f1c97)
![CleanShot 2023-08-19 at 17 13 59@2x](https://github.com/withastro/astro.build/assets/20273871/7d31faec-57b8-4c08-bb36-98dfee88291d)



