### PR TITLE
Fix canonical trailing slash with query params

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -22,7 +22,7 @@ const {
 	image = siteInfo.image,
 	canonicalURL = new URL(Astro.request.url, Astro.site),
 	pageType = "website",
-} = Astro.props 
+} = Astro.props
 
 const title = [Astro.props.title, siteInfo.name].filter(Boolean).join(" | ")
 const resolvedImage = {

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -53,25 +53,29 @@ const twitter = {
 	...Astro.props.twitter,
 } satisfies Twitter
 
-function ensureTrailingSlashWithQueryParams(url: string | URL) {
-	const [path, queryParams] = url.toString().split("?")
-	return `${path.replace(/\/?$/, "/")}${queryParams ? `?${queryParams}` : ""}`
+/**
+ * Enforce some standard canonical URL formatting across the site.
+ */
+function formatCanonicalURL(url: string | URL) {
+	const path = url.toString();
+	const hasQueryParams = path.includes('?');
+	// If there are query params, make sure the URL has no trailing slash
+	if (hasQueryParams) {
+		path.replace(/\/?$/, "");
+	}
+	// otherwise, canonical URL always has a trailing slash
+	return path.replace(/\/?$/, hasQueryParams ? "" : '/');
 }
 ---
 
-<!-- Page Metadata -->{
-	canonicalURL && <link rel="canonical" href={ensureTrailingSlashWithQueryParams(canonicalURL)} />
-}
+<!-- Page Metadata -->
+{canonicalURL && <link rel="canonical" href={formatCanonicalURL(canonicalURL)} />}
 <meta name="description" content={description} />
 
 <!-- OpenGraph Tags -->
 <meta property="og:title" content={og.title} />
 <meta property="og:type" content={og.type} />
-{
-	og.canonicalURL && (
-		<meta property="og:url" content={ensureTrailingSlashWithQueryParams(og.canonicalURL)} />
-	)
-}
+{og.canonicalURL && <meta property="og:url" content={formatCanonicalURL(og.canonicalURL)} />}
 <meta property="og:locale" content={og.locale} />
 <meta property="og:description" content={og.description} />
 <meta property="og:site_name" content={og.name} />

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -29,7 +29,7 @@ const {
 	image,
 	locale = "en",
 	canonicalURL = new URL(Astro.url.pathname, Astro.site),
-} = Astro.props 
+} = Astro.props
 
 const og = {
 	name,
@@ -53,18 +53,25 @@ const twitter = {
 	...Astro.props.twitter,
 } satisfies Twitter
 
-const ensureTrailingSlash = (url: string | URL) => url.toString().replace(/\/$/, "") + "/"
+function ensureTrailingSlashWithQueryParams(url: string | URL) {
+	const [path, queryParams] = url.toString().split("?")
+	return `${path.replace(/\/?$/, "/")}${queryParams ? `?${queryParams}` : ""}`
+}
 ---
 
 <!-- Page Metadata -->{
-	canonicalURL && <link rel="canonical" href={ensureTrailingSlash(canonicalURL)} />
+	canonicalURL && <link rel="canonical" href={ensureTrailingSlashWithQueryParams(canonicalURL)} />
 }
 <meta name="description" content={description} />
 
 <!-- OpenGraph Tags -->
 <meta property="og:title" content={og.title} />
 <meta property="og:type" content={og.type} />
-{og.canonicalURL && <meta property="og:url" content={ensureTrailingSlash(og.canonicalURL)} />}
+{
+	og.canonicalURL && (
+		<meta property="og:url" content={ensureTrailingSlashWithQueryParams(og.canonicalURL)} />
+	)
+}
 <meta property="og:locale" content={og.locale} />
 <meta property="og:description" content={og.description} />
 <meta property="og:site_name" content={og.name} />


### PR DESCRIPTION
Fix an issue with the trailing slash being added after query params.

Previous:
```
https://astro.build/themes/2/?categories%5B%5D=portfolio/
```

Now:
```
https://astro.build/themes/2/?categories%5B%5D=portfolio
```
