### PR TITLE
fix: use compressed images in detail page

### DIFF
--- a/src/components/ImageGallery.astro
+++ b/src/components/ImageGallery.astro
@@ -26,8 +26,9 @@ const { images, class: className, ...attrs } = Astro.props
 						class="relative flex w-full flex-shrink-0 snap-start snap-always items-center justify-center"
 						id={`gallery-${i + 1}`}
 					>
-						<img
+						<Image
 							src={image}
+							inferSize
 							alt=""
 							decoding="async"
 							class="aspect-video h-full w-full object-cover object-top"
@@ -62,8 +63,9 @@ const { images, class: className, ...attrs } = Astro.props
 				images.map((image, i) => (
 					<li>
 						<a href={`#gallery-${i + 1}`} aria-current={i === 0 ? "true" : "false"}>
-							<img
+							<Image
 								src={image}
+								inferSize
 								alt=""
 								class="aspect-video h-full w-full object-cover object-top"
 								decoding="async"

--- a/src/components/ImageGallery.astro
+++ b/src/components/ImageGallery.astro
@@ -66,7 +66,8 @@ const { images, class: className, ...attrs } = Astro.props
 						<a href={`#gallery-${i + 1}`} aria-current={i === 0 ? "true" : "false"}>
 							<Image
 								src={image}
-								inferSize
+								height={900}
+								width={1600}
 								alt=""
 								class="aspect-video h-full w-full object-cover object-top"
 								decoding="async"

--- a/src/components/ImageGallery.astro
+++ b/src/components/ImageGallery.astro
@@ -28,7 +28,8 @@ const { images, class: className, ...attrs } = Astro.props
 					>
 						<Image
 							src={image}
-							inferSize
+							height={900}
+							width={1600}
 							alt=""
 							decoding="async"
 							class="aspect-video h-full w-full object-cover object-top"

--- a/src/pages/themes/_components/ThemeCard.astro
+++ b/src/pages/themes/_components/ThemeCard.astro
@@ -20,7 +20,8 @@ const image = theme.Theme.image
 	<a class="flex h-full flex-col" href={`/themes/details/${theme.Theme.slug}`} data-astro-prefetch>
 		<Image
 			src={image}
-			inferSize
+			width={600}
+			height={400}
 			alt=""
 			class="aspect-video w-full object-cover"
 			loading="lazy"

--- a/src/pages/themes/details/[slug].astro
+++ b/src/pages/themes/details/[slug].astro
@@ -39,7 +39,8 @@ const relatedThemes: Array<any> = await fetch(
 			) : (
 				<Image
 					src={theme.Theme.image}
-					inferSize
+					height={900}
+					width={1600}
 					alt=""
 					class="mx-auto aspect-video w-full border-astro-gray-500 object-cover object-top xl:border-x xl:border-b"
 					decoding="async"


### PR DESCRIPTION
use `astro:assets` in theme detail pages