### PR TITLE
Update @sentryastro.md

### DIFF
--- a/src/content/integrations/@sentryastro.md
+++ b/src/content/integrations/@sentryastro.md
@@ -6,7 +6,7 @@ categories:
   - "css+ui"
 npmUrl: "https://www.npmjs.com/package/@sentry/astro"
 repoUrl: "https://github.com/getsentry/sentry-javascript"
-homepageUrl: "https://github.com/getsentry/sentry-javascript/tree/master/packages/astro"
+homepageUrl: "https://docs.sentry.io/platforms/javascript/guides/astro/"
 image: "/assets/integrations/sentry.svg"
 downloads: 18526
 ---


### PR DESCRIPTION
On Astro build there is a link to set up an integration with Sentry, but it doesn't take the developer to the most useful page.

https://astro.build/integrations/?search=sentry

Should take the developer here, for the latest info on the Sentry Astro SDK