### PR TITLE
Update weekly CI to run new formatter command

### DIFF
--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Format generated files
-        run: pnpm format
+        run: pnpm lint:prettier
 
       - name: Create Pull Request
         id: createpr
@@ -61,7 +61,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Format generated files
-        run: pnpm format
+        run: pnpm lint:prettier
 
       - name: Create Pull Request
         id: createpr


### PR DESCRIPTION
Our weekly CI depended on the `format` package script which we removed in #804.

This PR updates the workflow to use `lint:prettier` instead, which should be the only formatter relevant given these tasks generate `.md` and `.webp` files exclusively.