### PR TITLE
Fix Pill Link to Astro v4.10 release blog post

### DIFF
--- a/src/pages/_components/Hero.astro
+++ b/src/pages/_components/Hero.astro
@@ -16,7 +16,7 @@ const logos = [
 ---
 
 <section class="landing-section relative overflow-x-hidden pb-40 pt-14 sm:pt-20 lg:pt-32">
-    <PillLink href='/db' title='Astro 4.10' subtitle='New "astro:env" environment variable management' class="mb-8" /> 
+    <PillLink href='https://astro.build/blog/astro-4100/' title='Astro 4.10' subtitle='New "astro:env" environment variable management' class="mb-8" /> 
 	<PageTitleBlock
 		lg
 		body="Astro powers the world's fastest websites, client-side web apps, dynamic API endpoints, and everything in-between."


### PR DESCRIPTION
The Pill currently links to the previous content's resource.

Users would expect to read about the 4.10 release instead of being redirected to Astro DB on clicking on the Pill.