### PR TITLE
Revert "Adjust main CTA link (#1089)"

### DIFF
--- a/src/pages/_components/Hero.astro
+++ b/src/pages/_components/Hero.astro
@@ -30,7 +30,7 @@ const logos = [
 	</PageTitleBlock>
 
 	<div class="mb-14 mt-8 flex w-full justify-center gap-6 sm:mb-16 md:mb-20 lg:mb-24 xl:mb-28">
-		<ExternalLink href="https://docs.astro.build/en/install/auto/" class="button button-white">
+		<ExternalLink href="https://docs.astro.build/" class="button button-white">
 			Get Started
 		</ExternalLink>
 		<div class="hidden sm:block">


### PR DESCRIPTION
This restores the main CTA link back to pointing to the main docs landing page which offers users a more holistic set of options and information to get started with Astro.

The CTA was originally changed to avoid a double “Get started” => “Get started” sequence of CTAs when linking to the docs homepage, but we are updating that in https://github.com/withastro/docs/pull/8222 to add a better CTA once users land in docs.