### PR TITLE
Add note about outdated `--experimental-static-build`

### DIFF
--- a/src/content/blog/experimental-static-build.mdx
+++ b/src/content/blog/experimental-static-build.mdx
@@ -7,6 +7,14 @@ authors:
 lang: "en"
 ---
 
+import Note from '../../components/Note.astro';
+
+<Note>
+  This blog post introduces a feature that was new to Astro in early 2022, prior to our official 1.0.0 release.
+  
+  The `--experimental-static-build` flag is no longer required. It became the default build strategy in Astro 1.0.0.
+</Note>
+
 Astro is about to get a lot faster! Our new build optimization process is ready to try out in Astro today:
 
 ```shell


### PR DESCRIPTION
I've seen quite a few people asking about this blog post! It has fairly good SEO so people land here often. This feature flag was needed for a version of Astro prior to v1.0.0.

We might want to think of a way to automate this, but a manual `Note` inclusion seems fine for now.