### PR TITLE
A minor typo regarding WordPress on homepage

### DIFF
--- a/src/pages/_components/landing-page/Islands.astro
+++ b/src/pages/_components/landing-page/Islands.astro
@@ -29,7 +29,7 @@ import IslandGraphic from "./IslandGraphic.astro";
         glow
       />
       <IslandGraphic
-        label="Wordpress"
+        label="WordPress"
         score="38"
         src="/logos/wordpress.svg"
       />


### PR DESCRIPTION
It's WordPress, not Wordpress. Overall the WP community is quite strict about this - there is even a function `capital_P_dangit` that changes Wordpress to WordPress in WP core.

Sorry for this PR (as it's a bit shitty and don't want to be a person that writes "use capital P", but...). Thanks :)

