### PR TITLE
Add `/db/*` redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -90,11 +90,11 @@
     },
     {
       "source": "/db/config/",
-      "destination": "https://docs-git-sarah-patch-6-astrodotbuild.vercel.app/guides/astro-db/#configuration"
+      "destination": "https://docs-git-sarah-patch-6-astrodotbuild.vercel.app/en/guides/astro-db/#configuration"
     },
     {
       "source": "/db/seed/",
-      "destination": "https://docs-git-sarah-patch-6-astrodotbuild.vercel.app/astro-db/#seed-development-data"
+      "destination": "https://docs-git-sarah-patch-6-astrodotbuild.vercel.app/en/astro-db/#seed-development-data"
     },
     {
       "source": "/deprecated/resolve/",

--- a/vercel.json
+++ b/vercel.json
@@ -90,7 +90,7 @@
     },
     {
       "source": "/db/config/",
-      "destination": "https://docs.astro.build/reference/db-configuration/"
+      "destination": "https://docs.astro.build/guides/astro-db/#configuration"
     },
     {
       "source": "/db/seed/",

--- a/vercel.json
+++ b/vercel.json
@@ -90,11 +90,11 @@
     },
     {
       "source": "/db/config/",
-      "destination": "https://docs.astro.build/guides/astro-db/#configuration"
+      "destination": "https://docs-git-sarah-patch-6-astrodotbuild.vercel.app/guides/astro-db/#configuration"
     },
     {
       "source": "/db/seed/",
-      "destination": ""https://docs.astro.build/guides/astro-db/#seed-development-data"
+      "destination": "https://docs-git-sarah-patch-6-astrodotbuild.vercel.app/astro-db/#seed-development-data"
     },
     {
       "source": "/deprecated/resolve/",

--- a/vercel.json
+++ b/vercel.json
@@ -89,6 +89,14 @@
       "destination": "https://docs.astro.build/reference/configuration-reference"
     },
     {
+      "source": "/db/config/",
+      "destination": "https://docs.astro.build/reference/db-configuration/"
+    },
+    {
+      "source": "/db/seed/",
+      "destination": "https://docs.astro.build/guides/db/#seed"
+    },
+    {
       "source": "/deprecated/resolve/",
       "destination": "https://docs.astro.build/en/migrate/#deprecated-astroresolve"
     },

--- a/vercel.json
+++ b/vercel.json
@@ -94,7 +94,7 @@
     },
     {
       "source": "/db/seed/",
-      "destination": "https://docs.astro.build/guides/db/#seed"
+      "destination": ""https://docs.astro.build/guides/astro-db/#seed-development-data"
     },
     {
       "source": "/deprecated/resolve/",


### PR DESCRIPTION
We have an existing `astro.build/config` redirect. Would be nice to have the same for DB stuff!

These are being used in https://github.com/withastro/astro/pull/10349 but don't exist yet.