### PR TITLE
chore: add heading id to pricing section

### DIFF
--- a/src/pages/db/_components/Pricing.astro
+++ b/src/pages/db/_components/Pricing.astro
@@ -6,7 +6,7 @@ import SectionText from "./SectionText.astro"
 ---
 
 <section class="mx-auto w-full max-w-screen-xl space-y-10 p-4 sm:p-8">
-	<SectionText isCentered>
+	<SectionText headingId="pricing" isCentered>
 		<Fragment slot="eyebrow">Pricing</Fragment>
 		<Fragment slot="title">
 			Get started for free,<br />then pay as you grow.

--- a/src/pages/db/_components/SectionText.astro
+++ b/src/pages/db/_components/SectionText.astro
@@ -1,5 +1,10 @@
 ---
-const { isCentered = false } = Astro.props
+type Props = {
+	headingId?: string
+	isCentered?: boolean
+}
+
+const { isCentered = false, headingId } = Astro.props
 ---
 
 <div class:list={["space-y-1", isCentered && "sm:landing-section"]}>
@@ -10,7 +15,7 @@ const { isCentered = false } = Astro.props
 	>
 		<slot name="eyebrow" />
 	</h2>
-	<h3 class:list={["text-balance heading-3 max-w-3xl font-bold heading"]}>
+	<h3 id={headingId} class:list={["text-balance heading-3 max-w-3xl font-bold heading"]}>
 		<slot name="title" />
 	</h3>
 	{


### PR DESCRIPTION
We've received a few questions on pricing. This adds a `#pricing` id to the DB pricing header so we have a permalink: https://astro.build/db#pricing

- Add `headingId` property to `SectionText`
- Apply pricing id