### PR TITLE
chore: remove old Netlify deploy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Netlify Status](https://api.netlify.com/api/v1/badges/3442658e-265e-48ac-b3bc-e270853129c8/deploy-status)](https://app.netlify.com/sites/astro-build/deploys)
-
 # [astro.build](https://astro.build)
 
 The source code for [astro.build](https://astro.build), built with [Astro](https://github.com/withastro/astro).


### PR DESCRIPTION
## Changes

Remove the 'old' Netlify deploy badge in the `README.md`