### PR TITLE
Add showcase screenshot grid to “What’s New in Astro” blog posts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,6 +28,9 @@ export default defineConfig({
 			theme: JSON.parse(fs.readFileSync("./houston.theme.json", { encoding: "utf-8" })),
 		},
 	},
+	image: {
+		domains: ["v1.screenshot.11ty.dev"],
+	},
 	vite: {
 		ssr: {
 			noExternal: ["smartypants"],

--- a/src/content/blog/_whats-new-components/ShowcaseCard.astro
+++ b/src/content/blog/_whats-new-components/ShowcaseCard.astro
@@ -1,0 +1,39 @@
+---
+import { Image } from "astro:assets"
+import ExternalLinkIcon from "~/icons/ExternalLinkIcon.jsx"
+
+export interface Props {
+	url: string
+	title?: string
+}
+
+const { url, title } = Astro.props
+---
+
+<li
+	class:list={[
+		"group relative flex aspect-[1200/630] h-full w-full cursor-pointer flex-col overflow-hidden bg-astro-gray-600",
+		// Override default Markdown content styles
+		"!m-0 before:!hidden",
+	]}
+>
+	<a href={url} class="h-full w-full text-astro-gray-100">
+		<Image
+			src={`https://v1.screenshot.11ty.dev/${encodeURIComponent(url)}/opengraph/_wait:3`}
+			width={450}
+			height={236}
+			alt=""
+			class="h-full w-full object-cover object-top"
+		/>
+
+		<span
+			class="pointer-events-none absolute bottom-0 z-10 flex w-full flex-col gap-2 bg-astro-gray-500/95 p-4 opacity-0 transition-opacity duration-300 ease-out group-focus-within:opacity-100 group-hover:opacity-100"
+		>
+			{title && <span class="heading-5">{title}</span>}
+			<span class="body flex flex-row items-center gap-2">
+				<span>{url}</span>
+				<ExternalLinkIcon />
+			</span>
+		</span>
+	</a>
+</li>

--- a/src/content/blog/_whats-new-components/ShowcaseGrid.astro
+++ b/src/content/blog/_whats-new-components/ShowcaseGrid.astro
@@ -1,0 +1,15 @@
+---
+import ShowcaseCard, { type Props as CardProps } from "./ShowcaseCard.astro"
+
+export interface Props {
+	items: CardProps[]
+}
+
+const { items } = Astro.props
+---
+
+<ul
+	class="grid gap-5 !p-0 md:grid-flow-row-dense md:grid-cols-2 lg:-mx-16 lg:!mb-16 lg:!mt-8 lg:grid-cols-3 xl:-mx-32"
+>
+	{items.map(({ url, title }) => <ShowcaseCard url={url} title={title} />)}
+</ul>

--- a/src/content/blog/whats-new-december-2023.mdx
+++ b/src/content/blog/whats-new-december-2023.mdx
@@ -95,68 +95,79 @@ With the release of the Astro Dev Toolbar, we also have Dev Toolbar apps to show
 
 Websites submitted to our Discord `#showcase` channel and featured on community calls this month.
 
-- [playstormgate.com](https://playstormgate.com/) by @robbietron
-- [monicaandandy.com](https://monicaandandy.com/) by @joshuaiz
-- [flowsstudio.com](https://flowsstudio.com/) by @marvinkr
-- [lucasjouin.com](https://lucasjouin.com/) by @itshaunt
-- [ngc.pages.dev](https://ngc.pages.dev/) by @erkan59
-- [eldenlord.cskl.pl](https://eldenlord.cskl.pl/) by @konrad_32301
-- [cskl.pl](https://cskl.pl/) by @konrad_32301
-- [salam.app](https://salam.app/) by @golam71
-- [ltree.darko.io](https://ltree.darko.io/) by @_seiryuu_
-- [birksovskiy.vercel.app](https://birksovskiy.vercel.app/) by @birksovskiy
-- [tomgraafmans.com](https://tomgraafmans.com/) by @varvino
-- [erfianugrah.com](https://www.erfianugrah.com/) by @stoicopa
-- [hamza127.vercel.app](https://hamza127.vercel.app/) by @hamza12700
-- [app.malachidaily.com](https://app.malachidaily.com/) by @cameronpak
-- [sayings.cc](https://sayings.cc/) by @k16e.co
-- [new.aroxbilling.com](https://new.aroxbilling.com/) by @toxin141
-- [florian-lefebvre.dev](https://florian-lefebvre.dev/) by @florian_lefebvre
-- [potatodeveloper.online](https://www.potatodeveloper.online/) by @badh_rush#0730
-- [kreativan.dev](https://kreativan.dev/) by @kreativan.
-- [astratechz.com](https://astratechz.com/) by @engagepy
-- [hookdeck.com](https://hookdeck.com/) by @ernie9316
-- [sannajammeh.com](https://sannajammeh.com/) by @chiefkoshi
-- [events-3bg.pages.dev](https://events-3bg.pages.dev/demos/) by @martrapp
-- [greendream21.github.io](https://greendream21.github.io/) by @lovebee_
-- [pagepanda.vercel.app](https://pagepanda.vercel.app/) by @varvino
-- [hideoo.dev](https://hideoo.dev/notes) by @hideoo
-- [amigosdelretiro.com](https://www.amigosdelretiro.com/) by @suhaylmv
-- [caoutchou.vercel.app](https://caoutchou.vercel.app/) by @karel5743
-- [agency-git-new-flurium.vercel.app](https://agency-git-new-flurium.vercel.app/) by @koshchei.
-- [sahaja.bad.al](https://sahaja.bad.al/) by @theblapse
-- [calaisrespire.com](https://calaisrespire.com/) by @.kamalito
-- [johnzanussi.com](https://johnzanussi.com/) by @johnzanussi
-- [minirampfoundation.org](https://minirampfoundation.org/) by @johnzanussi
-- [switchcase.xyz](https://switchcase.xyz/) by @hellohithisme
-- [mmbu2023.vercel.app](https://mmbu2023.vercel.app/) by @heunha
-- [blog.memos.land](https://blog.memos.land/en/) by @oscarbustos
-- [trailbuddy-astro-view-transition-demo.netlify.app](https://trailbuddy-astro-view-transition-demo.netlify.app/) by @ekfuhrmann
-- [xn--berlandpost-shb.ch](https://xn--berlandpost-shb.ch/) by @meintest_26190
-- [caiodeveloper.ca](https://www.caiodeveloper.ca/) by @caiomarcellus
-- [offeringinspiration.com](https://offeringinspiration.com/Crafts/) by @randombits.dev
-- [lalospirits.com](https://lalospirits.com/) by @bigskillet0521
-- [clerk-astro-demo](https://github.com/vin-e/clerk-astro-demo) by @vinny_code
-- [belief.gg](https://belief.gg/) by @t1c.dev
-- [grafoma.se](https://grafoma.se/) by @.hydde
+import ShowcaseGrid from './_whats-new-components/ShowcaseGrid.astro';
+
+export const sites = [
+  { url: 'https://playstormgate.com/', title: '@robbietron' },
+  { url: 'https://monicaandandy.com/', title: '@joshuaiz' },
+  { url: 'https://flowsstudio.com/', title: '@marvinkr' },
+  { url: 'https://lucasjouin.com/', title: '@itshaunt' },
+  { url: 'https://ngc.pages.dev/', title: '@erkan59' },
+  { url: 'https://eldenlord.cskl.pl/', title: '@konrad_32301' },
+  { url: 'https://cskl.pl/', title: '@konrad_32301' },
+  { url: 'https://salam.app/', title: '@golam71' },
+  { url: 'https://ltree.darko.io/', title: '@_seiryuu_' },
+  { url: 'https://birksovskiy.vercel.app/', title: '@birksovskiy' },
+  { url: 'https://tomgraafmans.com/', title: '@varvino' },
+  { url: 'https://www.erfianugrah.com/', title: '@stoicopa' },
+  { url: 'https://hamza127.vercel.app/', title: '@hamza12700' },
+  { url: 'https://app.malachidaily.com/', title: '@cameronpak' },
+  { url: 'https://sayings.cc/', title: '@k16e.co' },
+  // Commented out this site as it’s broken in my testing:
+  // { url: 'https://new.aroxbilling.com/', title: '@toxin141' },
+  { url: 'https://florian-lefebvre.dev/', title: '@florian_lefebvre' },
+  { url: 'https://www.potatodeveloper.online/', title: '@badh_rush#0730' },
+  { url: 'https://kreativan.dev/', title: '@kreativan.' },
+  { url: 'https://astratechz.com/', title: '@engagepy' },
+  { url: 'https://hookdeck.com/', title: '@ernie9316' },
+  { url: 'https://sannajammeh.com/', title: '@chiefkoshi' },
+  { url: 'https://events-3bg.pages.dev/demos/', title: '@martrapp' },
+  { url: 'https://greendream21.github.io/', title: '@lovebee_' },
+  { url: 'https://pagepanda.vercel.app/', title: '@varvino' },
+  { url: 'https://hideoo.dev/notes', title: '@hideoo' },
+  { url: 'https://www.amigosdelretiro.com/', title: '@suhaylmv' },
+  { url: 'https://caoutchou.vercel.app/', title: '@karel5743' },
+  { url: 'https://agency-git-new-flurium.vercel.app/', title: '@koshchei.' },
+  { url: 'https://sahaja.bad.al/', title: '@theblapse' },
+  { url: 'https://calaisrespire.com/', title: '@.kamalito' },
+  { url: 'https://johnzanussi.com/', title: '@johnzanussi' },
+  { url: 'https://minirampfoundation.org/', title: '@johnzanussi' },
+  { url: 'https://switchcase.xyz/', title: '@hellohithisme' },
+  { url: 'https://mmbu2023.vercel.app/', title: '@heunha' },
+  { url: 'https://blog.memos.land/en/', title: '@oscarbustos' },
+  { url: 'https://trailbuddy-astro-view-transition-demo.netlify.app/', title: '@ekfuhrmann' },
+  { url: 'https://xn--berlandpost-shb.ch/', title: '@meintest_26190' },
+  { url: 'https://www.caiodeveloper.ca/', title: '@caiomarcellus' },
+  { url: 'https://offeringinspiration.com/Crafts/', title: '@randombits.dev' },
+  { url: 'https://lalospirits.com/', title: '@bigskillet0521' },
+  { url: 'https://github.com/vin-e/clerk-astro-demo', title: '@vinny_code' },
+  { url: 'https://belief.gg/', title: '@t1c.dev' },
+  { url: 'https://grafoma.se/', title: '@.hydde' },
+];
+
+<ShowcaseGrid items={sites} />
 
 ### Starlight in the wild
 
 Take a peek at the new Starlight sites that we discovered this month.
 
-- [Svelte Tweakpane UI](https://kitschpatrol.com/svelte-tweakpane-ui)
-- [New Horizons](https://nh.outerwildsmods.com/)
-- [Spotlight](https://spotlightjs.com/)
-- [secco](https://secco.lekoarts.de/)
-- [Astro Docs](https://docs.astro.build/)
-- [Ratatui](https://ratatui.rs/)
-- [Chamaeleon](https://chamaeleon-docs.vercel.app)
-- [Sarah's Starlight Blog](https://rainsberger.ca/)
-- [Signals.dart](https://rodydavis.github.io/signals.dart/)
-- [Dusa](https://dusa.rocks/docs/)
-- [csmos](https://csmos.space/)
-- [SiteOne](https://crawler.siteone.io/)
-- [Mr. Robøt](https://docs.mrrobot.app/)
-- [Progressively](https://progressively.app/)
-- [TACO project](https://taco-api.netlify.app/about/)
-- [Origami for Everyone](https://origami-for-everyone.ft.com/)
+export const starlightSites = [
+  { url: 'https://kitschpatrol.com/svelte-tweakpane-ui', title: 'Svelte Tweakpane UI' },
+  { url: 'https://nh.outerwildsmods.com/', title: 'New Horizons' },
+  { url: 'https://spotlightjs.com/', title: 'Spotlight' },
+  { url: 'https://secco.lekoarts.de/', title: 'secco' },
+  { url: 'https://docs.astro.build/', title: 'Astro Docs' },
+  { url: 'https://ratatui.rs/', title: 'Ratatui' },
+  { url: 'https://chamaeleon-docs.vercel.app', title: 'Chamaeleon' },
+  { url: 'https://rainsberger.ca/', title: 'Sarah\'s Starlight Blog' },
+  { url: 'https://rodydavis.github.io/signals.dart/', title: 'Signals.dart' },
+  { url: 'https://dusa.rocks/docs/', title: 'Dusa' },
+  { url: 'https://csmos.space/', title: 'csmos' },
+  { url: 'https://crawler.siteone.io/', title: 'SiteOne' },
+  { url: 'https://docs.mrrobot.app/', title: 'Mr. Robøt' },
+  { url: 'https://progressively.app/', title: 'Progressively' },
+  { url: 'https://taco-api.netlify.app/about/', title: 'TACO project' },
+  { url: 'https://origami-for-everyone.ft.com/', title: 'Origami for Everyone' },
+];
+
+<ShowcaseGrid items={starlightSites} />

--- a/src/content/blog/whats-new-november-2023.mdx
+++ b/src/content/blog/whats-new-november-2023.mdx
@@ -80,7 +80,8 @@ export const sites = [
   { url: 'https://garpunkal.dev/', title: '@garpunkal' },
   { url: 'https://neta-astrosl.vercel.app/', title: '@massv' },
   { url: 'https://melos.church/', title: '@cameronpak' },
-  { url: 'https://paperdave.net/', title: '@paperdave.net' },
+  // Site fails to load
+  // { url: 'https://paperdave.net/', title: '@paperdave.net' },
   { url: 'https://joselove2code.com/', title: '@joselove2code' },
   { url: 'https://westeroscraft.com/', title: '@geeberry' },
   { url: 'https://labs.leaningtech.com/', title: '@nanaian' },

--- a/src/content/blog/whats-new-november-2023.mdx
+++ b/src/content/blog/whats-new-november-2023.mdx
@@ -66,62 +66,73 @@ Our weekly Discord call "Talking and Doc’ing" is a chance for you to watch Tea
 
 ### Websites
 
-- [alexi.sh](https://alexi.sh/) by @alexi.sh
-- [charl.sh](https://charl.sh/) by @aczw
-- [pikhosh.surge.sh](https://pikhosh.surge.sh/) by @pikhosh
-- [espadeiro.pt](https://espadeiro.pt/) by @edswordsmith
-- [lego-demonstration-lloyd.netlify.app](https://lego-demonstration-lloyd.netlify.app/) by @lloyd1000
-- [calpa.me](https://calpa.me/) by @calpaliu.eth
-- [drackwolf.com](https://drackwolf.com/) by @drackwolf
-- [circus-real.vercel.app](https://circus-real.vercel.app/) by @circus_real
-- [garpunkal.dev](https://garpunkal.dev/) by @garpunkal
-- [neta-astrosl.vercel.app](https://neta-astrosl.vercel.app/) by @massv
-- [melos.church](https://melos.church/) by @cameronpak
-- [paperdave.net](https://paperdave.net/) by @paperdave.net
-- [joselove2code.com](https://joselove2code.com/) by @joselove2code
-- [westeroscraft.com](https://westeroscraft.com/) by @geeberry
-- [labs.leaningtech.com](https://labs.leaningtech.com/) by @nanaian
-- [flayks.com](https://flayks.com/) by @flayks
-- [ownclock.app](https://ownclock.app/) by @igloczek.
-- [lucfreelance.com](https://www.lucfreelance.com/) by @lucfreelance
-- [eastgatedigital.co.uk](https://eastgatedigital.co.uk/) by @.neilbee
-- [animeif.netlify.app](https://animeif.netlify.app/) by @infinite_programmer
-- [kievhorst.netlify.app](https://kievhorst.netlify.app/) by @preetam_nl
-- [tucker.xxx](https://www.tucker.xxx/) by @6x17
-- [mstill.dev](https://mstill.dev/) by @klltk
-- [palingenae.github.io](https://palingenae.github.io/) by @aliqqae
-- [shadizx.com](https://www.shadizx.com/) by @shadizx
-- [venger.me](https://venger.me/) by @eugenevenger
-- [pumpkin-kooba.netlify.app](https://pumpkin-kooba.netlify.app/) by @Sean_Smyth
-- [U2 Space Baby GitHub project](https://www.chrsgrrtt.com/u2-space-baby) by @chrsgrrtt
-- [new.aroxbilling.com](https://new.aroxbilling.com/) by @toxin141
-- [florian-lefebvre.dev](https://florian-lefebvre.dev/) by @florian_lefebvre
-- [potatodeveloper.online](https://www.potatodeveloper.online/) by @badh_rush#0730
-- [kreativan.dev](https://kreativan.dev/) by @kreativan.
+import ShowcaseGrid from './_whats-new-components/ShowcaseGrid.astro';
+
+export const sites = [
+  { url: 'https://alexi.sh/', title: '@alexi.sh' },
+  { url: 'https://charl.sh/', title: '@aczw' },
+  { url: 'https://pikhosh.surge.sh/', title: '@pikhosh' },
+  { url: 'https://espadeiro.pt/', title: '@edswordsmith' },
+  { url: 'https://lego-demonstration-lloyd.netlify.app/', title: '@lloyd1000' },
+  { url: 'https://calpa.me/', title: '@calpaliu.eth' },
+  { url: 'https://drackwolf.com/', title: '@drackwolf' },
+  { url: 'https://circus-real.vercel.app/', title: '@circus_real' },
+  { url: 'https://garpunkal.dev/', title: '@garpunkal' },
+  { url: 'https://neta-astrosl.vercel.app/', title: '@massv' },
+  { url: 'https://melos.church/', title: '@cameronpak' },
+  { url: 'https://paperdave.net/', title: '@paperdave.net' },
+  { url: 'https://joselove2code.com/', title: '@joselove2code' },
+  { url: 'https://westeroscraft.com/', title: '@geeberry' },
+  { url: 'https://labs.leaningtech.com/', title: '@nanaian' },
+  { url: 'https://flayks.com/', title: '@flayks' },
+  { url: 'https://ownclock.app/', title: '@igloczek.' },
+  { url: 'https://www.lucfreelance.com/', title: '@lucfreelance' },
+  { url: 'https://eastgatedigital.co.uk/', title: '@.neilbee' },
+  { url: 'https://animeif.netlify.app/', title: '@infinite_programmer' },
+  { url: 'https://kievhorst.netlify.app/', title: '@preetam_nl' },
+  { url: 'https://www.tucker.xxx/', title: '@6x17' },
+  { url: 'https://mstill.dev/', title: '@klltk' },
+  { url: 'https://palingenae.github.io/', title: '@aliqqae' },
+  { url: 'https://www.shadizx.com/', title: '@shadizx' },
+  { url: 'https://venger.me/', title: '@eugenevenger' },
+  { url: 'https://pumpkin-kooba.netlify.app/', title: '@Sean_Smyth' },
+  { url: 'https://www.chrsgrrtt.com/u2-space-baby', title: '@chrsgrrtt' },
+  // Security error on this site:
+  // { url: 'https://new.aroxbilling.com/', title: '@toxin141' },
+  { url: 'https://florian-lefebvre.dev/', title: '@florian_lefebvre' },
+  { url: 'https://www.potatodeveloper.online/', title: '@badh_rush#0730' },
+  { url: 'https://kreativan.dev/', title: '@kreativan.' },
+];
+
+<ShowcaseGrid items={sites} />
 
 ### Starlight in the wild
 
-- [react-awesome-reveal.morello.dev](https://react-awesome-reveal.morello.dev/)
-- [notes.alphasoundz.app](https://notes.alphasoundz.app/)
-- [bookshelf.docs.joss.dev](https://bookshelf.docs.joss.dev/)
-- [docs.no550.com](https://docs.no550.com/)
-- [knope.tech](https://knope.tech/)
-- [rec.danmuji.org](https://rec.danmuji.org/)
-- [setup.md](https://www.setup.md/)
-- [syncpack](https://jamiemason.github.io/syncpack/)
-- [suzza.dev](https://www.suzza.dev/)
-- [mysql-to-zod](https://mysql-to-zod.pages.dev/)
-- [Platzi Fake Store API](https://fakeapi.platzi.com/)
-- [TypeSQL](https://typesql.pages.dev/)
-- [WP Engine Atlas Platform](https://developers.wpengine.com/docs/)
-- [Easydev](https://easydev-library.qa.aspirity.com/getting-started/introduction/)
-- [Shelter Protocol](https://shelterprotocol.net/)
-- [Knip](https://knip.dev/)
-- [Ratatui](https://ratatui.rs/)
-- [Chamaeleon](https://chamaeleon-docs.vercel.app/)
-- [Sarah's Starlight Blog](https://rainsberger.ca/)
-- [Signals.dart](https://rodydavis.github.io/signals.dart/)
-- [Dusa](https://dusa.rocks/docs/)
+export const starlightSites = [
+  { url: 'https://react-awesome-reveal.morello.dev/', title: 'react-awesome-reveal.morello.dev' },
+  { url: 'https://notes.alphasoundz.app/', title: 'notes.alphasoundz.app' },
+  { url: 'https://bookshelf.docs.joss.dev/', title: 'bookshelf.docs.joss.dev' },
+  { url: 'https://docs.no550.com/', title: 'docs.no550.com' },
+  { url: 'https://knope.tech/', title: 'knope.tech' },
+  { url: 'https://rec.danmuji.org/', title: 'rec.danmuji.org' },
+  { url: 'https://www.setup.md/', title: 'setup.md' },
+  { url: 'https://jamiemason.github.io/syncpack/', title: 'syncpack' },
+  { url: 'https://www.suzza.dev/', title: 'suzza.dev' },
+  { url: 'https://mysql-to-zod.pages.dev/', title: 'mysql-to-zod' },
+  { url: 'https://fakeapi.platzi.com/', title: 'Platzi Fake Store API' },
+  { url: 'https://typesql.pages.dev/', title: 'TypeSQL' },
+  { url: 'https://developers.wpengine.com/docs/', title: 'WP Engine Atlas Platform' },
+  { url: 'https://easydev-library.qa.aspirity.com/getting-started/introduction/', title: 'Easydev' },
+  { url: 'https://shelterprotocol.net/', title: 'Shelter Protocol' },
+  { url: 'https://knip.dev/', title: 'Knip' },
+  { url: 'https://ratatui.rs/', title: 'Ratatui' },
+  { url: 'https://chamaeleon-docs.vercel.app/', title: 'Chamaeleon' },
+  { url: 'https://rainsberger.ca/', title: 'Sarah\'s Starlight Blog' },
+  { url: 'https://rodydavis.github.io/signals.dart/', title: 'Signals.dart' },
+  { url: 'https://dusa.rocks/docs/', title: 'Dusa' },
+];
+
+<ShowcaseGrid items={starlightSites} />
 
 ## The “State of JS” Survey!
 

--- a/src/content/blog/whats-new-october-2023.mdx
+++ b/src/content/blog/whats-new-october-2023.mdx
@@ -91,41 +91,52 @@ Each week on the Astro Community Call in Discord, we shine the spotlight on proj
 
 ### Websites
 
-- [noobscience.rocks](https://www.noobscience.rocks/) by @noobscience
-- [fadhelmurphy.github.io](https://fadhelmurphy.github.io/) by @mamangpro
-- [rohitk06.vercel.app](https://rohitk06.vercel.app/) by @rohit06
-- [hvlxh.tk](https://www.hvlxh.tk/) by @hitesh_dev
-- [astronvim.com](https://astronvim.com/) by @uzaaft
-- [minov.studio](https://www.minov.studio/en/) by @suhaylmv
-- [linwood.dev](https://www.linwood.dev/) by @codedoctor
-- [shamann.dev](https://shamann.dev/) by @sylvhama
-- [paualbert.netlify.app](https://paualbert.netlify.app/) by @akond
-- [procastinatordev.vercel.app](https://procastinatordev.vercel.app/) by @procastinatordev
-- [mcdle.net](https://www.mcdle.net/) by @elitogame
-- [decimal.fm](https://www.decimal.fm/) by @chrsgrrtt
-- [dev.jeromeabel.net](https://dev.jeromeabel.net/) by @jeromeabel
-- [nunogois.com](https://www.nunogois.com/) by @nunogois
-- [pumpkin-kooba.netlify.app](https://pumpkin-kooba.netlify.app/) by @Sean_Smyth 
+import ShowcaseGrid from './_whats-new-components/ShowcaseGrid.astro';
+
+export const sites = [
+  { url: 'https://www.noobscience.rocks/', title: '@noobscience' },
+  { url: 'https://fadhelmurphy.github.io/', title: '@mamangpro' },
+  { url: 'https://rohitk06.vercel.app/', title: '@rohit06' },
+  // This site 404s:
+  // { url: 'https://www.hvlxh.tk/', title: '@hitesh_dev' },
+  { url: 'https://astronvim.com/', title: '@uzaaft' },
+  { url: 'https://www.minov.studio/en/', title: '@suhaylmv' },
+  { url: 'https://www.linwood.dev/', title: '@codedoctor' },
+  { url: 'https://shamann.dev/', title: '@sylvhama' },
+  { url: 'https://paualbert.netlify.app/', title: '@akond' },
+  { url: 'https://procastinatordev.vercel.app/', title: '@procastinatordev' },
+  { url: 'https://www.mcdle.net/', title: '@elitogame' },
+  { url: 'https://www.decimal.fm/', title: '@chrsgrrtt' },
+  { url: 'https://dev.jeromeabel.net/', title: '@jeromeabel' },
+  { url: 'https://www.nunogois.com/', title: '@nunogois' },
+  { url: 'https://pumpkin-kooba.netlify.app/', title: '@Sean_Smyth ' },
+];
+
+<ShowcaseGrid items={sites} />
 
 ### Starlight in the wild
 
 Need inspiration for your documentation site? Here are the new [Starlight](https://starlight.astro.build) sites we spotted this month!
 
-- [docs.launchfa.st](https://docs.launchfa.st/documentation)
-- [docs.corsace.io](https://docs.corsace.io/en/)
-- [certs.msfthub.wiki](https://certs.msfthub.wiki/)
-- [aoi.js.org](https://aoi.js.org/)
-- [chproxy.org](https://www.chproxy.org/)
-- [bunshi.org](https://www.bunshi.org)
-- [drops-of-php.hi-folks.dev](https://drops-of-php.hi-folks.dev/)
-- [angular-challenges.vercel.app](https://angular-challenges.vercel.app)
-- [astro-docs-docs.netlify.app](https://astro-docs-docs.netlify.app/)
-- [docs.cataclysmbn.org](https://docs.cataclysmbn.org/en/)
-- [reatom.dev](https://www.reatom.dev/)
-- [zsh-test-runner-docs.vercel.app](https://zsh-test-runner-docs.vercel.app/)
-- [ngxtension.netlify.app](https://ngxtension.netlify.app/)
-- [skyscript.js.org](https://skyscript.js.org/)
-- [nostalgist.js.org](https://nostalgist.js.org/)
-- [reactnativeunistyles.vercel.app](https://reactnativeunistyles.vercel.app/)
-- [sibiraj-s.github.io](https://sibiraj-s.github.io/ngx-editor)
-- [webmonetization.org](https://webmonetization.org/docs/)
+export const starlightSites = [
+  { url: 'https://docs.launchfa.st/documentation', title: 'docs.launchfa.st' },
+  { url: 'https://docs.corsace.io/en/', title: 'docs.corsace.io' },
+  { url: 'https://certs.msfthub.wiki/', title: 'certs.msfthub.wiki' },
+  { url: 'https://aoi.js.org/', title: 'aoi.js.org' },
+  { url: 'https://www.chproxy.org/', title: 'chproxy.org' },
+  { url: 'https://www.bunshi.org', title: 'bunshi.org' },
+  { url: 'https://drops-of-php.hi-folks.dev/', title: 'drops-of-php.hi-folks.dev' },
+  { url: 'https://angular-challenges.vercel.app', title: 'angular-challenges.vercel.app' },
+  { url: 'https://astro-docs-docs.netlify.app/', title: 'astro-docs-docs.netlify.app' },
+  { url: 'https://docs.cataclysmbn.org/en/', title: 'docs.cataclysmbn.org' },
+  { url: 'https://www.reatom.dev/', title: 'reatom.dev' },
+  { url: 'https://zsh-test-runner-docs.vercel.app/', title: 'zsh-test-runner-docs.vercel.app' },
+  { url: 'https://ngxtension.netlify.app/', title: 'ngxtension.netlify.app' },
+  { url: 'https://skyscript.js.org/', title: 'skyscript.js.org' },
+  { url: 'https://nostalgist.js.org/', title: 'nostalgist.js.org' },
+  { url: 'https://reactnativeunistyles.vercel.app/', title: 'reactnativeunistyles.vercel.app' },
+  { url: 'https://sibiraj-s.github.io/ngx-editor', title: 'sibiraj-s.github.io' },
+  { url: 'https://webmonetization.org/docs/', title: 'webmonetization.org' },
+];
+
+<ShowcaseGrid items={starlightSites} />


### PR DESCRIPTION
Adds a new `<ShowcaseGrid>` component that can be used in the “What’s New in Astro” blog post series to show a grid of links showing a screenshot of the site with information on focus/hover like we do in our existing showcase section. For example:

<img width="1161" alt="A page heading for Websites followed by a three-column grid of screenshots" src="https://github.com/withastro/astro.build/assets/357379/ea91a1a7-c787-41eb-8249-cac9ef8355cd">

### Usage

```mdx
{/* src/content/blog/example.mdx */}

import ShowcaseGrid from './_whats-new-components/ShowcaseGrid.astro';

export const sites = [
  { title: 'Example Site', url: 'https://example.com' },
  { title: 'Another Demo', url: 'https://demo.dev' },
];

<ShowcaseGrid items={sites} />
```

### Notes

- I’ve updated all the preceding editions of the What’s New in Astro posts to use this component too: [October](https://astro-build-git-chris-month-in-astro-showc-d6d5f7-astrodotbuild.vercel.app/blog/whats-new-october-2023/#showcase), [November](https://astro-build-git-chris-month-in-astro-showc-d6d5f7-astrodotbuild.vercel.app/blog/whats-new-november-2023/#showcase), [December](https://astro-build-git-chris-month-in-astro-showc-d6d5f7-astrodotbuild.vercel.app/blog/whats-new-december-2023/#websites)

- The card design is lifted from our existing showcase card design. This includes a title and shows the URL below that, so doesn’t entirely match our `example.com by @username` pattern that was in use in the bullet-point version. To be quick, I’ve made the title for those sites the username. In the future, we might want to use the actual site title instead.

- For speed, this uses the [11ty screenshot service](https://www.11ty.dev/docs/services/screenshots/) to generate the site screenshots and optimises those by allowing that service as a remote image source for Astro assets. In the future, we might want to add something like https://github.com/withastro/astro.build/blob/main/scripts/update-showcase.mjs to generate the screenshots instead of relying on the remote service.