### PR TITLE
Adding back the /examples redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -52,6 +52,11 @@
       "destination": "https://github.com/withastro/roadmap/discussions/521"
     },
     {
+      "source": "/examples/",
+      "destination": "https://github.com/withastro/astro/tree/main/examples",
+      "permanent": true
+    },
+    {
       "source": "/issues/site/",
       "destination": "https://github.com/withastro/astro.build/issues/new/choose"
     },


### PR DESCRIPTION
Looks like this was lost during the Vercel migration