### PR TITLE
Removing some unnecessary meta tags, "mask-icon" and quick fixes

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -35,8 +35,6 @@ const resolvedImage = {
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
 <title set:html={smartypants(title, 1)} />
-<meta name="generator" content={Astro.generator} />
-<meta name="theme-color" content="#8D46E7" />
 
 <!-- Fathom - beautiful, simple website analytics -->
 <script is:inline src="https://cdn.usefathom.com/script.js" data-site="EZBHTSIG" defer></script>
@@ -47,9 +45,11 @@ const resolvedImage = {
 
 <!-- Low Priority Global Metadata -->
 <Favicon />
-<link rel="mask-icon" href="/favicon.svg" color="#8D46E7" />
 <link rel="sitemap" href="/sitemap-index.xml" />
 <link rel="alternate" type="application/rss+xml" href="/rss.xml" title="RSS" />
+
+<meta name="generator" content={Astro.generator} />
+<meta name="theme-color" content="#8D46E7" />
 
 <SEO
 	name={siteInfo.name}

--- a/src/components/BlogSummary.astro
+++ b/src/components/BlogSummary.astro
@@ -1,7 +1,3 @@
----
-
----
-
 <p class="text-xl">
 	<strong><slot /></strong>
 </p>

--- a/src/components/CardBadge.astro
+++ b/src/components/CardBadge.astro
@@ -1,7 +1,3 @@
----
-
----
-
 <p
 	class="code absolute right-0 top-0 m-px -translate-y-px translate-x-px rounded-b-md bg-orange-yellow-gradient px-3 py-1 text-sm font-bold uppercase tracking-widest text-astro-gray-700"
 >

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -44,11 +44,6 @@ const og = {
 
 const twitter = {
 	name,
-	title,
-	description,
-	canonicalURL,
-	image,
-	locale,
 	card: "summary_large_image",
 	...Astro.props.twitter,
 } satisfies Twitter;
@@ -86,8 +81,3 @@ function formatCanonicalURL(url: string | URL) {
 <!-- Twitter Tags -->
 {twitter.card && <meta name="twitter:card" content={twitter.card} />}
 {twitter.handle && <meta name="twitter:site" content={twitter.handle} />}
-
-<meta name="twitter:title" content={twitter.title} />
-<meta name="twitter:description" content={twitter.description} />
-{twitter.image && <meta name="twitter:image" content={twitter.image.src} />}
-{twitter.image && <meta name="twitter:image:alt" content={twitter.image.alt} />}

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -16,18 +16,15 @@ const { bgClass = "bg-black", header = "default", ...head } = Astro.props;
 ---
 
 <!doctype html>
-<html
-  lang="en"
-  class:list={[
-    "astro-gray-700 overflow-x-hidden break-words text-astro-gray-100 [color-scheme:dark] [word-break:break-word]",
-    bgClass,
-    Astro.props.class,
-  ]}
->
+<html lang="en">
   <head>
     <BaseHead {...head} />
   </head>
-  <body class="flex min-h-screen max-w-screen flex-col overflow-x-hidden">
+  <body class:list={[
+    "astro-gray-700 overflow-x-hidden break-words text-astro-gray-100 [color-scheme:dark] [word-break:break-word]",
+    bgClass,
+    Astro.props.class,
+  ]} class="flex min-h-screen max-w-screen flex-col overflow-x-hidden">
     <SkipLink />
     <div
       id="nav"

--- a/src/layouts/Standalone.astro
+++ b/src/layouts/Standalone.astro
@@ -11,14 +11,11 @@ const { ...head } = Astro.props;
 ---
 
 <!doctype html>
-<html
-	lang="en"
-	class="astro-gray-700 overflow-x-hidden break-words bg-black text-astro-gray-100 [color-scheme:dark] [word-break:break-word]"
->
+<html lang="en">
 	<head>
 		<BaseHead {...head} />
 	</head>
-	<body>
+	<body class="astro-gray-700 overflow-x-hidden break-words bg-black text-astro-gray-100 [color-scheme:dark] [word-break:break-word]">
 		<div class="flex min-h-screen flex-col overflow-x-hidden">
 			<SkipLink />
 			<div id="nav" class="sticky top-0 z-20 max-h-screen bg-black">


### PR DESCRIPTION
1. Removing some "twitter" meta tags in order to use OG tags as fallback and reducing code size.
2. Removing unnecessary script (---) in some files.
3. Re-arranging "generator" and "theme-color" tags to load important resources faster (script, styles, fonts).
4. Removing "mask-icon" because it's unnecessary.
5. Changing class attribute from `html` to `body`, because the only elements that effected are flow and content elements which live under `body` element, so it's more straightforward and applicable.

Resources for:
OG and Twitter Card:
> Basically, you can use same sub-properties like title, description, image, image:alt, url and so on.

https://ogp.me/
https://developer.x.com/en/docs/twitter-for-websites/cards/guides/getting-started

Re-arranging some tags:
https://github.com/rviscomi/capo.js

Removing "mask-icon":
https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs
```html
<link rel="icon" href="/favicon.ico" sizes="32x32">
<link rel="icon" href="/icon.svg" type="image/svg+xml">
<link rel="apple-touch-icon" href="/apple-touch-icon.png"><!-- 180×180 -->
<link rel="manifest" href="/manifest.webmanifest">
```
and
```js
// manifest.webmanifest
{
  "icons": [
    { "src": "/icon-192.png", "type": "image/png", "sizes": "192x192" },
    { "src": "/icon-512.png", "type": "image/png", "sizes": "512x512" }
  ]
}
```

<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [x] Android Firefox
- [ ] Safari
- [ ] iOS Safari

