### PR TITLE
Fix ahref issues - page has links to redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The source code for [astro.build](https://astro.build), built with [Astro](https
 
 ## Updating Themes
 
-The [themes catalog](https://astro.build/themes) is based on the [themes content collection](/src/content/themes/). Optimized images should be saved to the collection's [\_images directory](/src/content/themes/_images/), ideally as format with a `{image}.webp` file at 800px wide and `{image}@2x.webp` at 1600px wide.
+The [themes catalog](https://astro.build/themes/) is based on the [themes content collection](/src/content/themes/). Optimized images should be saved to the collection's [\_images directory](/src/content/themes/_images/), ideally as format with a `{image}.webp` file at 800px wide and `{image}@2x.webp` at 1600px wide.
 
 Theme data is updated weekly by a [GitHub Action](/.github/workflows/weekly.yaml). This action mainly updates the star count in public GitHub repos (used for sorting), but may be updated in the future to update additional theme details.
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -50,7 +50,7 @@ const groups: LinkGroup[] = [
 				text: "Open Collective",
 			},
 			{
-				href: "/chat",
+				href: "/chat/",
 				text: "Join our Discord",
 			},
 		],
@@ -130,8 +130,8 @@ const socialLinks = siteInfo.socialLinks
 		aria-label="Legal"
 		class="grid grid-cols-[1fr,auto] items-center gap-x-4 gap-y-16 py-8 opacity-60 md:grid-cols-[auto,1fr,auto] md:py-12"
 	>
-		<a class="link" href="/privacy">Privacy Policy</a>
-		<a class="link mr-auto" href="/terms">Terms of Service</a>
+		<a class="link" href="/privacy/">Privacy Policy</a>
+		<a class="link mr-auto" href="/terms/">Terms of Service</a>
 		<p class="col-span-2 text-center md:col-span-1">
 			<a href="https://github.com/withastro/astro/blob/main/LICENSE" target="_blank" class="link"
 				>MIT License</a

--- a/src/components/ResourcesMenu.astro
+++ b/src/components/ResourcesMenu.astro
@@ -19,11 +19,11 @@ import PaletteIcon from "~/icons/PaletteIcon.jsx"
 
 			// positioning
 
-			"absolute top-full left-0 translate-y-2",
+			"absolute left-0 top-full translate-y-2",
 
 			// panel styling
 
-			"rounded bg-astro-gray-100 p-1 text-astro-gray-700 min-w-[150px] shadow-md",
+			"min-w-[150px] rounded bg-astro-gray-100 p-1 text-astro-gray-700 shadow-md",
 
 			// transitioning
 
@@ -35,7 +35,7 @@ import PaletteIcon from "~/icons/PaletteIcon.jsx"
 	>
 		<li>
 			<a
-				href="/themes"
+				href="/themes/"
 				rel="prefetch"
 				class="flex items-center gap-2 rounded p-3 leading-none transition hover:bg-black/10"
 			>
@@ -44,7 +44,7 @@ import PaletteIcon from "~/icons/PaletteIcon.jsx"
 		</li>
 		<li>
 			<a
-				href="/integrations"
+				href="/integrations/"
 				rel="prefetch"
 				class="flex items-center gap-2 rounded p-3 leading-none transition hover:bg-black/10"
 			>

--- a/src/content/blog/astro-018.mdx
+++ b/src/content/blog/astro-018.mdx
@@ -77,7 +77,7 @@ We've been absolutely blown away by the love Astro has received in such a short 
 
 - Featured articles and guides from [Netlify](https://www.netlify.com/blog/2021/07/23/build-a-modern-shopping-site-with-astro-and-serverless-functions/), [Cloudflare](https://developers.cloudflare.com/pages/framework-guides/astro), [CSS Tricks](https://css-tricks.com/a-look-at-building-with-astro/), and more.
 - Over 2,000 developers have downloaded the [Astro VSCode extension](https://marketplace.visualstudio.com/items?itemName=astro-build.astro-vscode)
-- Over 500 weekly visitors to our [amazing Discord](https://astro.build/chat)
+- Over 500 weekly visitors to our [amazing Discord](https://astro.build/chat/)
 - Over 300 public projects using Astro [on Github](https://github.com/withastro/astro)
 - 2 (TWO!) Astro jobs already posted on Discord!
 - [GitHub adds support for Astro component syntax highlighting](https://twitter.com/n_moore/status/1417881860051509250)

--- a/src/content/blog/astro-019.mdx
+++ b/src/content/blog/astro-019.mdx
@@ -177,4 +177,4 @@ This is such a huge milestone for Astro, especially considering how young the pr
 
 Thank you for reading! [Follow us on Twitter](https://twitter.com/astrodotbuild) to stay up to date as we move closer to a v1.0 release. Also, you can check out [our previous release post](https://astro.build/blog/astro-018) for even more updates on Astro.
 
-And, if you've read this far, you should definitely [join us on Discord.](https://astro.build/chat) ;)
+And, if you've read this far, you should definitely [join us on Discord.](https://astro.build/chat/) ;)

--- a/src/content/blog/astro-021-preview.mdx
+++ b/src/content/blog/astro-021-preview.mdx
@@ -92,7 +92,7 @@ Now, Astro's dev server sends HTML updates to the browser and then runs a small 
 
 If you've read this far, we'd love your help trying out the latest release before launch. You can try out our latest release today [in the browser](https://gitpod.io#snapshot/5e7cf2f1-8108-4fa5-99d3-ed8de70d8c23) or by running `npm install astro@next--compiler` in a new project directory. You can follow our progress and leave feedback in the `next` PR on GitHub: https://github.com/withastro/astro/pull/1406
 
-Leave feedback, report bugs, and get involved with Astro's development in our [Discord server](https://astro.build/chat). You can also [follow along](https://twitter.com/astrodotbuild) on Twitter.
+Leave feedback, report bugs, and get involved with Astro's development in our [Discord server](https://astro.build/chat/). You can also [follow along](https://twitter.com/astrodotbuild) on Twitter.
 
 <Note type="tip">
 

--- a/src/content/blog/astro-021-release.mdx
+++ b/src/content/blog/astro-021-release.mdx
@@ -36,7 +36,7 @@ Astro v0.21.0 is finally here! This is by far our biggest release ever, includin
 
 Very little has changed in the v0.21.0 API to make your migration as easy as possible.
 
-Leave feedback, report bugs, and get involved with Astro's development in our [Discord server](https://astro.build/chat). You can also [follow along](https://twitter.com/astrodotbuild) with our community on Twitter.
+Leave feedback, report bugs, and get involved with Astro's development in our [Discord server](https://astro.build/chat/). You can also [follow along](https://twitter.com/astrodotbuild) with our community on Twitter.
 
 ## Why Rewrite? Why Now?
 

--- a/src/content/blog/astro-023.mdx
+++ b/src/content/blog/astro-023.mdx
@@ -117,4 +117,4 @@ If you haven't tried the `--experimental-static-build` flag out yet in your buil
 
 Thank you for reading! [Follow us on Twitter](https://twitter.com/astrodotbuild) to stay up to date on Astro releases and news.
 
-If you've read this far, you should definitely [join us on Discord.](https://astro.build/chat) ;)
+If you've read this far, you should definitely [join us on Discord.](https://astro.build/chat/) ;)

--- a/src/content/blog/astro-025.mdx
+++ b/src/content/blog/astro-025.mdx
@@ -76,4 +76,4 @@ Check our new [syntax highlighting docs](https://docs.astro.build/en/guides/mark
 
 ---
 
-Thank you to every contributor and early preview tester who made this release possible. [Follow Astro on Twitter](https://twitter.com/astrodotbuild) for more updates and [join us on Discord](https://astro.build/chat) to get involved with everything Astro.
+Thank you to every contributor and early preview tester who made this release possible. [Follow Astro on Twitter](https://twitter.com/astrodotbuild) for more updates and [join us on Discord](https://astro.build/chat/) to get involved with everything Astro.

--- a/src/content/blog/astro-1-beta-release.mdx
+++ b/src/content/blog/astro-1-beta-release.mdx
@@ -106,4 +106,4 @@ This week is **Launch Week** at Astro HQ, so we have a few more exciting announc
 
 Beyond that, you can check [our public roadmap](https://github.com/withastro/rfcs/discussions/161) for updates as we work towards the official release of Astro v1.0.0 on **June 8, 2022**! 🎉
 
-If you’re interested in getting involved or sharing any feedback, we invite you to [visit our GitHub](https://github.com/withastro/astro) repository and [join our Discord server](https://astro.build/chat).
+If you’re interested in getting involved or sharing any feedback, we invite you to [visit our GitHub](https://github.com/withastro/astro) repository and [join our Discord server](https://astro.build/chat/).

--- a/src/content/blog/astro-1-release-update.mdx
+++ b/src/content/blog/astro-1-release-update.mdx
@@ -21,4 +21,4 @@ In order to deliver on the best-in-class developer experience that we promised, 
 
 In the meantime, please continue to use the [Astro v1.0.0 Beta Release](https://docs.astro.build/en/getting-started/), which benefits from all of these improvements with regular weekly releases.
 
-Thank you for your patience as we continue to develop the best website build tool on the planet! If you want to get involved or share feedback with the team, please [visit our GitHub](https://github.com/withastro/astro) repository and [join us on Discord](https://astro.build/chat).
+Thank you for your patience as we continue to develop the best website build tool on the planet! If you want to get involved or share feedback with the team, please [visit our GitHub](https://github.com/withastro/astro) repository and [join us on Discord](https://astro.build/chat/).

--- a/src/content/blog/astro-260.mdx
+++ b/src/content/blog/astro-260.mdx
@@ -190,7 +190,7 @@ Traditionally, redirects have been left for developers to figure out for themsel
 
 Astro's new `redirects` feature solves this with a single API for managing your redirects directly in your Astro config. This works across development and production and can be optimized even further to a specific host using our existing `adapter` API. For example, the Netlify adapter will automatically convert your redirects into a Netlify-specific `_redirects` file for the fastest-possible performance via their CDN.
 
-Our goal is to have a reliable way to configure redirects that works across [all of our supported hosts and adapters](https://docs.astro.build/en/guides/integrations-guide/#official-integrations). We are looking for feedback during this experimental period, so please try it and share your experience with us on [Discord](https://astro.build/chat).
+Our goal is to have a reliable way to configure redirects that works across [all of our supported hosts and adapters](https://docs.astro.build/en/guides/integrations-guide/#official-integrations). We are looking for feedback during this experimental period, so please try it and share your experience with us on [Discord](https://astro.build/chat/).
 
 ## Markdoc Improvements
 

--- a/src/content/blog/astro-repl.mdx
+++ b/src/content/blog/astro-repl.mdx
@@ -28,6 +28,6 @@ The Astro team proudly presents the new [Astro REPL:](https://astro.build/play) 
 
 <Note>
 
-To learn more about our new compiler, [join us on Discord](https://astro.build/chat) and tune in to [Astro Demo Days](https://www.youtube.com/watch?v=-ExcBJrXOd8) next Monday, September 20, 2021 at 11am PST.
+To learn more about our new compiler, [join us on Discord](https://astro.build/chat/) and tune in to [Astro Demo Days](https://www.youtube.com/watch?v=-ExcBJrXOd8) next Monday, September 20, 2021 at 11am PST.
 
 </Note>

--- a/src/content/blog/astro-tutorial.mdx
+++ b/src/content/blog/astro-tutorial.mdx
@@ -48,6 +48,6 @@ We also had some helpful early feedback from community members. Thanks to all of
 
 ## Docs Week is over, but “Docs are never done”
 
-Are you interested in getting involved with Astro’s Docs? Check out our [Contributor’s Guide](https://github.com/withastro/docs/blob/main/CONTRIBUTING.md) for [the docs repo on GitHub](https://github.com/withastro/docs) or find us in [the `#docs` channel on Discord](https://astro.build/chat). Join our team of writers, editors, translators, designers, coders, testers, builders, thinkers and dreamers. It takes a community to produce documentation, and we can’t wait for you to join us!
+Are you interested in getting involved with Astro’s Docs? Check out our [Contributor’s Guide](https://github.com/withastro/docs/blob/main/CONTRIBUTING.md) for [the docs repo on GitHub](https://github.com/withastro/docs) or find us in [the `#docs` channel on Discord](https://astro.build/chat/). Join our team of writers, editors, translators, designers, coders, testers, builders, thinkers and dreamers. It takes a community to produce documentation, and we can’t wait for you to join us!
 
 <BlogContentImage src={community} alt="Avatars for the many, many contributors to Astro docs" />

--- a/src/content/blog/community-awards-22.mdx
+++ b/src/content/blog/community-awards-22.mdx
@@ -40,6 +40,6 @@ This time around, our monthly sponsorships totalled almost **$8500** which we 
 
 Thanks to these awesome Astronauts, we have first-class documentation support in six languages! A wonderful range of amazing Astro integrations, a fantastic support channel, there is so much more than I can list here! But most importantly, these recipients have have helped nurture a friendly community that everyone feels welcome in.
 
-If you have contributed to Astro in any way over the past year, thank you! You can **[join us on Discord](https://astro.build/chat)** to learn more about these awards and the standout work done by this latest batch of recipients.
+If you have contributed to Astro in any way over the past year, thank you! You can **[join us on Discord](https://astro.build/chat/)** to learn more about these awards and the standout work done by this latest batch of recipients.
 
 Lastly, a huge thank you to our amazing sponsors — including **[Netlify](https://www.netlify.com/)**, **[Storyblok](https://storyblok.com/)**, **[Vercel](https://vercel.com/)**, **[Ship Shape](https://shipshape.io/)**, and **[Google](https://google.com/)** — for supporting open source software and helping to make programs like this posssible.

--- a/src/content/blog/community-day.mdx
+++ b/src/content/blog/community-day.mdx
@@ -19,7 +19,7 @@ I’m excited to share a couple of new announcements, as well as updates on our 
 
 **We do a lot of work on [GitHub](https://github.com/withastro/astro).** In the Astro monorepo alone, we have welcomed over 240 unique contributors across 2,600+ commits. The project is covered by a well-defined [open governance model](https://github.com/withastro/astro/blob/main/GOVERNANCE.md), a [Code of Conduct](https://github.com/withastro/astro/blob/main/CODE_OF_CONDUCT.md), a structured [RFC process](https://github.com/withastro/rfcs), [cool automation](https://twitter.com/FredKSchott/status/1489287560387956736), and 17 amazing Maintainers who help us keep it all running.
 
-**We do a lot of community-building on [Discord](https://astro.build/chat).** We have over 4000 total members in our Discord, with over 400 actively engaged members visiting and hanging out with us every week. Self-organizing teams like **@Maintainers**, **@Moderators**, **@Support Squad**, and our awesome **@Docs Team** are a huge part of what make our server the best software-focused community on Discord, hands down.
+**We do a lot of community-building on [Discord](https://astro.build/chat/).** We have over 4000 total members in our Discord, with over 400 actively engaged members visiting and hanging out with us every week. Self-organizing teams like **@Maintainers**, **@Moderators**, **@Support Squad**, and our awesome **@Docs Team** are a huge part of what make our server the best software-focused community on Discord, hands down.
 
 <BlogContentImage src={community} alt="Astro community contributors" />
 

--- a/src/content/blog/contributor-awards-4.mdx
+++ b/src/content/blog/contributor-awards-4.mdx
@@ -29,6 +29,6 @@ This time around, our monthly sponsorships totalled almost **$5000** which we ar
 
 Thanks to these standout contributors we have translated documentation, a battle-tested Vercel integration, a fantastic support channel, a friendly Discord community that everyone feels welcome in, and more improvements than I can list here!
 
-If you have contributed to Astro in any way over the last few months, thank you. Astro is what it is today because of this amazing community. You can [join us on Discord](https://astro.build/chat) to learn more about these awards and the standout work done by this latest batch of recipients.
+If you have contributed to Astro in any way over the last few months, thank you. Astro is what it is today because of this amazing community. You can [join us on Discord](https://astro.build/chat/) to learn more about these awards and the standout work done by this latest batch of recipients.
 
 Lastly, a huge thank you to our amazing sponsors -- including [Netlify](https://www.netlify.com/), [Storyblok](https://storyblok.com/), [Vercel](https://vercel.com/), and [Google](https://google.com/) -- for supporting open source software and helping to make programs like this posssible.

--- a/src/content/blog/demo-day-2021-09.mdx
+++ b/src/content/blog/demo-day-2021-09.mdx
@@ -28,4 +28,4 @@ As always, our Discord community brought the hype:
 
 Astro's next release will be our biggest ever, featuring a new WASM-powered compiler plus a new Vite-powered runtime. You can expect a preview release on [npm](https://www.npmjs.com/package/astro) later today or tomorrow. Over the next few weeks, we will continue to polish the new code as we prepare for its official release!
 
-If you haven't already, follow [@astrodotbuild](https://twitter.com/astrodotbuild) on Twitter for more news and announcements, and [join our Discord](https://astro.build/chat) to learn how you can try out the new previous release.
+If you haven't already, follow [@astrodotbuild](https://twitter.com/astrodotbuild) on Twitter for more news and announcements, and [join our Discord](https://astro.build/chat/) to learn how you can try out the new previous release.

--- a/src/content/blog/docs-hacktoberfest.mdx
+++ b/src/content/blog/docs-hacktoberfest.mdx
@@ -30,7 +30,7 @@ To kick things off, let’s take a moment to talk about Astro Docs and Hacktober
 
 For us, contributions come in all shapes and sizes. From typo fixes and CSS tweaks, to bigger documentation improvements. But that’s not all! Astro’s Docs are available in 10 languages thanks to our tireless translators. That’s where we decided to focus our efforts this month.
 
-In line with Hacktoberfest’s low-code focus, we wanted to encourage new translations. But **we can’t merge translations without reviews from our multilingual community.** It might not be obvious, but a good PR review is as valuable as the PR itself. To recognize this, we made it possible to [get Hacktoberfest credit for reviewing PRs](https://github.com/withastro/docs/blob/main/.github/hacktoberfest.md). Then we let folks know our plans on [Discord](https://astro.build/chat) and [Twitter](https://twitter.com/astrodotbuild/status/1576221838950412289), sat back, and waited…
+In line with Hacktoberfest’s low-code focus, we wanted to encourage new translations. But **we can’t merge translations without reviews from our multilingual community.** It might not be obvious, but a good PR review is as valuable as the PR itself. To recognize this, we made it possible to [get Hacktoberfest credit for reviewing PRs](https://github.com/withastro/docs/blob/main/.github/hacktoberfest.md). Then we let folks know our plans on [Discord](https://astro.build/chat/) and [Twitter](https://twitter.com/astrodotbuild/status/1576221838950412289), sat back, and waited…
 
 ## So, how did it go?
 
@@ -51,4 +51,4 @@ Thank you so much to everyone who took part! We welcomed new contributors, but w
 
 ## Hacktoberfest is over, but Open Source is for life
 
-Are you interested in getting involved with Astro’s Docs? You can always find us in [the docs repo on GitHub](https://github.com/withastro/docs) or in [the `#docs` channel on Discord](https://astro.build/chat). Can’t wait to meet you and merge your PR!
+Are you interested in getting involved with Astro’s Docs? You can always find us in [the docs repo on GitHub](https://github.com/withastro/docs) or in [the `#docs` channel on Discord](https://astro.build/chat/). Can’t wait to meet you and merge your PR!

--- a/src/content/blog/experimental-static-build.mdx
+++ b/src/content/blog/experimental-static-build.mdx
@@ -13,7 +13,7 @@ Astro is about to get a lot faster! Our new build optimization process is ready 
 astro build --experimental-static-build
 ```
 
-Our new build system can scale to tens, or even hundreds, of thousands of pages. If you hang out in our [Discord](https://astro.build/chat) or pay attention to recent releases you might have seen a lot of discussion about a "static build". Our new implementation of `astro build` does 2 things:
+Our new build system can scale to tens, or even hundreds, of thousands of pages. If you hang out in our [Discord](https://astro.build/chat/) or pay attention to recent releases you might have seen a lot of discussion about a "static build". Our new implementation of `astro build` does 2 things:
 
 - Improves build times by up to 75%.
 - Lowers memory usage when building very large sites (10,000+ pages).
@@ -22,4 +22,4 @@ This new build works by first building an SSR version of your app and then rende
 
 If you are a current Astro user please try out this new build by passing the flag in your `build` script.
 
-This build approach will remain flagged for the next few releases until we iron out any issues, at which point we plan to promote it to be the default `astro build` command. Please help us by reporting issues you encounter, either in the [Discord](https://astro.build/chat) or by filing an [issue](https://github.com/withastro/astro/issues/new/choose).
+This build approach will remain flagged for the next few releases until we iron out any issues, at which point we plan to promote it to be the default `astro build` command. Please help us by reporting issues you encounter, either in the [Discord](https://astro.build/chat/) or by filing an [issue](https://github.com/withastro/astro/issues/new/choose).

--- a/src/content/blog/hybrid-rendering.mdx
+++ b/src/content/blog/hybrid-rendering.mdx
@@ -108,4 +108,4 @@ Hybrid rendering is available today in Astro 2.0! You can head to our [server-si
 
 To celebrate the launch, our friends at [SST](https://sst.dev/) just launched [astro-sst](https://www.npmjs.com/package/astro-sst), their official AWS Adapter for Astro. Check out their [announcement video & walkthrough](https://www.youtube.com/watch?v=AFP3ZHxO7Gg) to learn more and get started with AWS + SST.
 
-We welcome your feedback! We collected some wonderful input during the [Prerender API RFC](https://github.com/withastro/roadmap/blob/main/proposals/0029-prerender-api.md) and invite you to propose future ideas using our new [public roadmap](https://github.com/withastro/roadmap) or [Discord community](https://astro.build/chat).
+We welcome your feedback! We collected some wonderful input during the [Prerender API RFC](https://github.com/withastro/roadmap/blob/main/proposals/0029-prerender-api.md) and invite you to propose future ideas using our new [public roadmap](https://github.com/withastro/roadmap) or [Discord community](https://astro.build/chat/).

--- a/src/content/blog/images.mdx
+++ b/src/content/blog/images.mdx
@@ -152,6 +152,6 @@ We're looking forward to seeing our community use this feature to integrate Astr
 
 ## What next?
 
-We'll continue to gather your feedback as we move closer to an official release in Astro 3.0 later this year. If you find any issues, do not hesitate to let us know, either [by creating an issue](https://github.com/withastro/astro/issues), or on [our Discord](https://astro.build/chat).
+We'll continue to gather your feedback as we move closer to an official release in Astro 3.0 later this year. If you find any issues, do not hesitate to let us know, either [by creating an issue](https://github.com/withastro/astro/issues), or on [our Discord](https://astro.build/chat/).
 
 There's plenty that we didn't get to cover here, like caching between builds, controlling the file format, and MDX support. For more information on how to use this feature, please [visit our assets documentation](https://docs.astro.build/en/guides/assets/).

--- a/src/content/blog/introducing-astro.mdx
+++ b/src/content/blog/introducing-astro.mdx
@@ -95,10 +95,10 @@ We care deeply about building a more sustainable future for open source software
 
 We're inspired by the early success of projects like [Tailwind](https://tailwindcss.com/), [Rome](https://rome.tools/), [Remix](https://remix.run/), [Ionic](https://ionicframework.com/), and others who are experimenting with long-term financial sustainability on top of Open Source. Over the next year we'll be exploring how we can create a sustainable business to support a 100% free, open source Astro for years to come.
 
-If your company is as excited about Astro as we are, [we'd love to hear from you.](https://astro.build/chat)
+If your company is as excited about Astro as we are, [we'd love to hear from you.](https://astro.build/chat/)
 
 <Note type="tip">
 
-Finally, I'd like to give a **HUGE** thanks to the 300+ developers who joined our earliest private beta. Your feedback has been essential in shaping Astro into the tool it is today. If you're interested in getting involved (or just following along with development) please [join us on Discord.](https://astro.build/chat)
+Finally, I'd like to give a **HUGE** thanks to the 300+ developers who joined our earliest private beta. Your feedback has been essential in shaping Astro into the tool it is today. If you're interested in getting involved (or just following along with development) please [join us on Discord.](https://astro.build/chat/)
 
 </Note>

--- a/src/content/blog/netlify-astro-hosting-sponsorship.mdx
+++ b/src/content/blog/netlify-astro-hosting-sponsorship.mdx
@@ -35,7 +35,7 @@ Here's what Jason told us about Astro:
 
 Astro is honored and excited to have Netlify as our first official corporate sponsor. We are grateful for the support of Jason Lengstorf, Cassidy Williams, and the entire Netlify team for their help and evangelism. It's because of support from companies like Netlify that we are able to receive ongoing maintenance and keep developing Astro in an open, financially-sustainable way.
 
-Our first integration with Netlify will be to add the ["Deploy with Netlify"](https://www.netlify.com/blog/2016/11/29/introducing-the-deploy-to-netlify-button/) button to our official Astro starter templates. This will make it even easier to create new, hosted Astro websites in just a few clicks. Check out all of our batteries-included starter templates in the brand new [Astro Theme Showcase.](https://astro.build/themes)
+Our first integration with Netlify will be to add the ["Deploy with Netlify"](https://www.netlify.com/blog/2016/11/29/introducing-the-deploy-to-netlify-button/) button to our official Astro starter templates. This will make it even easier to create new, hosted Astro websites in just a few clicks. Check out all of our batteries-included starter templates in the brand new [Astro Theme Showcase.](https://astro.build/themes/)
 
 Thanks, Netlify!
 

--- a/src/content/blog/the-astro-technology-company.mdx
+++ b/src/content/blog/the-astro-technology-company.mdx
@@ -33,4 +33,4 @@ Our goal is to grow Astro into the next great platform for web developers. We se
 
 Love web development? Love developer tooling? Love the thought of working with talented, thoughtful people full-time? [**We're hiring!**](/company)
 
-You can also [join us on Discord](https://astro.build/chat) to learn more about Astro and the community behind it.
+You can also [join us on Discord](https://astro.build/chat/) to learn more about Astro and the community behind it.

--- a/src/content/blog/themes-and-integrations.mdx
+++ b/src/content/blog/themes-and-integrations.mdx
@@ -17,7 +17,7 @@ import themes from "/src/content/blog/_images/themes-and-integrations/astro-them
 
 We [launched Astro](https://astro.build/blog/introducing-astro/) almost a year ago with the goal of delivering lightning-fast performance with a modern developer experience. Astro makes it easy to ship only what you need - 100% static HTML by default, bring your own framework to sprinkle in interactivity only where you need it.
 
-**Today, we're excited to announce two new catalogs to help speed up development: [Themes](https://astro.build/themes) and [Integrations](https://astro.build/integrations).**
+**Today, we're excited to announce two new catalogs to help speed up development: [Themes](https://astro.build/themes/) and [Integrations](https://astro.build/integrations).**
 
 <BlogContentImage src={integrations} alt="Astro Themes and Integrations Catalog" />
 
@@ -33,9 +33,9 @@ We created the Astro Themes Catalog to showcase these amazing community-develope
 
 <BlogContentImage src={themes} alt="Astro Themes Catalog" />
 
-Visit [astro.build/themes](https://astro.build/themes) to get started with any official or community theme.
+Visit [astro.build/themes](https://astro.build/themes/) to get started with any official or community theme.
 
-Interested in releasing your own theme? We’re here to help! Check out our [publishing best-practices](https://docs.astro.build/en/guides/publish-to-npm/#packagejson) for help getting started and instructions to get your theme listed on our catalog. Need help? Join the #themes channel on [Discord](https://astro.build/chat) to chat with other Astro theme creators.
+Interested in releasing your own theme? We’re here to help! Check out our [publishing best-practices](https://docs.astro.build/en/guides/publish-to-npm/#packagejson) for help getting started and instructions to get your theme listed on our catalog. Need help? Join the #themes channel on [Discord](https://astro.build/chat/) to chat with other Astro theme creators.
 
 ## Integrations
 
@@ -49,7 +49,7 @@ Check out the [full docs](https://docs.astro.build/en/reference/integrations-ref
 
 ## Ship It
 
-We can't wait to see what you come up with! [Add your own themes to the catalog](https://github.com/withastro/astro.build/issues/new/choose), publish your own [components and integrations](https://docs.astro.build/en/guides/publish-to-npm/#integrations-library), and join our [Discord](https://astro.build/chat) to say hello!
+We can't wait to see what you come up with! [Add your own themes to the catalog](https://github.com/withastro/astro.build/issues/new/choose), publish your own [components and integrations](https://docs.astro.build/en/guides/publish-to-npm/#integrations-library), and join our [Discord](https://astro.build/chat/) to say hello!
 
 <Note title="Stay Tuned">
 	We're launching the next Astro Hackathon on Monday, April 11! Cash prizes will be awarded for a

--- a/src/content/blog/themes-catalog-updates.mdx
+++ b/src/content/blog/themes-catalog-updates.mdx
@@ -66,7 +66,7 @@ Gone are the days of filling out GitHub issue templates. The new submission form
     flex-direction: column;
     align-items: center;"
 >
-	<a class="button button-primary" href="https://astro.build/themes">
+	<a class="button button-primary" href="https://astro.build/themes/">
 		<span>Visit the Themes Catalog</span>
 	</a>
 	<span style="font-size: 1rem;margin: 1rem;">

--- a/src/content/blog/vercel-official-hosting-partner.mdx
+++ b/src/content/blog/vercel-official-hosting-partner.mdx
@@ -83,7 +83,7 @@ You can enable this feature today by specifying [`{ imageService: true }`](https
 
 We've built all three of these features in collaboration with Vercel by leveraging their [Build Output API](https://vercel.com/docs/build-output-api/v3). Our goal is to bring them to more hosting platforms in the future. Everything mentioned in this post has been designed in a platform-agnostic way so that anyone can take these same features and enable them on their own hosting platform.
 
-If you are interested in enabling these features for your hosting platform, you can [reach out on Discord](https://astro.build/chat).
+If you are interested in enabling these features for your hosting platform, you can [reach out on Discord](https://astro.build/chat/).
 
 ## Astro ❤️ Vercel
 

--- a/src/content/caseStudies/contenda-share-pear/index.mdx
+++ b/src/content/caseStudies/contenda-share-pear/index.mdx
@@ -56,7 +56,7 @@ Cassidy (Contenda CTO) saw an opportunity to pair Astro with Netlify’s on-dema
 
 ## Solution and Implementation
 
-Contenda found success in Astro’s developer community. The team was able to enlist the help of the core team and active contributors in [Astro's community Discord server](https://astro.build/chat). From there, building Share Pear moved quickly.
+Contenda found success in Astro’s developer community. The team was able to enlist the help of the core team and active contributors in [Astro's community Discord server](https://astro.build/chat/). From there, building Share Pear moved quickly.
 
 <Blockquote>
 	<Fragment slot="quote">

--- a/src/content/pages/privacy.md
+++ b/src/content/pages/privacy.md
@@ -5,7 +5,7 @@ seo:
 updated_date: 2023-03-01
 ---
 
-_In addition to this Privacy Policy, Astro also has [Terms of Service](/terms)._
+_In addition to this Privacy Policy, Astro also has [Terms of Service](/terms/)._
 
 The Astro Privacy Policy describes the privacy practices of Astro website and services. The laws of California and the laws of the United States apply. If you are a resident of EU/EEA, the European Commission-approved Standard Contractual Clauses (also referred to as Model Contracts) apply to Trans-Atlantic data transfers.
 
@@ -13,7 +13,7 @@ The Astro Privacy Policy describes the privacy practices of Astro website and se
 
 We collect very limited personally identifiable information described below (the “data”) from [GitHub](https://help.github.com/articles/github-privacy-policy/) and of those who communicate with us directly via e-mail, aggregate information on what pages consumers access or visit, and information volunteered by the consumer (such as survey information and/or site registrations). The information we collect is used to provide our services, and to improve the quality of our services, and is not shared with or sold to other organizations for commercial purposes, except to provide products or services you've requested when we have your permission, or under the following circumstances:
 
-- It is necessary to share information in order to investigate, prevent, or take action regarding illegal activities, suspected fraud, situations involving potential threats to the physical safety of any person, violations of [Terms of Service](/terms), or as otherwise required by law.
+- It is necessary to share information in order to investigate, prevent, or take action regarding illegal activities, suspected fraud, situations involving potential threats to the physical safety of any person, violations of [Terms of Service](/terms/), or as otherwise required by law.
 - We transfer information about you if Astro is acquired by or merged with another company. In this event, Astro will notify you before information about you is transferred and becomes subject to a different privacy policy.
 
 ### Information Gathering and Usage

--- a/src/content/pages/terms.md
+++ b/src/content/pages/terms.md
@@ -19,7 +19,7 @@ If you continue to use the Service after the revised Terms go into effect, then 
 
 ### Privacy Policy
 
-For information about how we collect and use information about users of the Service, please view our [privacy policy](/privacy).
+For information about how we collect and use information about users of the Service, please view our [privacy policy](/privacy/).
 
 ### Third-Party Services
 

--- a/src/pages/_components/Hero.astro
+++ b/src/pages/_components/Hero.astro
@@ -16,7 +16,7 @@ const logos = [
 ---
 
 <section class="landing-section relative overflow-x-hidden pb-40 pt-14 sm:pt-20 lg:pt-32">
-	<PillLink title="Astro 3.0 is here!" subtitle="Learn more" href="/blog/astro-3" class="mb-8" />
+	<PillLink title="Astro 3.0 is here!" subtitle="Learn more" href="/blog/astro-3/" class="mb-8" />
 	<PageTitleBlock
 		lg
 		body="Astro builds fast content sites, powerful web applications, dynamic server APIs, and everything in-between."

--- a/src/pages/integrations/[...page].astro
+++ b/src/pages/integrations/[...page].astro
@@ -138,7 +138,7 @@ const recentlyAddedHref = `${Astro.url.pathname}?${recentlyAddedSearch.toString(
 		<Fragment slot="sidebar">
 			<SidebarPanel>
 				<SearchFilter
-					indexRoute="/integrations"
+					indexRoute="/integrations/"
 					groups={[categoryFilter]}
 					search={search}
 					searchPlaceholder="Search for an integration"

--- a/src/pages/themes/[...page].astro
+++ b/src/pages/themes/[...page].astro
@@ -171,7 +171,7 @@ const recentlyAddedHref = `${Astro.url.pathname}?${recentlyAddedSearch.toString(
 		<Fragment slot="sidebar">
 			<SidebarPanel>
 				<SearchFilter
-					indexRoute="/themes"
+					indexRoute="/themes/"
 					groups={[categoryFilter, toolFilter]}
 					search={search}
 					searchPlaceholder="Search for a theme"


### PR DESCRIPTION
Add a trailing `/` to links across the site, eliminating redirects.

I'm unsure the changes from `/chat` to `/chat/` will fix the redirect ahref issue for that, since it still redirects to a discord link, but it eliminates the redirect chain.