### PR TITLE
Make mobile nav resources drop-down animated

### DIFF
--- a/src/components/HeaderDrawerContent.astro
+++ b/src/components/HeaderDrawerContent.astro
@@ -1,9 +1,6 @@
 ---
 import siteInfo from "~/data/site-info.js"
-import ChevronIcon from "~/icons/ChevronIcon.jsx"
-import LayersIcon from "~/icons/LayersIcon.jsx"
-import OpenBookIcon from "~/icons/OpenBookIcon.jsx"
-import PaletteIcon from "~/icons/PaletteIcon.jsx"
+import ResourcesDropdown from "./ResourcesDropdown.tsx"
 import SocialLinks from "./SocialLinks.astro"
 
 const socialLinks = siteInfo.socialLinks.filter((link) => !link.footerOnly)
@@ -15,26 +12,7 @@ const socialLinks = siteInfo.socialLinks.filter((link) => !link.footerOnly)
 >
 	<a href="https://docs.astro.build/" class="link"> Docs</a>
 	<a href="/showcase/" data-astro-prefetch class="link"> Showcase</a>
-	<details class="group">
-		<summary class="accordion link flex cursor-pointer list-none items-center justify-between">
-			Resources
-			<ChevronIcon class="inline-block rotate-0 transition-transform group-open:-rotate-180" />
-		</summary>
-		<div class="mt-4 flex flex-col gap-4 text-2xl font-light">
-			<a href="/themes/" data-astro-prefetch class="link flex items-center gap-4">
-				<PaletteIcon /> Themes
-			</a>
-			<a href="/integrations/" data-astro-prefetch class="link flex items-center gap-4">
-				<LayersIcon /> Integrations
-			</a>
-			<a
-				href="https://docs.astro.build/en/tutorial/0-introduction/"
-				class="link flex items-center gap-4"
-			>
-				<OpenBookIcon /> Tutorials
-			</a>
-		</div>
-	</details>
+	<ResourcesDropdown client:idle />
 	<a href="/blog/" data-astro-prefetch class="link"> Blog</a>
 	<div class="flex flex-col gap-6">
 		<SocialLinks links={socialLinks} />

--- a/src/components/ResourcesDropdown.tsx
+++ b/src/components/ResourcesDropdown.tsx
@@ -1,0 +1,54 @@
+import { createEffect, createSignal } from "solid-js"
+import ChevronIcon from "~/icons/ChevronIcon.jsx"
+import LayersIcon from "~/icons/LayersIcon.jsx"
+import OpenBookIcon from "~/icons/OpenBookIcon.jsx"
+import PaletteIcon from "~/icons/PaletteIcon.jsx"
+import Collapse from "./Collapse.tsx"
+
+export default function ResourcesDropdown() {
+	const [open, setOpen] = createSignal(false)
+	const details = (
+		// includes "p-6 border-t-[1px] border-astro-gray-500"
+		// because astro-island blocks these styles from being applied
+		<details
+			class="group border-t-[1px] border-astro-gray-500 p-6"
+			onClick={(event) => {
+				event.preventDefault()
+				setOpen(!open())
+			}}
+		>
+			<summary class="accordion link flex cursor-pointer list-none items-center justify-between">
+				Resources
+				<ChevronIcon class="inline-block rotate-0 transition-transform group-open:-rotate-180" />
+			</summary>
+
+			<Collapse
+				isOpen={open()}
+				onTransitionEnd={() => {
+					if (details.open && !open()) details.open = false
+				}}
+			>
+				<div class="mt-4 flex flex-col gap-4 text-2xl font-light">
+					<a href="/themes/" data-astro-prefetch class="link flex items-center gap-4">
+						<PaletteIcon /> Themes
+					</a>
+					<a href="/integrations/" data-astro-prefetch class="link flex items-center gap-4">
+						<LayersIcon /> Integrations
+					</a>
+					<a
+						href="https://docs.astro.build/en/tutorial/0-introduction/"
+						class="link flex items-center gap-4"
+					>
+						<OpenBookIcon /> Tutorials
+					</a>
+				</div>
+			</Collapse>
+		</details>
+	) as HTMLDetailsElement
+
+	createEffect(() => {
+		if (open()) details.open = true
+	})
+
+	return details
+}


### PR DESCRIPTION
[astro.build](astro.build) has some great animated collapsable elements already.

<img width="401" alt="Screenshot 2024-01-07 at 1 52 57 PM" src="https://github.com/withastro/astro.build/assets/8485687/19cd3c69-bad2-49fe-a9c0-58b1f357cf06">

Using the site on mobile, I noticed the mobile nav could reuse this animation too!

## Before

https://github.com/withastro/astro.build/assets/8485687/7e287b4c-f044-4297-87f3-f0f1cded2b28

_(Notice there is also FOUC on the first open. Seems like the font loads in too late?)_

## After

https://github.com/withastro/astro.build/assets/8485687/06c2693d-7a23-4dcb-ab6e-29e4a6a22f86

## Future Considerations

The desktop version of the site works great with JavaScript disabled. However, the existing mobile nav hamburger button does not work with JavaScript disabled. If we want the mobile site to work well without JavaScript, this may need to be slightly modified too.

The existing `Collapse` component does not currently respect `prefers-reduced-motion`. I imagine the `Collapse` component can be changed to support this in a future MR.

The sidebar drop downs in Docusaurus and Nextra docs have nice animations like this, but Astro Starlight does not. Maybe this effect could be reused in Astro Starlight in some nice way?