### PR TITLE
Fix nightly CI

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,7 +23,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Format generated files
-        run: pnpm lint:prettier
+        run: pnpm lint
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
#1038 removed the `lint:prettier` script, but our Nightly CI was still using it, causing it to fail ever since (e.g. https://github.com/withastro/astro.build/actions/runs/9580083120/job/26413945456)

This PR updates the CI workflow to use the newer `lint` script that runs Biome instead.