### PR TITLE
Adjust timeout for showcase screenshots

### DIFF
--- a/scripts/update-showcase.mjs
+++ b/scripts/update-showcase.mjs
@@ -347,7 +347,7 @@ class ShowcaseScraper {
 		console.log("Waiting for page to settle");
 		await page.evaluate(() => {
 			return new Promise((resolve) => {
-				setTimeout(() => requestAnimationFrame(() => requestIdleCallback(resolve)), 2000);
+				setTimeout(() => requestAnimationFrame(() => requestIdleCallback(resolve, { timeout: 2000 })), 2000);
 			});
 		});
 		console.log("Getting title");


### PR DESCRIPTION
**Summary:**

Adds the [timeout option](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback#timeout) to the `requestIdleCallback` when getting screenshots for showcase sites.

**Background:**

After opening #1157, I added a site to https://github.com/withastro/roadmap/discussions/521#discussioncomment-9904855, then ran the update-showcase script locally to see things run. The script timed out on the new site, due to requestIdleCallback not resolving. This probably has something to do with animations running on load and an idle state never being reached for this particular site.

Before | After
--- | ---
<img width="659" alt="image" src="https://github.com/withastro/astro.build/assets/283397/9b707f70-685d-4d3b-9b31-44802c083cfc"> | <img width="656" alt="image" src="https://github.com/withastro/astro.build/assets/283397/687d6197-0992-4a29-b70a-3ad040521e09">
