### PR TITLE
Small showcase scraper script tweaks

### DIFF
--- a/scripts/update-showcase.mjs
+++ b/scripts/update-showcase.mjs
@@ -111,7 +111,7 @@ class ShowcaseScraper {
 				"",
 				"We couldn’t detect that these sites were built with Astro. You might want to check manually.",
 				"",
-				sites.nonAstro.join(", "),
+				sites.nonAstro.map((site) => `[${new URL(site).host}](${site})`).join(", "),
 			)
 		}
 

--- a/scripts/update-showcase.mjs
+++ b/scripts/update-showcase.mjs
@@ -385,6 +385,7 @@ const scraper = new ShowcaseScraper({
 		"https://github.com",
 		"https://user-images.githubusercontent.com",
 		"https://camo.githubusercontent.com",
+		"https://private-user-images.githubusercontent.com",
 		"https://astro.build",
 		"https://pagespeed.web.dev",
 		"https://lighthouse-metrics.com",


### PR DESCRIPTION
- Blocks a (new?) GitHub images origin so that images people add to the GitHub discussion are ignored
- Adds a small formatting tweak so that we only show the URL’s host for non-Astro sites — should avoid super verbose output like in https://github.com/withastro/astro.build/pull/891