### PR TITLE
fix inline code and link style collision

### DIFF
--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -62,6 +62,11 @@
 		@apply mx-0.5 inline-block rounded-lg bg-astro-gray-500 px-2 align-baseline text-sm leading-6 text-astro-gray-100;
 	}
 
+	.prose > p a > code {
+		@apply text-inherit;
+		text-decoration: inherit;
+	}
+
 	.prose > pre {
 		@apply my-6 rounded-md border border-astro-gray-400 bg-transparent px-5 py-3 text-sm;
 	}


### PR DESCRIPTION
## Description

- Fixes #955 

### Before
<img width="728" alt="image" src="https://github.com/withastro/astro.build/assets/46791833/62fc5c80-d532-4310-a139-e88149dc8ee1">

### After
<img width="736" alt="image" src="https://github.com/withastro/astro.build/assets/46791833/fba11bd9-d22a-47f3-ae23-50d232b4dc46">

*(disregard the font change, local dev couldn't load fonts for some reason)*
