### PR TITLE
fixes ev0 theme broken demo link

### DIFF
--- a/src/content/themes/ev0.md
+++ b/src/content/themes/ev0.md
@@ -10,7 +10,7 @@ categories:
   - "blog"
   - "recent"
 repoUrl: "https://github.com/gndx/ev0-astro-theme"
-demoUrl: "https://ev0.gndx.io/"
+demoUrl: "https://ev0.gndx.dev/"
 tools:
   - "tailwind"
   - "typescript"


### PR DESCRIPTION
Original theme developer has changed the demo url on the repo.
https://github.com/gndx/ev0-astro-theme

Current demo link is broken.