### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->
+
+## Browser Test Checklist
+
+<!--
+Test on as many of these browsers as you can, ideally 3+ of them.
+
+Tests for all browsers are **strongly recommended** if this PR includes:
+
+- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
+- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
+- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
+-->
+
+I have tested this PR on at least three of the following browsers:
+
+- [ ] Chrome / Chromium
+- [ ] Firefox
+- [ ] Android Firefox
+- [ ] Safari
+- [ ] iOS Safari
+


### PR DESCRIPTION
Adds a PR template to encourage cross-browser tests

We've missed a decent number of edge cases off of Chrom[e/ium] when merging in major cross-site changes. Hopefully putting this here front-and-center can help reduce regressions

I made the requirement a _recommendation_ for testing on three or more browsers. Enforcing testing for all changes on every browser seems excessive, especially for smaller changes, and especially for those who don't have access to each browser.