### PR TITLE
Update zerk.md

### DIFF
--- a/src/content/themes/zerk.md
+++ b/src/content/themes/zerk.md
@@ -12,7 +12,7 @@ categories:
   - "portfolio"
   - "recent"
 repoUrl: "https://github.com/Jamship-io/zerk"
-demoUrl: "https:/zerk.vercel.app"
+demoUrl: "https://zerk.vercel.app"
 tools:
   - "tailwind"
 publishDate: "Oct 13, 2023"


### PR DESCRIPTION
Missing a ‘/‘ in ‘https://‘ led to a broken link when clicking the ‘Live Demo’ button to the external url.

my PR fixes this.
