### PR TITLE
chore: rename community to ecosystem

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -35,8 +35,12 @@ const groups: LinkGroup[] = [
 		],
 	},
 	{
-		title: "Community",
+		title: "Ecosystem",
 		items: [
+			{
+				href: "https://community.astro.build",
+				text: "Community",
+			},
 			{
 				href: "/showcase/",
 				text: "Showcase",
@@ -44,14 +48,6 @@ const groups: LinkGroup[] = [
 			{
 				href: "https://github.com/withastro/astro/blob/main/CONTRIBUTING.md",
 				text: "Contributing",
-			},
-			{
-				href: "https://opencollective.com/astrodotbuild",
-				text: "Open Collective",
-			},
-			{
-				href: "/chat/",
-				text: "Join our Discord",
 			},
 		],
 	},


### PR DESCRIPTION
Renames the "Community" category to "Ecosystem" and add community as a link to community.astro.build