### PR TITLE
chore: add MDX as recommended extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,4 @@
 {
-	"recommendations": ["astro-build.astro-vscode", "biomejs.biome"],
+	"recommendations": ["astro-build.astro-vscode", "biomejs.biome", "unifiedjs.vscode-mdx"],
 	"unwantedRecommendations": []
 }


### PR DESCRIPTION
Adds MDX as a recommended extension, so VSCode / Gitpod users get prompted for an install