### PR TITLE
Adding logic to use Vercel env variables for preview "site" config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,7 +10,8 @@ import tailwind from "@astrojs/tailwind"
 import vercel from "@astrojs/vercel/serverless"
 
 /* https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables */
-const VERCEL_PREVIEW_SITE = process.env.VERCEL_ENV !== "production" && process.env.VERCEL_URL
+const VERCEL_PREVIEW_SITE =
+	process.env.VERCEL_ENV !== "production" && `https://${process.env.VERCEL_URL}`
 
 console.log("[VERCEL_PREVIEW_SITE]", VERCEL_PREVIEW_SITE)
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,8 @@ import vercel from "@astrojs/vercel/serverless"
 /* https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables */
 const VERCEL_PREVIEW_SITE = process.env.VERCEL_ENV !== "production" && process.env.VERCEL_URL
 
+console.log("[VERCEL_PREVIEW_SITE]", VERCEL_PREVIEW_SITE)
+
 // https://astro.build/config
 export default defineConfig({
 	site: VERCEL_PREVIEW_SITE || "https://astro.build",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,7 +14,7 @@ const VERCEL_PREVIEW_SITE = process.env.VERCEL_ENV !== "production" && process.e
 
 // https://astro.build/config
 export default defineConfig({
-	site: "https://astro.build",
+	site: VERCEL_PREVIEW_SITE || "https://astro.build",
 	integrations: [
 		image({
 			serviceEntryPoint: "@astrojs/image/sharp",


### PR DESCRIPTION
Our open graph images need to use the preview URLs when building so that we can test the social share cards