### PR TITLE
Fix footer margin & background colours

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,6 +3,12 @@ import siteInfo from "~/data/site-info.js";
 import NewsLetterSignup from "./NewsLetterSignup.astro";
 import SocialLinks from "./SocialLinks.astro";
 
+interface Props {
+	bgClass?: string;
+}
+
+const { bgClass = 'bg-dark' } = Astro.props;
+
 type Link = {
 	href: string;
 	label: string;
@@ -67,7 +73,10 @@ const socialLinks = siteInfo.socialLinks;
 ---
 
 <footer
-	class="mt-20 sm:mt-36 w-full bg-astro-dark-800 border-t border-astro-dark-100/20"
+	class:list={[
+		"w-full border-t border-astro-dark-100/20",
+		bgClass,
+	]}
 >
 	<div class="w-full max-w-screen-2xl mx-auto px-4 sm:px-8">
 		<nav

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -21,6 +21,7 @@ const { bgClass = 'bg-black', header = "default", ...head } = Astro.props;
   class:list={[
     "astro-gray-700 overflow-x-hidden break-words text-astro-gray-100 [color-scheme:dark] [word-break:break-word]",
     bgClass,
+    Astro.props.class,
   ]}
 >
   <head>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -9,9 +9,10 @@ import "~/styles/tailwind.css";
 
 interface Props extends HeadProps, HeaderProps {
 	class?: string;
+  bgClass?: string;
 }
 
-const { class: classList, header = "default", ...head } = Astro.props;
+const { bgClass = 'bg-black', header = "default", ...head } = Astro.props;
 ---
 
 <!doctype html>
@@ -19,7 +20,7 @@ const { class: classList, header = "default", ...head } = Astro.props;
   lang="en"
   class:list={[
     "astro-gray-700 overflow-x-hidden break-words text-astro-gray-100 [color-scheme:dark] [word-break:break-word]",
-    classList || "bg-astro-dark-900",
+    bgClass,
   ]}
 >
   <head>
@@ -31,7 +32,7 @@ const { class: classList, header = "default", ...head } = Astro.props;
       id="nav"
       class:list={{
         "inset-x-0 top-0 z-20 max-h-screen": true,
-        "sticky bg-astro-dark-900/30 backdrop-blur-xl": header === "default",
+        "sticky bg-black-900/30 backdrop-blur-xl": header === "default",
         absolute: header === "transparent",
       }}
     >
@@ -46,7 +47,7 @@ const { class: classList, header = "default", ...head } = Astro.props;
     <main id="main" class="relative z-10 flex flex-1 flex-col">
       <slot />
     </main>
-    <Footer />
+    <Footer {bgClass} />
   </body>
 </html>
 

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -32,7 +32,7 @@ const { bgClass = 'bg-black', header = "default", ...head } = Astro.props;
       id="nav"
       class:list={{
         "inset-x-0 top-0 z-20 max-h-screen": true,
-        "sticky bg-black-900/30 backdrop-blur-xl": header === "default",
+        "sticky bg-black/30 backdrop-blur-xl": header === "default",
         absolute: header === "transparent",
       }}
     >

--- a/src/pages/db/index.astro
+++ b/src/pages/db/index.astro
@@ -14,7 +14,8 @@ const description = "The SQL database platform for content-driven websites.";
 ---
 
 <MainLayout
-  class="bg-[#060913] scroll-pt-[7.5rem] scroll-smooth"
+  bgClass="bg-[#060913]"
+  class="scroll-pt-[7.5rem] scroll-smooth"
   header="transparent"
   rawTitle={title}
   description={description}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ import Sponsors from "./_components/landing-page/Sponsors.astro";
 
 <Sprite.Provider>
   <MainLayout
-    class="bg-astro-dark-900"
+    bgClass="bg-astro-dark-900"
     image={{ src: "/og/astro.jpg", alt: "Astro - Build the web you want." }}
   >
     <Hero />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,6 +13,7 @@ import Sponsors from "./_components/landing-page/Sponsors.astro";
 
 <Sprite.Provider>
   <MainLayout
+    class="bg-astro-dark-900"
     image={{ src: "/og/astro.jpg", alt: "Astro - Build the web you want." }}
   >
     <Hero />
@@ -24,5 +25,6 @@ import Sponsors from "./_components/landing-page/Sponsors.astro";
     <Ecosystem />
     <FinalCTA />
     <Sponsors />
+    <div class="h-20 sm:h-36" />
   </MainLayout>
 </Sprite.Provider>


### PR DESCRIPTION
Hot fix for a few issues introduced by #1110.

- Removes margin top from the Footer — this worked on the homepage but broke other layouts. Hotfix is a quick spacer div in the homepage layout so that that view is spaced correctly without breaking other pages

- Reverts the move to use a new `astro-dark` palette in some of our core layout components that was bleeding into other pages in ways that didn’t quite work. The homepage is still using this, but the other layouts use the background from before until a more comprehensive palette migration in those other views can be implemented (if indeed that is the goal)