### PR TITLE
feat: Add docs redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -48,6 +48,10 @@
       "destination": "https://studio.astro.build"
     },
     {
+      "source": "/docs/",
+      "destination": "https://docs.astro.build"
+    },
+    {
       "source": "/showcase/submit/",
       "destination": "https://github.com/withastro/roadmap/discussions/521"
     },


### PR DESCRIPTION
https://astro.build/docs gave a sad and cryptic 404:

<img width="605" alt="image" src="https://github.com/withastro/astro.build/assets/4117920/6f6e93e7-3646-4e59-a88f-0cc996fed699">

Now it'll redirect users to https://docs.astro.build ⏩ 