### PR TITLE
redirects should handle trailing slashes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,9 @@ import vercel from "@astrojs/vercel/serverless"
 
 /* https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables */
 const VERCEL_PREVIEW_SITE =
-	process.env.VERCEL_ENV !== "production" && `https://${process.env.VERCEL_URL}`
+	process.env.VERCEL_ENV !== "production" &&
+	process.env.VERCEL_URL &&
+	`https://${process.env.VERCEL_URL}`
 
 console.log("[VERCEL_PREVIEW_SITE]", VERCEL_PREVIEW_SITE)
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "trailingSlash": true,
   "headers": [
     {
       "source": "/assets/(.*)",
@@ -31,31 +32,31 @@
       "destination": "/"
     },
     {
-      "source": "/chat",
+      "source": "/chat/",
       "destination": "https://discord.gg/grF4GTXXYm"
     },
     {
-      "source": "/company",
+      "source": "/company/",
       "destination": "/careers/"
     },
     {
-      "source": "/partnerships",
+      "source": "/partnerships/",
       "destination": "https://astroinc.notion.site/Partner-with-Astro-b05cfd5dcf4248dcbea4a2d81554efed"
     },
     {
-      "source": "/showcase/submit",
+      "source": "/showcase/submi/",
       "destination": "https://github.com/withastro/roadmap/discussions/521"
     },
     {
-      "source": "/issues/site",
+      "source": "/issues/site/",
       "destination": "https://github.com/withastro/astro.build/issues/new/choose"
     },
     {
-      "source": "/issues",
+      "source": "/issues/",
       "destination": "https://github.com/withastro/astro/issues/new/choose"
     },
     {
-      "source": "/issues/compiler",
+      "source": "/issues/compiler/",
       "destination": "https://github.com/withastro/compiler/issues/new/choose"
     },
     {
@@ -63,31 +64,31 @@
       "destination": "https://github.com/withastro/astro/releases/tag/astro@:v*"
     },
     {
-      "source": "/code-of-conduct",
+      "source": "/code-of-conduct/",
       "destination": "https://github.com/withastro/.github/blob/main/CODE_OF_CONDUCT.md#readme"
     },
     {
-      "source": "/governance",
+      "source": "/governance/",
       "destination": "https://github.com/withastro/.github/blob/main/GOVERNANCE.md#readme"
     },
     {
-      "source": "/config",
+      "source": "/config/",
       "destination": "https://docs.astro.build/reference/configuration-reference"
     },
     {
-      "source": "/deprecated/resolve",
+      "source": "/deprecated/resolve/",
       "destination": "https://docs.astro.build/en/migrate/#deprecated-astroresolve"
     },
     {
-      "source": "/v0.21",
+      "source": "/v0.21/",
       "destination": "/blog/astro-021-release/"
     },
     {
-      "source": "/hack",
+      "source": "/hack/",
       "destination": "https://astroinc.notion.site/FRIDAY-Astro-1-0-Hackathon-9fb3499b375e4b01b88b080fd918b184"
     },
     {
-      "source": "/resources/image-templates",
+      "source": "/resources/image-templates/",
       "destination": "https://www.figma.com/community/file/1182357255394426899"
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -28,7 +28,7 @@
   ],
   "redirects": [
     {
-      "source": "/play/:splat*",
+      "source": "/play/:path*(/)?",
       "destination": "/"
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -44,7 +44,7 @@
       "destination": "https://astroinc.notion.site/Partner-with-Astro-b05cfd5dcf4248dcbea4a2d81554efed"
     },
     {
-      "source": "/showcase/submi/",
+      "source": "/showcase/submit/",
       "destination": "https://github.com/withastro/roadmap/discussions/521"
     },
     {


### PR DESCRIPTION
This adds the `trialingSlash` config in `vercel.json` and updates our redirects to expect a trailing slash

ex: this should handle redirecting both `astro.build/chat` and `astro.build/chat/`

Redirects tested to confirm:
https://astro-build-git-redirects-trailing-slash-astrodotbuild.vercel.app/chat
https://astro-build-git-redirects-trailing-slash-astrodotbuild.vercel.app/chat/
https://astro-build-git-redirects-trailing-slash-astrodotbuild.vercel.app/releases/3.0.0-rc.9
https://astro-build-git-redirects-trailing-slash-astrodotbuild.vercel.app/releases/3.0.0-rc.9/