### PR TITLE
feat: add expressive code to style code block diffs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,8 +3,9 @@ import sitemap from "@astrojs/sitemap"
 import solidJs from "@astrojs/solid-js"
 import tailwind from "@astrojs/tailwind"
 import vercel from "@astrojs/vercel/serverless"
+import astroExpressiveCode from "astro-expressive-code"
 import { defineConfig } from "astro/config"
-import fs from "node:fs"
+import houston from "./houston.theme.json"
 
 /* https://vercel.com/docs/projects/environment-variables/system-environment-variables#system-environment-variables */
 const VERCEL_PREVIEW_SITE =
@@ -20,14 +21,13 @@ export default defineConfig({
 			applyBaseStyles: false,
 		}),
 		solidJs(),
+		astroExpressiveCode({
+			themes: [houston],
+			frames: false,
+		}),
 		mdx(),
 		sitemap(),
 	],
-	markdown: {
-		shikiConfig: {
-			theme: JSON.parse(fs.readFileSync("./houston.theme.json", { encoding: "utf-8" })),
-		},
-	},
 	image: {
 		domains: ["v1.screenshot.11ty.dev"],
 	},

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@astrojs/tailwind": "^5.0.3",
     "@fontsource-variable/inter": "^5.0.16",
     "astro": "^4.0.4",
+    "astro-expressive-code": "^0.32.0",
     "chart.js": "4.4.1",
     "clsx": "^2.0.0",
     "gray-matter": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   astro:
     specifier: ^4.0.4
     version: 4.0.4(@types/node@20.10.4)(typescript@5.3.3)
+  astro-expressive-code:
+    specifier: ^0.32.0
+    version: 0.32.0(astro@4.0.4)
   chart.js:
     specifier: 4.4.1
     version: 4.4.1
@@ -710,6 +713,11 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
+  /@ctrl/tinycolor@3.6.1:
+    resolution: {integrity: sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==}
+    engines: {node: '>=10'}
+    dev: false
+
   /@emmetio/abbreviation@2.3.3:
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
     dependencies:
