### PR TITLE
Adjust main CTA link

### DIFF
--- a/src/pages/_components/Hero.astro
+++ b/src/pages/_components/Hero.astro
@@ -30,7 +30,7 @@ const logos = [
 	</PageTitleBlock>
 
 	<div class="mb-14 mt-8 flex w-full justify-center gap-6 sm:mb-16 md:mb-20 lg:mb-24 xl:mb-28">
-		<ExternalLink href="https://docs.astro.build/" class="button button-white">
+		<ExternalLink href="https://docs.astro.build/en/install/auto/" class="button button-white">
 			Get Started
 		</ExternalLink>
 		<div class="hidden sm:block">


### PR DESCRIPTION
Rather than linking the main CTA to https://docs.astro.build (which is another landing page), we should link directly to https://docs.astro.build/en/install/auto/. 

This PR implements that change.