### PR TITLE
Adding telemetry disclosure and documentation

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,146 +3,146 @@ import siteInfo from "~/data/site-info.js"
 import SocialLinks from "./SocialLinks.astro"
 
 type Link = {
-  href: string
-  text: string
+	href: string
+	text: string
 }
 
 type LinkGroup = {
-  title: string
-  items: Link[]
+	title: string
+	items: Link[]
 }
 
 const groups: LinkGroup[] = [
-  {
-    title: "Resources",
-    items: [
-      {
-        href: "https://docs.astro.build/en/getting-started/",
-        text: "Documentation",
-      },
-      {
-        href: "https://astro.new/",
-        text: "Starter templates",
-      },
-      {
-        href: "/themes/",
-        text: "Themes",
-      },
-      {
-        href: "/integrations/",
-        text: "Integrations",
-      },
-    ],
-  },
-  {
-    title: "Community",
-    items: [
-      {
-        href: "/showcase/",
-        text: "Showcase",
-      },
-      {
-        href: "https://github.com/withastro/astro/blob/main/CONTRIBUTING.md",
-        text: "Contributing",
-      },
-      {
-        href: "https://opencollective.com/astrodotbuild",
-        text: "Open Collective",
-      },
-      {
-        href: "/chat",
-        text: "Join our Discord",
-      },
-    ],
-  },
-  {
-    title: "About",
-    items: [
-      {
-        text: "Who we are",
-        href: "/about/",
-      },
-      {
-        text: "Press",
-        href: "/press/",
-      },
-      {
-        text: "Careers",
-        href: "/careers/",
-      },
-      {
-        text: "Telemetry",
-        href: "/telemetry/",
-      },
-      {
-        text: "Partner with us!",
-        href: "/partnerships/",
-      },
-    ],
-  },
-  {
-    title: "More links",
-    items: [
-      {
-        text: "Blog",
-        href: "/blog/",
-      },
-      {
-        text: "Swag Shop",
-        href: "https://shop.astro.build",
-      },
-      {
-        text: "Wallpapers",
-        href: "/wallpapers/",
-      },
-    ],
-  },
+	{
+		title: "Resources",
+		items: [
+			{
+				href: "https://docs.astro.build/en/getting-started/",
+				text: "Documentation",
+			},
+			{
+				href: "https://astro.new/",
+				text: "Starter templates",
+			},
+			{
+				href: "/themes/",
+				text: "Themes",
+			},
+			{
+				href: "/integrations/",
+				text: "Integrations",
+			},
+		],
+	},
+	{
+		title: "Community",
+		items: [
+			{
+				href: "/showcase/",
+				text: "Showcase",
+			},
+			{
+				href: "https://github.com/withastro/astro/blob/main/CONTRIBUTING.md",
+				text: "Contributing",
+			},
+			{
+				href: "https://opencollective.com/astrodotbuild",
+				text: "Open Collective",
+			},
+			{
+				href: "/chat",
+				text: "Join our Discord",
+			},
+		],
+	},
+	{
+		title: "About",
+		items: [
+			{
+				text: "Who we are",
+				href: "/about/",
+			},
+			{
+				text: "Press",
+				href: "/press/",
+			},
+			{
+				text: "Careers",
+				href: "/careers/",
+			},
+			{
+				text: "Telemetry",
+				href: "/telemetry/",
+			},
+			{
+				text: "Partner with us!",
+				href: "/partnerships/",
+			},
+		],
+	},
+	{
+		title: "More links",
+		items: [
+			{
+				text: "Blog",
+				href: "/blog/",
+			},
+			{
+				text: "Swag Shop",
+				href: "https://shop.astro.build",
+			},
+			{
+				text: "Wallpapers",
+				href: "/wallpapers/",
+			},
+		],
+	},
 ]
 
 const socialLinks = siteInfo.socialLinks
 ---
 
 <footer class="container">