@@ -946,6 +954,38 @@ packages:
     resolution: {integrity: sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
+
+  /@expressive-code/core@0.32.0:
+    resolution: {integrity: sha512-CB3LFbxXBJHalXWrEQgAtYamntgGOvhFO9vjsA/bkjlyshIrqgavo0mWV3uIRZH/RGQFfeL+j5SBlF9W2nwgvQ==}
+    dependencies:
+      '@ctrl/tinycolor': 3.6.1
+      hast-util-to-html: 8.0.4
+      hastscript: 7.2.0
+      postcss: 8.4.32
+      postcss-nested: 6.0.1(postcss@8.4.32)
+    dev: false
+
+  /@expressive-code/plugin-frames@0.32.0:
+    resolution: {integrity: sha512-4PjHO4cLpDqeA1xjZvawwXi10BG6vBggVqBU6cV5/3xpkkVAyjLfxlJWWXKbvUEs++TBav4BDCB81fRFeqEorA==}
+    dependencies:
+      '@expressive-code/core': 0.32.0
+      hastscript: 7.2.0
+    dev: false
+
+  /@expressive-code/plugin-shiki@0.32.0:
+    resolution: {integrity: sha512-EsH59cDdXdxxOsIDv0bflvBYptUxCm7FsfVTk4PJMnZx6mecosH+m6WA0pSo4FgyA+SCnf/4XkoiaLvPWADoLw==}
+    dependencies:
+      '@expressive-code/core': 0.32.0
+      shikiji: 0.8.7
+    dev: false
+
+  /@expressive-code/plugin-text-markers@0.32.0:
+    resolution: {integrity: sha512-iXFHucBKfwB5hiCrkKPAd5DmOfSFhpSJSdyJG/fNj7IuqDW7Ezy8SCZJcE8xwQvXs9NQtKWbQr3KWPLIs2U4OQ==}
+    dependencies:
+      '@expressive-code/core': 0.32.0
+      hastscript: 7.2.0
+      unist-util-visit-parents: 5.1.3
+    dev: false
 
   /@fastify/busboy@2.1.0:
     resolution: {integrity: sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==}
@@ -1503,6 +1543,12 @@ packages:
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
+  /@types/hast@2.3.9:
+    resolution: {integrity: sha512-pTHyNlaMD/oKJmS+ZZUyFUcsZeBZpC0lmGquw98CqRVNgAdJZJeD7GoeLiT6Xbx5rU9VCjSt0RwEvDgzh4obFw==}
+    dependencies:
+      '@types/unist': 2.0.10
+    dev: false
+
   /@types/hast@3.0.3:
     resolution: {integrity: sha512-2fYGlaDy/qyLlhidX42wAH0KBi2TCjKMH8CHmBXgRlJ3Y+OXTiqsPQ6IWarZKwF1JoUcAJdPogv1d4b0COTpmQ==}
     dependencies:
@@ -1537,6 +1583,10 @@ packages:
     resolution: {integrity: sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==}
     dependencies:
       undici-types: 5.26.5
+
+  /@types/parse5@6.0.3:
+    resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
+    dev: false
 
   /@types/quill@2.0.14:
     resolution: {integrity: sha512-zvoXCRnc2Dl8g+7/9VSAmRWPN6oH+MVhTPizmCR+GJCITplZ5VRVzMs4+a/nOE3yzNwEZqylJJrMB07bwbM1/g==}
@@ -2031,6 +2081,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /astro-expressive-code@0.32.0(astro@4.0.4):
+    resolution: {integrity: sha512-jSfAFdFFPPeMqV+S9OD6S+EQvYahAX3dCF0hTpwMNUD7qc7ACk6nvSvEBYXJ80U3zhgQPWvrWbYDSZbrwYmA9A==}
+    peerDependencies:
+      astro: ^3.3.0 || ^4.0.0-beta
+    dependencies:
+      astro: 4.0.4(@types/node@20.10.4)(typescript@5.3.3)
+      hast-util-to-html: 8.0.4
+      remark-expressive-code: 0.32.0
+    dev: false
 
   /astro-icon@0.8.2:
     resolution: {integrity: sha512-+LgbDM6ku760pwoRwc7UfkVKy9V+QiRfZory4KzdMqVOYKyKSM1rmJ3CXcR7mezTd4pKJnH+guxR4ySpcn8fGg==}
@@ -3402,6 +3462,15 @@ packages:
     requiresBuild: true
     optional: true
 
+  /expressive-code@0.32.0:
+    resolution: {integrity: sha512-4MNlwDNsAtA2T1YTROQrgj2j6V7yvMDQM8/ShM6bO+B/oD+zHO49GW4adi3PfUF++jHrotRA2fw6ZnngRDQuUA==}
+    dependencies:
+      '@expressive-code/core': 0.32.0
+      '@expressive-code/plugin-frames': 0.32.0
+      '@expressive-code/plugin-shiki': 0.32.0
+      '@expressive-code/plugin-text-markers': 0.32.0
+    dev: false
+
   /extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -3834,6 +3903,18 @@ packages:
       vfile: 6.0.1
       vfile-message: 4.0.2
 
+  /hast-util-from-parse5@7.1.2:
+    resolution: {integrity: sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==}
+    dependencies:
+      '@types/hast': 2.3.9
+      '@types/unist': 2.0.10
+      hastscript: 7.2.0
+      property-information: 6.4.0
+      vfile: 5.3.7
+      vfile-location: 4.1.0
+      web-namespaces: 2.0.1
+    dev: false
+
   /hast-util-from-parse5@8.0.1:
     resolution: {integrity: sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==}
     dependencies:
@@ -3846,10 +3927,32 @@ packages:
       vfile-location: 5.0.2
       web-namespaces: 2.0.1
 
+  /hast-util-parse-selector@3.1.1:
+    resolution: {integrity: sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==}
+    dependencies:
+      '@types/hast': 2.3.9
+    dev: false
+
   /hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
     dependencies:
       '@types/hast': 3.0.3
+
+  /hast-util-raw@7.2.3:
+    resolution: {integrity: sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==}
+    dependencies:
+      '@types/hast': 2.3.9
+      '@types/parse5': 6.0.3
+      hast-util-from-parse5: 7.1.2
+      hast-util-to-parse5: 7.1.0
+      html-void-elements: 2.0.1
+      parse5: 6.0.1
+      unist-util-position: 4.0.4
+      unist-util-visit: 4.1.2
+      vfile: 5.3.7
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+    dev: false
 
   /hast-util-raw@9.0.1:
     resolution: {integrity: sha512-5m1gmba658Q+lO5uqL5YNGQWeh1MYWZbZmWrM5lncdcuiXuo5E2HT/CIOp0rLF8ksfSwiCVJ3twlgVRyTGThGA==}
@@ -3891,6 +3994,22 @@ packages:
       - supports-color
     dev: false
 
+  /hast-util-to-html@8.0.4:
+    resolution: {integrity: sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==}
+    dependencies:
+      '@types/hast': 2.3.9
+      '@types/unist': 2.0.10
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-raw: 7.2.3
+      hast-util-whitespace: 2.0.1
+      html-void-elements: 2.0.1
+      property-information: 6.4.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.3
+      zwitch: 2.0.4
+    dev: false
+
   /hast-util-to-html@9.0.0:
     resolution: {integrity: sha512-IVGhNgg7vANuUA2XKrT6sOIIPgaYZnmLx3l/CCOAK0PtgfoHrZwX7jCSYyFxHTrGmC6S9q8aQQekjp4JPZF+cw==}
     dependencies:
@@ -3929,6 +4048,17 @@ packages:
       - supports-color
     dev: false
 
+  /hast-util-to-parse5@7.1.0:
+    resolution: {integrity: sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==}
+    dependencies:
+      '@types/hast': 2.3.9
+      comma-separated-tokens: 2.0.3
+      property-information: 6.4.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+    dev: false
+
   /hast-util-to-parse5@8.0.0:
     resolution: {integrity: sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==}
     dependencies:
@@ -3940,10 +4070,24 @@ packages:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  /hast-util-whitespace@2.0.1:
+    resolution: {integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==}
+    dev: false
+
   /hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
     dependencies:
       '@types/hast': 3.0.3
+
+  /hastscript@7.2.0:
+    resolution: {integrity: sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==}
+    dependencies:
+      '@types/hast': 2.3.9
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 3.1.1
+      property-information: 6.4.0
+      space-separated-tokens: 2.0.2
+    dev: false
 
   /hastscript@8.0.0:
     resolution: {integrity: sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==}
@@ -3964,6 +4108,10 @@ packages:
 
   /html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  /html-void-elements@2.0.1:
+    resolution: {integrity: sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==}
+    dev: false
 
   /html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -5621,6 +5769,10 @@ packages:
       unist-util-modify-children: 3.1.1
       unist-util-visit-children: 2.0.2
 
+  /parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+    dev: false
+
   /parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
     dependencies:
@@ -6162,6 +6314,14 @@ packages:
       rehype-stringify: 10.0.0
       unified: 11.0.4
 
+  /remark-expressive-code@0.32.0:
+    resolution: {integrity: sha512-Npn7eWuEwHZnE7E8wEnjsqgaalzZOCKP8jn1TSRYCztXHnqBy0S9W7z+1h2MFgujbH26mXnxPirgLkaas8NAzg==}
+    dependencies:
+      expressive-code: 0.32.0
+      hast-util-to-html: 8.0.4
+      unist-util-visit: 4.1.2
+    dev: false
+
   /remark-gfm@4.0.0:
     resolution: {integrity: sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==}
     dependencies:
@@ -6512,6 +6672,12 @@ packages:
     resolution: {integrity: sha512-4T7X39csvhT0p7GDnq9vysWddf2b6BeioiN3Ymhnt3xcy9tXmDcnsEFVxX18Z4YcQgEE/w48dLJ4pPPUcG9KkA==}
     dependencies:
       hast-util-to-html: 9.0.0
+
+  /shikiji@0.8.7:
+    resolution: {integrity: sha512-j5usxwI0yHkDTHOuhuSJl9+wT5CNYeYO82dJMSJBlJ/NYT5SIebGcPoL6y9QOyH15wGrJC4LOP2nz5k8mUDGRQ==}
+    dependencies:
+      hast-util-to-html: 9.0.0
+    dev: false
 
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -7212,6 +7378,12 @@ packages:
       '@types/unist': 3.0.2
     dev: false
 
+  /unist-util-position@4.0.4:
+    resolution: {integrity: sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==}
+    dependencies:
+      '@types/unist': 2.0.10
+    dev: false
+
   /unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
     dependencies:
@@ -7317,6 +7489,13 @@ packages:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
     dev: true
+
+  /vfile-location@4.1.0:
+    resolution: {integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==}
+    dependencies:
+      '@types/unist': 2.0.10
+      vfile: 5.3.7
+    dev: false
 
   /vfile-location@5.0.2:
     resolution: {integrity: sha512-NXPYyxyBSH7zB5U6+3uDdd6Nybz6o6/od9rk8bp9H8GR3L+cm/fC0uUTbqBmUTnMCUDslAGBOIKNfvvb+gGlDg==}

--- a/src/content/blog/astro-025.mdx
+++ b/src/content/blog/astro-025.mdx
@@ -31,7 +31,7 @@ We can't do anything about the first two, but we can make Astro even easier for 
 
 We'll share a lot more on this over the next two weeks, but you can start exploring the new API today [on our docs site.](https://docs.astro.build/en/guides/integrations-guide/). To migrate an existing Astro project to this new API, [read through our migration guide](https://docs.astro.build/en/migrate/#astro-integrations).
 
-```diff
+```diff lang="js"
 // astro.config.js
 + import lit from '@astrojs/lit';
 + import react from '@astrojs/react';

--- a/src/content/blog/astro-150.mdx
+++ b/src/content/blog/astro-150.mdx
@@ -29,7 +29,7 @@ npm run preview
 
 We will be updating the other first party Astro adapters to support preview over time. Adapters can opt-in to this feature by providing the `previewEntrypoint` via the `setAdapter` function in `astro:config:done` hook. The Node.js adapter's code looks like this:
 
-```diff
+```diff lang="js"
 export default function() {
   return {
     name: '@astrojs/node',

--- a/src/content/blog/astro-250.mdx
+++ b/src/content/blog/astro-250.mdx
@@ -29,7 +29,7 @@ First, we've introduced a new `type: 'data'` property to store data formats like
 
 Create data collections alongside your existing content collections:
 
-```diff
+```diff lang="js"
 src/content/
     blog/
         week-1.md

--- a/src/content/blog/astro-420.mdx
+++ b/src/content/blog/astro-420.mdx
@@ -47,7 +47,7 @@ Thanks to [Ross Robino](https://github.com/rossrobino), Astro's `prefetch` featu
 
 To enable this feature, add the following to your `astro.config.mjs` file:
 
-```diff
+```diff lang="js"
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
@@ -83,7 +83,7 @@ With this flag enabled, routes injected using the `injectRoute()` API, as well a
 
 Try the future of Astro today by adding the new `experimental.globalRoutePriority` option to `astro.config.mjs` file to opt-in to the new behavior:
 
-```diff
+```diff lang="js"
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
@@ -104,7 +104,7 @@ A common request since the introduction of [internationalization support in Astr
 
 This is now possible with the new `redirectToDefaultLocale` option:
 
-```diff
+```diff lang="js"
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config

--- a/src/content/blog/netlify-edge-functions.mdx
+++ b/src/content/blog/netlify-edge-functions.mdx
@@ -58,7 +58,7 @@ npm install @astrojs/netlify@latest
 
 Then, update your `astro.config.mjs` to import the edge functions adapter:
 
-```diff
+```diff lang="js"
 import { defineConfig } from 'astro/config';
 - import netlify from '@astrojs/netlify/functions';
 + import netlify from '@astrojs/netlify/edge-functions';

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -67,7 +67,7 @@
 		text-decoration: inherit;
 	}
 
-	.prose > pre {
-		@apply my-6 rounded-md border border-astro-gray-400 bg-transparent px-5 py-3 text-sm;
+	.prose > .expressive-code pre {
+		@apply my-6 rounded-md border border-astro-gray-400;
 	}
 }


### PR DESCRIPTION
## Description

- This PR adds the `astro-expressive-code` integration to add syntax highlight to diff code blocks.
- Adds `lang="js"` metadata to diff codeblocks.
- Updates blog posts with proper code block metadata

### Before

<img width="788" alt="image" src="https://github.com/withastro/astro.build/assets/46791833/c836cd48-eb43-441c-8cb8-81c54f1c80c8">

### After

<img width="795" alt="image" src="https://github.com/withastro/astro.build/assets/46791833/78f1f774-d39c-42cc-aaec-21140eaa7153">
