### PR TITLE
style: fixed responsive styling for themes search results on mobile.

### DIFF
--- a/src/pages/themes/[...page].astro
+++ b/src/pages/themes/[...page].astro
@@ -217,7 +217,7 @@ const recentlyAddedHref = `${Astro.url.pathname}?${recentlyAddedSearch.toString(
 					)}
 				</div>
 			) : (
-				<div class="flex flex-col items-center gap-12 pt-8 text-center sm:px-4 md:px-8 lg:px-10 lg:pt-10">
+				<div class="flex flex-col items-center gap-8 pb-10 pt-8 text-center sm:px-4 sm:pb-12 md:gap-10 md:pb-16 lg:gap-12 lg:px-8 lg:pb-20 lg:pt-10 xl:px-10">
 					<p>
 						<strong>0</strong> results found for themes matching <strong>"{search}"</strong>
 					</p>


### PR DESCRIPTION
Fixed responsive styling for themes search results and matched container with results stylings. 

Style issue: No spacings between element when there's no items within the search result on mobile.

Test: https://astro.build/themes/?search=testing+search+with+no+results

<img width="389" alt="Screenshot 2023-10-01 at 4 13 49 pm" src="https://github.com/withastro/astro.build/assets/54312759/5493f503-d5dc-426d-9bd2-6ab03e2e74ad">
