### PR TITLE
Improve DB intersection observer logic

### DIFF
--- a/src/pages/db/_components/Subnav.astro
+++ b/src/pages/db/_components/Subnav.astro
@@ -68,22 +68,18 @@ import Badge from "./Badge.astro";
 		.map((a) => a.getAttribute("href")?.slice(1))
 		.filter(Boolean);
 	const selector = `:is(${targets.map((id) => `[id="${id}"]`).join(",")})`;
-	const ids: Record<string, number> = {};
+	const ids = new Map<string, number>();
 	const io = new IntersectionObserver(
 		([entry]) => {
-			console.log(
-				entry.target.querySelector(selector),
-				entry.intersectionRatio,
-			);
 			const element = entry.target.querySelector(selector);
 			if (!element) return;
-			const prevRatio = ids[element.id] ?? 0;
+			const prevRatio = ids.get(element.id) ?? 0;
 			if (entry.intersectionRatio > prevRatio) {
 				const link = nav.querySelector(`a[href="#${element.id}"]`);
 				resetSubnav();
 				link?.setAttribute("aria-current", "true");
 			}
-			ids[element.id] = entry.intersectionRatio;
+			ids.set(element.id, entry.intersectionRatio);
 		},
 		{ threshold: [0, 0.4, 0.6, 1] },
 	);

--- a/src/pages/db/_components/Subnav.astro
+++ b/src/pages/db/_components/Subnav.astro
@@ -67,18 +67,23 @@ import Badge from "./Badge.astro";
 	const targets = Array.from(nav.querySelectorAll("a[href^='#']"))
 		.map((a) => a.getAttribute("href")?.slice(1))
 		.filter(Boolean);
+	const selector = `:is(${targets.map((id) => `[id="${id}"]`).join(",")})`;
+	const ids: Record<string, number> = {};
 	const io = new IntersectionObserver(
 		([entry]) => {
-			if (entry.intersectionRatio > 0.5) {
-				const element = entry.target.querySelector(
-					`:is(${targets.map((id) => `[id="${id}"]`).join(",")})`,
-				);
-				if (element) {
-					const link = nav.querySelector(`a[href="#${element.id}"]`);
-					resetSubnav();
-					link?.setAttribute("aria-current", "true");
-				}
+			console.log(
+				entry.target.querySelector(selector),
+				entry.intersectionRatio,
+			);
+			const element = entry.target.querySelector(selector);
+			if (!element) return;
+			const prevRatio = ids[element.id];
+			if (entry.intersectionRatio > prevRatio) {
+				const link = nav.querySelector(`a[href="#${element.id}"]`);
+				resetSubnav();
+				link?.setAttribute("aria-current", "true");
 			}
+			ids[element.id] = entry.intersectionRatio;
 		},
 		{ threshold: [0, 0.4, 0.6, 1] },
 	);

--- a/src/pages/db/_components/Subnav.astro
+++ b/src/pages/db/_components/Subnav.astro
@@ -77,7 +77,7 @@ import Badge from "./Badge.astro";
 			);
 			const element = entry.target.querySelector(selector);
 			if (!element) return;
-			const prevRatio = ids[element.id];
+			const prevRatio = ids[element.id] ?? 0;
 			if (entry.intersectionRatio > prevRatio) {
 				const link = nav.querySelector(`a[href="#${element.id}"]`);
 				resetSubnav();


### PR DESCRIPTION
The `IntersectionObserver` logic added to `/db` in #1059 consistently skipped highlighting the **Features** section. 

This PR refactors the logic to track the delta between ratios rather than using a naive `entry.isIntersecting` check.

Tiny perf improvement by hoisting the `selector` variable up, too.