-  <nav
-    aria-label="Secondary"
-    class="flex flex-col items-start justify-between gap-12 py-8 sm:flex-row-reverse md:py-12"
-  >
-    <SocialLinks links={socialLinks} />
-    <div class="grid grid-cols-2 gap-12 sm:flex sm:flex-wrap sm:gap-16 lg:gap-20">
-      {
-        groups.map(({ title, items }, index) => (
-          <section class="group flex flex-col">
-            <h2 id={`footerHeading${index}`} class="code mb-4 text-base leading-none opacity-50">
-              {title}
-            </h2>
-            <ul aria-labelledby={`footerHeading${index}`} class="flex flex-col gap-2">
-              {items.map(({ href, text }) => (
-                <li>
-                  <a href={href} class="link whitespace-nowrap">
-                    {text}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </section>
-        ))
-      }
-    </div>
-  </nav>
-  <hr class="border-astro-gray-500" />
-  <nav
-    aria-label="Legal"
-    class="grid grid-cols-[1fr,auto] items-center gap-x-4 gap-y-16 py-8 opacity-60 md:grid-cols-[auto,1fr,auto] md:py-12"
-  >
-    <a class="link" href="/privacy">Privacy Policy</a>
-    <a class="link mr-auto" href="/terms">Terms of Service</a>
-    <p class="col-span-2 text-center md:col-span-1">
-      <a href="https://github.com/withastro/astro/blob/main/LICENSE" target="_blank" class="link"
-        >MIT License</a
-      > &copy; {new Date().getFullYear()}
-      <a href="https://github.com/withastro/astro/graphs/contributors" class="link" target="_blank"
-        >Astro Contributors</a
-      >
-    </p>
-  </nav>
+	<nav
+		aria-label="Secondary"
+		class="flex flex-col items-start justify-between gap-12 py-8 sm:flex-row-reverse md:py-12"
+	>
+		<SocialLinks links={socialLinks} />
+		<div class="grid grid-cols-2 gap-12 sm:flex sm:flex-wrap sm:gap-16 lg:gap-20">
+			{
+				groups.map(({ title, items }, index) => (
+					<section class="group flex flex-col">
+						<h2 id={`footerHeading${index}`} class="code mb-4 text-base leading-none opacity-50">
+							{title}
+						</h2>
+						<ul aria-labelledby={`footerHeading${index}`} class="flex flex-col gap-2">
+							{items.map(({ href, text }) => (
+								<li>
+									<a href={href} class="link whitespace-nowrap">
+										{text}
+									</a>
+								</li>
+							))}
+						</ul>
+					</section>
+				))
+			}
+		</div>
+	</nav>
+	<hr class="border-astro-gray-500" />
+	<nav
+		aria-label="Legal"
+		class="grid grid-cols-[1fr,auto] items-center gap-x-4 gap-y-16 py-8 opacity-60 md:grid-cols-[auto,1fr,auto] md:py-12"
+	>
+		<a class="link" href="/privacy">Privacy Policy</a>
+		<a class="link mr-auto" href="/terms">Terms of Service</a>
+		<p class="col-span-2 text-center md:col-span-1">
+			<a href="https://github.com/withastro/astro/blob/main/LICENSE" target="_blank" class="link"
+				>MIT License</a
+			> &copy; {new Date().getFullYear()}
+			<a href="https://github.com/withastro/astro/graphs/contributors" class="link" target="_blank"
+				>Astro Contributors</a
+			>
+		</p>
+	</nav>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,142 +3,146 @@ import siteInfo from "~/data/site-info.js"
 import SocialLinks from "./SocialLinks.astro"
 
 type Link = {
-	href: string
-	text: string
+  href: string
+  text: string
 }
 
 type LinkGroup = {
-	title: string
-	items: Link[]
+  title: string
+  items: Link[]
 }
 
 const groups: LinkGroup[] = [
-	{
-		title: "Resources",
-		items: [
-			{
-				href: "https://docs.astro.build/en/getting-started/",
-				text: "Documentation",
-			},
-			{
-				href: "https://astro.new/",
-				text: "Starter templates",
-			},
-			{
-				href: "/themes/",
-				text: "Themes",
-			},
-			{
-				href: "/integrations/",
-				text: "Integrations",
-			},
-		],
-	},
-	{
-		title: "Community",
-		items: [
-			{
-				href: "/showcase/",
-				text: "Showcase",
-			},
-			{
-				href: "https://github.com/withastro/astro/blob/main/CONTRIBUTING.md",
-				text: "Contributing",
-			},
-			{
-				href: "https://opencollective.com/astrodotbuild",
-				text: "Open Collective",
-			},
-			{
-				href: "/chat",
-				text: "Join our Discord",
-			},
-		],
-	},
-	{
-		title: "About",
-		items: [
-			{
-				text: "Who we are",
-				href: "/about/",
-			},
-			{
-				text: "Press",
-				href: "/press/",
-			},
-			{
-				text: "Careers",
-				href: "/careers/",
-			},
-			{
-				text: "Partner with us!",
-				href: "/partnerships/",
-			},
-		],
-	},
-	{
-		title: "More links",
-		items: [
-			{
-				text: "Blog",
-				href: "/blog/",
-			},
-			{
-				text: "Swag Shop",
-				href: "https://shop.astro.build",
-			},
-			{
-				text: "Wallpapers",
-				href: "/wallpapers/",
-			},
-		],
-	},
+  {
+    title: "Resources",
+    items: [
+      {
+        href: "https://docs.astro.build/en/getting-started/",
+        text: "Documentation",
+      },
+      {
+        href: "https://astro.new/",
+        text: "Starter templates",
+      },
+      {
+        href: "/themes/",
+        text: "Themes",
+      },
+      {
+        href: "/integrations/",
+        text: "Integrations",
+      },
+    ],
+  },
+  {
+    title: "Community",
+    items: [
+      {
+        href: "/showcase/",
+        text: "Showcase",
+      },
+      {
+        href: "https://github.com/withastro/astro/blob/main/CONTRIBUTING.md",
+        text: "Contributing",
+      },
+      {
+        href: "https://opencollective.com/astrodotbuild",
+        text: "Open Collective",
+      },
+      {
+        href: "/chat",
+        text: "Join our Discord",
+      },
+    ],
+  },
+  {
+    title: "About",
+    items: [
+      {
+        text: "Who we are",
+        href: "/about/",
+      },
+      {
+        text: "Press",
+        href: "/press/",
+      },
+      {
+        text: "Careers",
+        href: "/careers/",
+      },
+      {
+        text: "Telemetry",
+        href: "/telemetry/",
+      },
+      {
+        text: "Partner with us!",
+        href: "/partnerships/",
+      },
+    ],
+  },
+  {
+    title: "More links",
+    items: [
+      {
+        text: "Blog",
+        href: "/blog/",
+      },
+      {
+        text: "Swag Shop",
+        href: "https://shop.astro.build",
+      },
+      {
+        text: "Wallpapers",
+        href: "/wallpapers/",
+      },
+    ],
+  },
 ]
 
 const socialLinks = siteInfo.socialLinks
 ---
 
 <footer class="container">
-	<nav
-		aria-label="Secondary"
-		class="flex flex-col items-start justify-between gap-12 py-8 sm:flex-row-reverse md:py-12"
-	>
-		<SocialLinks links={socialLinks} />
-		<div class="grid grid-cols-2 gap-12 sm:flex sm:flex-wrap sm:gap-16 lg:gap-20">
-			{
-				groups.map(({ title, items }, index) => (
-					<section class="group flex flex-col">
-						<h2 id={`footerHeading${index}`} class="code mb-4 text-base leading-none opacity-50">
-							{title}
-						</h2>
-						<ul aria-labelledby={`footerHeading${index}`} class="flex flex-col gap-2">
-							{items.map(({ href, text }) => (
-								<li>
-									<a href={href} class="link whitespace-nowrap">
-										{text}
-									</a>
-								</li>
-							))}
-						</ul>
-					</section>
-				))
-			}
-		</div>
-	</nav>
-	<hr class="border-astro-gray-500" />
-	<nav
-		aria-label="Legal"
-		class="grid grid-cols-[1fr,auto] items-center gap-x-4 gap-y-16 py-8 opacity-60 md:grid-cols-[auto,1fr,auto] md:py-12"
-	>
-		<a class="link" href="/privacy">Privacy Policy</a>
-		<a class="link mr-auto" href="/terms">Terms of Service</a>
-		<p class="col-span-2 text-center md:col-span-1">
-			<a href="https://github.com/withastro/astro/blob/main/LICENSE" target="_blank" class="link"
-				>MIT License</a
-			> &copy; {new Date().getFullYear()}
-			<a href="https://github.com/withastro/astro/graphs/contributors" class="link" target="_blank"
-				>Astro Contributors</a
-			>
-		</p>
-	</nav>
+  <nav
+    aria-label="Secondary"
+    class="flex flex-col items-start justify-between gap-12 py-8 sm:flex-row-reverse md:py-12"
+  >
+    <SocialLinks links={socialLinks} />
+    <div class="grid grid-cols-2 gap-12 sm:flex sm:flex-wrap sm:gap-16 lg:gap-20">
+      {
+        groups.map(({ title, items }, index) => (
+          <section class="group flex flex-col">
+            <h2 id={`footerHeading${index}`} class="code mb-4 text-base leading-none opacity-50">
+              {title}
+            </h2>
+            <ul aria-labelledby={`footerHeading${index}`} class="flex flex-col gap-2">
+              {items.map(({ href, text }) => (
+                <li>
+                  <a href={href} class="link whitespace-nowrap">
+                    {text}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))
+      }
+    </div>
+  </nav>
+  <hr class="border-astro-gray-500" />
+  <nav
+    aria-label="Legal"
+    class="grid grid-cols-[1fr,auto] items-center gap-x-4 gap-y-16 py-8 opacity-60 md:grid-cols-[auto,1fr,auto] md:py-12"
+  >
+    <a class="link" href="/privacy">Privacy Policy</a>
+    <a class="link mr-auto" href="/terms">Terms of Service</a>
+    <p class="col-span-2 text-center md:col-span-1">
+      <a href="https://github.com/withastro/astro/blob/main/LICENSE" target="_blank" class="link"
+        >MIT License</a
+      > &copy; {new Date().getFullYear()}
+      <a href="https://github.com/withastro/astro/graphs/contributors" class="link" target="_blank"
+        >Astro Contributors</a
+      >
+    </p>
+  </nav>
 </footer>

--- a/src/content/pages/telemetry.md
+++ b/src/content/pages/telemetry.md
@@ -18,10 +18,10 @@ We track general usage information about Astro and different configuration optio
 - Command invoked (`astro build`, `astro dev`, `astro preview`, etc.)
 - Astro version
 - General machine information (e.g. number of CPUs, macOS/Windows/Linux, CI environment, etc.)
-- Integrations, adapters, markdown options, and other select configuration
-- Errors during the build process
+- General configuration information (Integrations, adapters, markdown options, etc.)
+- Sanitized error information
 
-This list is regularly audited to ensure its accuracy. You can audit telemetry yourself locally by settings the `DEBUG=”astro:telemetry”` environment variable when running the Astro CLI.
+This list is regularly audited to ensure its accuracy. You can audit telemetry yourself locally by settings the `DEBUG=”astro:telemetry”` environment variable when running the Astro CLI. While in debug mode, telemetry events ares only logged to the console.
 
 An example telemetry event might look like this:
 
@@ -41,7 +41,7 @@ An example telemetry event might look like this:
 
 ## What about sensitive data?
 
-We **do not** collect any metrics which may contain sensitive data. This includes, but is not limited to: environment variables, personally identifiable information, file paths, contents of files, logs, stack traces, git remote information, or un-serialized JavaScript error messages.
+We **do not** collect any metrics which may contain sensitive data. This includes, but is not limited to: environment variables, personally identifiable information, file paths, contents of files, logs, stack traces, git remote information, or unsanitized JavaScript error messages.
 
 We take your privacy very seriously. You can read our [privacy policy](https://astro.build/privacy/) to learn more.
 
@@ -49,11 +49,11 @@ We take your privacy very seriously. You can read our [privacy policy](https://a
 
 The data collected by the Astro CLI is completely anonymous and only meaningful in aggregate form. The data that we store is not traceable to the source, and is only available to a small subset of the Astro core maintainer team to help inform our roadmap prioritization.
 
-None of the data that we collect is personally identifiable. It has never and will never be sold or monetized in any form.
+The Astro CLI does not track, collect, or store personally identifiable information (PII). The telemetry data that we do track has never and will never be sold or monetized in any form.
 
 ## How do I opt out?
 
-You can also opt-out by running `astro telemetry disable` in the root of any Astro project directory:
+You can always opt-out by running `astro telemetry disable` in the root of any Astro project directory:
 
 ```bash
 npx astro telemetry disable

--- a/src/content/pages/telemetry.md
+++ b/src/content/pages/telemetry.md
@@ -1,0 +1,68 @@
+---
+seo:
+    title: Telemetry
+    description: Astro collects anonymous telemetry data about general usage to help inform our roadmap. Participation is optional and you may opt-out at any time.
+updated_date: 2023-03-01
+---
+
+The `astro` CLI collects **anonymous telemetry data** about general usage. Participation is optional, and you may opt-out at any time.
+
+## Why is telemetry collected?
+
+Anonymous telemetry data makes up an important piece of our roadmap prioritization process. It gives our core team insight into broad trends in feature usage, pain points, and configuration which then helps us make more informed decisions about what to work on next.
+
+## What is being collected?
+
+We track general usage information about Astro and different configuration options that we support. Specifically, we track the following anonymous data:
+
+- Command invoked (`astro build`, `astro dev`, `astro preview`, etc.)
+- Astro version
+- General machine information (e.g. number of CPUs, macOS/Windows/Linux, CI environment, etc.)
+- Integrations, adapters, markdown options, and other select configuration
+- Errors during the build process
+
+This list is regularly audited to ensure its accuracy. You can audit telemetry yourself locally by settings the `DEBUG=”astro:telemetry”` environment variable when running the Astro CLI.
+
+An example telemetry event might look like this:
+
+```json
+{
+  "cliCommand": "dev",
+  "config": {
+    "markdownPlugins": [],
+    "adapter": "@astrojs/vercel",
+    "integrations": ["@astrojs/mdx", "@astrojs/rss"],
+    "markdown": {
+      "syntaxHighlight": "shiki"
+    }
+  }
+}
+```
+
+## What about sensitive data?
+
+We **do not** collect any metrics which may contain sensitive data. This includes, but is not limited to: environment variables, personally identifiable information, file paths, contents of files, logs, stack traces, git remote information, or un-serialized JavaScript error messages.
+
+We take your privacy very seriously. You can read our [privacy policy](https://astro.build/privacy/) to learn more.
+
+## How is my data protected?
+
+The data collected by the Astro CLI is completely anonymous and only meaningful in aggregate form. The data that we store is not traceable to the source, and is only available to a small subset of the Astro core maintainer team to help inform our roadmap prioritization.
+
+None of the data that we collect is personally identifiable. It has never and will never be sold or monetized in any form.
+
+## How do I opt out?
+
+You can also opt-out by running `astro telemetry disable` in the root of any Astro project directory:
+
+```bash
+npx astro telemetry disable
+```
+
+You can re-enable telemetry at any time by running `astro telemetry enable` in the root of any Astro project directory:
+
+```bash
+npx astro telemetry enable
+```
+
+You can also opt-out by setting the environment variable: `ASTRO_TELEMETRY_DISABLED=1`. If this environment variable is set when Astro runs, it will disable all telemetry.

--- a/src/content/pages/telemetry.md
+++ b/src/content/pages/telemetry.md
@@ -53,13 +53,13 @@ The Astro CLI does not track, collect, or store personally identifiable informat
 
 ## How do I opt out?
 
-You can always opt-out by running `astro telemetry disable` in the root of any Astro project directory:
+You can always opt-out by running `astro telemetry disable` in the root of any Astro project directory. This will disable telemetry across your entire machine, not just the project directory that you run it in:
 
 ```bash
 npx astro telemetry disable
 ```
 
-You can re-enable telemetry at any time by running `astro telemetry enable` in the root of any Astro project directory:
+You can re-enable telemetry at any time by running `astro telemetry enable` in the root of any Astro project directory. This will enable telemetry across your entire machine, not just the project that you run it in:
 
 ```bash
 npx astro telemetry enable

--- a/src/content/pages/telemetry.md
+++ b/src/content/pages/telemetry.md
@@ -1,7 +1,7 @@
 ---
 seo:
-    title: Telemetry
-    description: Astro collects anonymous telemetry data about general usage to help inform our roadmap. Participation is optional and you may opt-out at any time.
+  title: Telemetry
+  description: Astro collects anonymous telemetry data about general usage to help inform our roadmap. Participation is optional and you may opt-out at any time.
 updated_date: 2023-03-01
 ---
 


### PR DESCRIPTION
This adds a page detailing what telemetry data is collected, why it's collected, how it may be used, and how to opt-out.

### `tl;dr;`

Astro's CLI collects anonymous telemetry data that is used internally to help uncover issues and prioritize features that will have the most impact on Astro users.  None of the data that we collect is personally identifiable. It has never and will never be sold or monetized in any form.