### PR TITLE
fixes broken URL in May 2024 blog post

### DIFF
--- a/src/content/blog/whats-new-may-2024.mdx
+++ b/src/content/blog/whats-new-may-2024.mdx
@@ -114,10 +114,11 @@ The latest community-built utilities and integrations to help you build with Ast
 
 Several new Astro themes were added to the [Astro theme directory](https://astro.build/themes/) this month. Try them out!
 
-<ThemeGrid themes={[ 'quartiere', 'bsaas-astro-website-template-for-startup-saas', 'astro-simple-portfolio','atlas',]} />
+<ThemeGrid themes={['bsaas-astro-website-template-for-startup-saas', 'astro-simple-portfolio','atlas',]} />
 
 Also check out:
 
+- [Quartiere](https://lexingtonthemes.com/info/quartiere/) by @LexingtonThemes
 - [LaunchFast Blog CMS Template](https://twitter.com/rishi_raj_jain_/status/1785573947121262733) by @rishirajjain
 - [blahg](https://github.com/cassidoo/blahg) by @cassidoo
 - [Beginner Astro Starter Kit](https://github.com/BuckyBuck135/Beginner-Astro-v4-Starter-Kit) by @buckybuck135


### PR DESCRIPTION
This moves a theme from the themes component to a text link because the link in the themes catalogue is broken