### PR TITLE
Add meetup banner

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import { Sprite } from "astro-icon";
+import NotificationBanner from "~/components/NotificationBanner.astro";
 import MainLayout from "~/layouts/MainLayout.astro";
 import ContentFirstFast from "./_components/ContentFirstFast.astro";
 import FrontendArchitecture from "./_components/FrontendArchitecture.astro";
@@ -11,7 +12,18 @@ import ToolingAndEcosystem from "./_components/ToolingAndEcosystem.astro";
 ---
 
 <Sprite.Provider>
-	<MainLayout image={{ src: "/og/astro.jpg", alt: "Astro - Build the web you want." }}>
+	<MainLayout
+		image={{ src: "/og/astro.jpg", alt: "Astro - Build the web you want." }}
+	>
+		<NotificationBanner uid="astro-together-2024">
+			Join us and 100+ Astro developers at
+			<a
+				style="whitespace-nowrap"
+				href="https://lu.ma/astro-together-meetup-2024"
+				>Astro Together</a
+			>
+			 in Montreal on <time datetime="2024-05-28">May 28th</time>!
+		</NotificationBanner>
 		<Hero />
 		<div class="relative">
 			<div class="bg-grid absolute inset-0 z-grid"></div>


### PR DESCRIPTION
Follow-up to #1088, which broke for unknown reasons.

Implements a banner announcement for [**Astro Together**](https://lu.ma/astro-together-meetup-2024/). Please join us and 100+ Astro developer in Montreal on May 28th!


![CleanShot 2024-05-07 at 14 01 10@2x](https://github.com/withastro/astro.build/assets/7118177/6c926d51-e0ae-486b-acc0-ba1050b54fee)


