### PR TITLE
Fixing Footer Link for Terms and Conditions Link broken

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -58,7 +58,7 @@ const groups: LinkGroup[] = [
 		title: "Legal",
 		links: [
 			{ label: "Privacy Policy", href: "/privacy/" },
-			{ label: "Terms of Service", href: "terms" },
+			{ label: "Terms of Service", href: "/terms/" },
 		],
 	},
 ];


### PR DESCRIPTION
As title, it keeps appending terms when clicking to the end of the url.