### PR TITLE
Handle update-showcase script error

### DIFF
--- a/scripts/update-showcase.mjs
+++ b/scripts/update-showcase.mjs
@@ -201,8 +201,13 @@ class ShowcaseScraper {
 	async #filterHrefs(hrefs) {
 		const currentSites = await ShowcaseScraper.#getLiveShowcaseUrls()
 		return hrefs.filter((href) => {
-			const { origin } = new URL(href)
-			return !this.#blocklist.has(origin) && !currentSites.has(origin)
+			try {
+				const { origin } = new URL(href)
+				return !this.#blocklist.has(origin) && !currentSites.has(origin)
+			} catch (error) {
+				console.error(`Error parsing URL: ${href}`)
+				return false
+			}
 		})
 	}
 


### PR DESCRIPTION
This week’s CI script updating the showcase failed trying to parse an invalid URL: https://github.com/withastro/astro.build/actions/runs/6770471354/job/18411300157

Not 100% sure which link we’re scraping that is tripping it up (we just get `#`), but this PR adds some error handling so the script can keep running, ignoring any invalid URLs like this.