### PR TITLE
removing Balanced Chef demo link

### DIFF
--- a/src/content/themes/balanced-chef.md
+++ b/src/content/themes/balanced-chef.md
@@ -10,7 +10,6 @@ author:
 categories:
   - "other"
 repoUrl: "https://github.com/fahad0samara/Astro.js-Chef-Project"
-demoUrl: "https://astro-js-iota.vercel.app/"
 tools:
   - "tailwind"
   - "typescript"


### PR DESCRIPTION
Removing the demo link for the Balanced Chef theme.  I'll try to find a contact for the theme dev before removing the theme completely, it looks like the repo is still correct and the demo link was reused for a different theme