### PR TITLE
fix: CSRF typo in 4.9 blog post

### DIFF
--- a/src/content/blog/astro-490.mdx
+++ b/src/content/blog/astro-490.mdx
@@ -132,7 +132,7 @@ To learn more about Astro Actions, and to offer feedback on this experimental AP
 
 ## Stabilized experimental features
 
-This release stabilizes the CRSF protection (introduced in [Astro 4.6](/blog/astro-460/#experimental-support-for-csrf-protection)) and i18n domains support (introduced in [Astro 4.3](/blog/astro-430/#experimental-add-domain-support-for-i18n)) features. It is no longer necessary to enable the `experimental.csrfProtection` and `experimental.i18nDomains` options in your Astro config to use these features.
+This release stabilizes the CSRF protection (introduced in [Astro 4.6](/blog/astro-460/#experimental-support-for-csrf-protection)) and i18n domains support (introduced in [Astro 4.3](/blog/astro-430/#experimental-add-domain-support-for-i18n)) features. It is no longer necessary to enable the `experimental.csrfProtection` and `experimental.i18nDomains` options in your Astro config to use these features.
 
 The `experimental.security.csrfProtection` option has been removed in favor of a new `security.checkOrigin` option. To enable cross-site request forgery protection, set `security.checkOrigin` to `true` in your Astro config and remove the `experimental.security.csrfProtection` option if you have it enabled:
 


### PR DESCRIPTION
Fixes a small typo (CRSF -> CSRF) in the 4.9 blog post.