### PR TITLE
Integrations catalogue tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
 	"devDependencies": {
 		"@actions/core": "^1.10.1",
 		"@astrojs/check": "^0.5.6",
-		"@astrojs/site-kit": "github:withastro/site-kit",
 		"@astrojs/netlify": "^5.3.5",
+		"@astrojs/site-kit": "github:withastro/site-kit",
 		"@biomejs/biome": "1.7.0",
 		"@octokit/graphql": "^7.0.2",
 		"@types/json-to-pretty-yaml": "1.2.1",
@@ -54,6 +54,8 @@
 		"dotenv": "^16.3.1",
 		"json-to-pretty-yaml": "^1.2.2",
 		"linkedom": "^0.16.4",
+		"mdast-util-from-markdown": "^2.0.1",
+		"mdast-util-to-string": "^4.0.0",
 		"only-allow": "1.2.1",
 		"puppeteer": "^21.6.0",
 		"smartypants": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,12 @@ importers:
       linkedom:
         specifier: ^0.16.4
         version: 0.16.11
+      mdast-util-from-markdown:
+        specifier: ^2.0.1
+        version: 2.0.1
+      mdast-util-to-string:
+        specifier: ^4.0.0
+        version: 4.0.0
       only-allow:
         specifier: 1.2.1
         version: 1.2.1
@@ -3027,7 +3033,6 @@ packages:
 
   libsql@0.3.18:
     resolution: {integrity: sha512-lvhKr7WV3NLWRbXkjn/MeKqXOAqWKU0PX9QYrvDh7fneukapj+iUQ4qgJASrQyxcCrEsClXCQiiK5W6OoYPAlA==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@2.1.0:

--- a/scripts/integrations.mjs
+++ b/scripts/integrations.mjs
@@ -60,11 +60,6 @@ export function badgeForPackage(pkg) {
 	return undefined;
 }
 
-export function getFeaturedPackagePriority(pkg) {
-	const index = integrations.featured.indexOf(pkg) + 1;
-	return index > 0 ? index : undefined;
-}
-
 export function getToolbarPackagePriority(pkg) {
 	const index = integrations.toolbar.indexOf(pkg) + 1;
 	return index > 0 ? index : undefined;

--- a/scripts/markdown.mjs
+++ b/scripts/markdown.mjs
@@ -1,9 +1,11 @@
-const LINK_REGEX = /\[(?<text>.+)\]\((?<url>[^ ]+)(?: "(?<title>.+)")?\)/;
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { toString as mdastToString } from "mdast-util-to-string";
 
-export function stringifyLinks(content) {
-	if (!content) {
-		return undefined;
-	}
-
-	return content.replace(LINK_REGEX, (matched) => LINK_REGEX.exec(matched).groups?.text || matched);
+/**
+ * Convert Markdown content to plain text.
+ * @param content {string | undefined}
+ */
+export function markdownToPlainText(content) {
+	if (!content) return undefined;
+	return mdastToString(fromMarkdown(content));
 }

--- a/scripts/update-integrations.mjs
+++ b/scripts/update-integrations.mjs
@@ -10,7 +10,6 @@ import {
 	badgeForPackage,
 	blocklist,
 	getCategoriesForKeyword,
-	getFeaturedPackagePriority,
 	getOverrides,
 	getToolbarPackagePriority,
 	isNewPackage,
@@ -50,13 +49,11 @@ async function getIntegrationFiles() {
 function normalizePackageDetails(data, pkg) {
 	const keywordCategories = (data.keywords ?? []).flatMap(getCategoriesForKeyword);
 
-	const featured = getFeaturedPackagePriority(pkg);
 	const toolbar = getToolbarPackagePriority(pkg);
 	const official = isOfficial(pkg);
 
 	const otherCategories = [
 		official ? "official" : undefined,
-		featured ? "featured" : undefined,
 		toolbar ? "toolbar" : undefined,
 		isNewPackage(data) ? "recent" : undefined,
 	].filter(Boolean);
@@ -86,14 +83,12 @@ async function fetchWithOverrides(pkg, includeDownloads = true) {
 	const integrationOverrides = getOverrides(pkg) || {};
 
 	const badge = badgeForPackage(details);
-	const featured = getFeaturedPackagePriority(pkg);
 	const toolbar = getToolbarPackagePriority(pkg);
 
 	const newData = {
 		...normalizePackageDetails(details, pkg),
 		...integrationOverrides,
 		badge,
-		featured,
 		toolbar,
 	};
 

--- a/scripts/update-integrations.mjs
+++ b/scripts/update-integrations.mjs
@@ -14,7 +14,7 @@ import {
 	getToolbarPackagePriority,
 	isNewPackage,
 } from "./integrations.mjs";
-import { stringifyLinks } from "./markdown.mjs";
+import { markdownToPlainText } from "./markdown.mjs";
 import { fetchDetailsForPackage, fetchDownloadsForPackage, searchByKeyword } from "./npm.mjs";
 
 function isOfficial(pkg) {
@@ -69,7 +69,7 @@ function normalizePackageDetails(data, pkg) {
 	return {
 		name: data.name,
 		title: data.name,
-		description: stringifyLinks(data.description),
+		description: markdownToPlainText(data.description),
 		categories: uniqCategories,
 		npmUrl,
 		repoUrl,

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -2,7 +2,6 @@ import { defineCollection } from "astro:content";
 import { z } from "zod";
 
 export const IntegrationCategories = new Map([
-	["featured", "Featured"],
 	["recent", "Recently Added"],
 	["official", "Official"],
 	["frameworks", "Frameworks"],
@@ -92,9 +91,9 @@ export const collections = {
 			npmUrl: z.string().url(),
 			homepageUrl: z.string().url().optional(),
 			official: z.boolean().default(false),
-			featured: z.number().min(1).optional(),
 			toolbar: z.number().min(1).optional(),
 			downloads: z.number().min(0).default(0),
+			downloadFactor: z.number().min(0).default(1),
 			badge: z.string().optional(),
 		}),
 	},

--- a/src/content/integrations/@astrojsmdx.md
+++ b/src/content/integrations/@astrojsmdx.md
@@ -5,11 +5,9 @@ description: "Add support for MDX pages in your Astro site"
 categories:
   - "css+ui"
   - "official"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/@astrojs/mdx"
 image: "/assets/integrations/mdx.svg"
 repoUrl: "https://github.com/withastro/astro"
-featured: 14
 homepageUrl: "https://docs.astro.build/en/guides/integrations-guide/mdx/"
 downloads: 339301
 official: true

--- a/src/content/integrations/@astrojspartytown.md
+++ b/src/content/integrations/@astrojspartytown.md
@@ -7,11 +7,9 @@ categories:
   - "analytics"
   - "performance+seo"
   - "official"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/@astrojs/partytown"
 image: "/assets/integrations/partytown.svg"
 repoUrl: "https://github.com/withastro/astro"
-featured: 3
 homepageUrl: "https://docs.astro.build/en/guides/integrations-guide/partytown/"
 downloads: 121940
 official: true

--- a/src/content/integrations/@astrojsprism.md
+++ b/src/content/integrations/@astrojsprism.md
@@ -9,5 +9,7 @@ npmUrl: "https://www.npmjs.com/package/@astrojs/prism"
 repoUrl: "https://github.com/withastro/astro"
 homepageUrl: "https://docs.astro.build/en/reference/api-reference/#prism-"
 downloads: 892250
+# @astrojs/prism is bundled with astro. In reality far fewer people use it than download count suggests
+downloadFactor: 0.0005
 official: true
 ---

--- a/src/content/integrations/@astrojssitemap.md
+++ b/src/content/integrations/@astrojssitemap.md
@@ -6,11 +6,9 @@ categories:
   - "css+ui"
   - "performance+seo"
   - "official"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/@astrojs/sitemap"
 image: "/assets/integrations/sitemap.svg"
 repoUrl: "https://github.com/withastro/astro"
-featured: 8
 homepageUrl: "https://docs.astro.build/en/guides/integrations-guide/sitemap/"
 downloads: 396552
 official: true

--- a/src/content/integrations/@astrojstailwind.md
+++ b/src/content/integrations/@astrojstailwind.md
@@ -5,11 +5,9 @@ description: "Use Tailwind CSS to style your Astro site"
 categories:
   - "css+ui"
   - "official"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/@astrojs/tailwind"
 image: "/assets/integrations/tailwind.svg"
 repoUrl: "https://github.com/withastro/astro"
-featured: 1
 homepageUrl: "https://docs.astro.build/en/guides/integrations-guide/tailwind/"
 downloads: 470144
 official: true

--- a/src/content/integrations/@astropubicons.md
+++ b/src/content/integrations/@astropubicons.md
@@ -4,10 +4,8 @@ title: "@astropub/icons"
 description: "Radix Icons for Astro"
 categories:
   - "css+ui"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/@astropub/icons"
 repoUrl: "https://github.com/astro-community/icons"
-featured: 17
 homepageUrl: "https://github.com/astro-community/icons#readme"
 downloads: 217
 ---

--- a/src/content/integrations/@playformcompress.md
+++ b/src/content/integrations/@playformcompress.md
@@ -5,11 +5,9 @@ description: "🗜️ Compress —"
 categories:
   - "css+ui"
   - "performance+seo"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/@playform/compress"
 image: "/assets/integrations/@playform/compress.svg"
 repoUrl: "https://github.com/PlayForm/Compress"
-featured: 4
 homepageUrl: "HTTPS://GitHub.Com/PlayForm/Compress#readme"
 downloads: 17239
 ---

--- a/src/content/integrations/@storyblokastro.md
+++ b/src/content/integrations/@storyblokastro.md
@@ -4,12 +4,10 @@ title: "@storyblok/astro"
 description: "Official Astro integration for the Storyblok Headless CMS"
 categories:
   - "css+ui"
-  - "featured"
   - "toolbar"
 npmUrl: "https://www.npmjs.com/package/@storyblok/astro"
 image: "/assets/integrations/storyblok.svg"
 repoUrl: "https://github.com/storyblok/storyblok-astro"
-featured: 5
 homepageUrl: "https://github.com/storyblok/storyblok-astro"
 downloads: 11923
 toolbar: 1

--- a/src/content/integrations/@unocssastro.md
+++ b/src/content/integrations/@unocssastro.md
@@ -8,4 +8,6 @@ npmUrl: "https://www.npmjs.com/package/@unocss/astro"
 repoUrl: "https://github.com/unocss/unocss"
 homepageUrl: "https://github.com/unocss/unocss#readme"
 downloads: 975889
+# unocss bundles its Astro integration with all installs, real usage is much lower than the download count suggests
+downloadFactor: 0.02
 ---

--- a/src/content/integrations/accessible-astro-components.md
+++ b/src/content/integrations/accessible-astro-components.md
@@ -5,11 +5,9 @@ description: "A set of Accessible, easy to use, Front-end UI Components for Astr
 categories:
   - "css+ui"
   - "accessibility"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/accessible-astro-components"
 image: "/assets/integrations/accessible-astro-components.png"
 repoUrl: "https://github.com/markteekman/accessible-astro-components"
-featured: 15
 homepageUrl: "https://accessible-astro.netlify.app/accessible-components/"
 downloads: 4100
 url: "https://components.accessible-astro.dev/"

--- a/src/content/integrations/astro-compress.md
+++ b/src/content/integrations/astro-compress.md
@@ -9,4 +9,5 @@ npmUrl: "https://www.npmjs.com/package/astro-compress"
 repoUrl: "https://github.com/PlayForm/Compress"
 homepageUrl: "HTTPS://GitHub.Com/PlayForm/Compress#readme"
 downloads: 85659
+downloadFactor: 0.25
 ---

--- a/src/content/integrations/astro-eleventy-img.md
+++ b/src/content/integrations/astro-eleventy-img.md
@@ -5,10 +5,8 @@ description: "Astro + eleventy-img"
 categories:
   - "css+ui"
   - "performance+seo"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/astro-eleventy-img"
 repoUrl: "https://github.com/Princesseuh/astro-eleventy-img"
-featured: 7
 homepageUrl: "https://github.com/Princesseuh/astro-eleventy-img#readme"
 downloads: 307
 ---

--- a/src/content/integrations/astro-i18next.md
+++ b/src/content/integrations/astro-i18next.md
@@ -5,10 +5,8 @@ description: "An astro integration of i18next + some utility components to help 
 categories:
   - "css+ui"
   - "performance+seo"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/astro-i18next"
 repoUrl: "https://github.com/yassinedoghri/astro-i18next"
-featured: 16
 homepageUrl: "https://astro-i18next.yassinedoghri.com/"
 downloads: 7133
 ---

--- a/src/content/integrations/astro-icon.md
+++ b/src/content/integrations/astro-icon.md
@@ -5,11 +5,9 @@ description: "This Astro integration provides a straight-forward `Icon` componen
 categories:
   - "css+ui"
   - "performance+seo"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/astro-icon"
 image: "/assets/integrations/astro-icon.svg"
 repoUrl: "https://github.com/natemoo-re/astro-icon"
-featured: 6
 homepageUrl: "https://github.com/natemoo-re/astro-icon#readme"
 downloads: 158189
 ---

--- a/src/content/integrations/astro-imagetools.md
+++ b/src/content/integrations/astro-imagetools.md
@@ -5,10 +5,8 @@ description: "Image Optimization tools for the Astro JS framework"
 categories:
   - "css+ui"
   - "performance+seo"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/astro-imagetools"
 repoUrl: "https://github.com/RafidMuhymin/astro-imagetools"
-featured: 2
 homepageUrl: "https://github.com/RafidMuhymin/astro-imagetools#readme"
 downloads: 6531
 ---

--- a/src/content/integrations/astro-json-element.md
+++ b/src/content/integrations/astro-json-element.md
@@ -4,10 +4,8 @@ title: "astro-json-element"
 description: "Create/define HTML elements using JSON objects"
 categories:
   - "css+ui"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/astro-json-element"
 repoUrl: "https://github.com/BryceRussell/astro-json-element"
-featured: 18
 homepageUrl: "https://github.com/BryceRussell/astro-json-element#readme"
 downloads: 63
 ---

--- a/src/content/integrations/astro-robots-txt.md
+++ b/src/content/integrations/astro-robots-txt.md
@@ -5,10 +5,8 @@ description: "Generate a robots.txt for Astro"
 categories:
   - "css+ui"
   - "performance+seo"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/astro-robots-txt"
 repoUrl: "https://github.com/alextim/astro-lib"
-featured: 9
 homepageUrl: "https://github.com/alextim/astro-lib/tree/main/packages/astro-robots-txt#readme"
 downloads: 35689
 ---

--- a/src/content/integrations/astro-seo.md
+++ b/src/content/integrations/astro-seo.md
@@ -5,10 +5,8 @@ description: "Makes it easy to add SEO relevant tags to your Astro app."
 categories:
   - "css+ui"
   - "performance+seo"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/astro-seo"
 repoUrl: "https://github.com/jonasmerlin/astro-seo"
-featured: 10
 homepageUrl: "https://github.com/jonasmerlin/astro-seo#readme"
 downloads: 62865
 image: "/assets/integrations/astro-seo.png"

--- a/src/content/integrations/astro-spa.md
+++ b/src/content/integrations/astro-spa.md
@@ -4,10 +4,8 @@ title: "astro-spa"
 description: "A component for Astro JS that turns a website into an SPA"
 categories:
   - "css+ui"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/astro-spa"
 repoUrl: "https://github.com/RafidMuhymin/astro-spa"
-featured: 12
 homepageUrl: "https://github.com/RafidMuhymin/astro-spa#readme"
 downloads: 447
 ---

--- a/src/content/integrations/astro-xelement.md
+++ b/src/content/integrations/astro-xelement.md
@@ -4,10 +4,8 @@ title: "astro-xelement"
 description: "XElement is a powerful Astro Web Component generator. Create your own Astro compliant Web Components using only HTML Elements with additional Client-Side JS/TS interactivity sprinkled into the Element."
 categories:
   - "css+ui"
-  - "featured"
 npmUrl: "https://www.npmjs.com/package/astro-xelement"
 repoUrl: "https://github.com/aFuzzyBear/xelement"
-featured: 11
 homepageUrl: "https://github.com/aFuzzyBear/xelement"
 downloads: 158
 ---

--- a/src/helpers/integrations.ts
+++ b/src/helpers/integrations.ts
@@ -60,23 +60,14 @@ export function validateCategories(
 	return true;
 }
 
-// Sorting priority: featured first, then compare downloads, then sort alphabetically
+// Sorting priority: compare download count then sort alphabetically
 function sortIntegrations(a: CollectionEntry<"integrations">, b: CollectionEntry<"integrations">) {
-	if (a.data.featured && b.data.featured) {
-		return a.data.featured - b.data.featured;
-	}
+	const aDownloads = a.data.downloadFactor * a.data.downloads;
+	const bDownloads = b.data.downloadFactor * b.data.downloads;
 
-	if (a.data.featured && !b.data.featured) {
-		return -1;
-	}
-
-	if (!a.data.featured && b.data.featured) {
-		return 1;
-	}
-
-	if (a.data.downloads === b.data.downloads) {
+	if (aDownloads === bDownloads) {
 		return b.data.name.localeCompare(a.data.name);
 	}
 
-	return b.data.downloads - a.data.downloads;
+	return bDownloads - aDownloads;
 }

--- a/src/pages/integrations/[...page].astro
+++ b/src/pages/integrations/[...page].astro
@@ -127,7 +127,11 @@ const recentlyAddedHref = `${Astro.url.pathname}?${recentlyAddedSearch.toString(
 
 					<CardGridGroup
 						title={
-							showRecentlyAdded && recentlyAdded.length > 0 ? 'Popular integrations' : undefined
+							showRecentlyAdded && recentlyAdded.length > 0
+								? 'Popular integrations'
+								: search
+									? `Results for "${search}"`
+									: undefined
 						}
 					>
 						<CardGrid class="w-full max-w-screen-xl sm:grid-cols-2 xl:grid-cols-3">

--- a/src/pages/integrations/[...page].astro
+++ b/src/pages/integrations/[...page].astro
@@ -78,7 +78,7 @@ const recentlyAddedHref = `${Astro.url.pathname}?${recentlyAddedSearch.toString(
 
 <MainLayout
 	title="Integrations"
-	image={{ src: "/og/integrations.jpg", alt: "Discover our integrations" }}
+	image={{ src: '/og/integrations.jpg', alt: 'Discover our integrations' }}
 >
 	<div class="bg-grid relative">
 		<div class="grid-container">
@@ -110,10 +110,10 @@ const recentlyAddedHref = `${Astro.url.pathname}?${recentlyAddedSearch.toString(
 
 					{showRecentlyAdded && recentlyAdded.length > 0 && (
 						<CardGridGroup
-							title="Recently Added"
+							title="Recently added"
 							cta={
 								recentlyAdded.length > 3
-									? { href: recentlyAddedHref, text: "View all new integrations" }
+									? { href: recentlyAddedHref, text: 'View all new integrations' }
 									: undefined
 							}
 						>
@@ -126,7 +126,9 @@ const recentlyAddedHref = `${Astro.url.pathname}?${recentlyAddedSearch.toString(
 					)}
 
 					<CardGridGroup
-						title={showRecentlyAdded && recentlyAdded.length > 0 ? "All Integrations" : undefined}
+						title={
+							showRecentlyAdded && recentlyAdded.length > 0 ? 'Popular integrations' : undefined
+						}
 					>
 						<CardGrid class="w-full max-w-screen-xl sm:grid-cols-2 xl:grid-cols-3">
 							{integrations.map((integration) => (


### PR DESCRIPTION
- Removes the concept of “featured” integrations entirely

  We were not good about keeping this updated and download count is a reasonable proxy for popularity and what gets featured.

- Adds a new `downloadFactor` field to support downranking integrations with lots of downloads. This was needed for a couple of integrations that are bundled in some more popular package but don’t actually get used as much as the npm download count suggests. For example, `@astrojs/prism` is a dependency of `astro`, so is kind of automatically the “most popular integration”. But in reality only like 0.05% of Astro users actually enable it.

- Tweaked the wording in the integrations catalogue headings from “All integrations” to “Popular integrations”. This text only ever displays on the catalogue homepage and follows the “Recently added” heading, so feels like it might be a better counterpart.

- Displays a heading when a user has searched for something. Previously, search results had no heading. Now, the heading reads “Results for "query"”.

- Updates our integration script to properly escape Markdown in integration descriptions with `mdast` utilities. Currently this is done with a regular expression that tries to strip Markdown links, but leads to stuff like this:

  <img width="393" alt="astro-htmx integration card with a garbled description containing partial Markdown syntax for bold text and a link" src="https://github.com/user-attachments/assets/0a1c898f-edb5-47d9-8c84-95e885b3319b">

  Tested this fix locally but going to rerun CI after this merges to apply the updated descriptions rather than doing that in this PR

## Browser Test Checklist

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [x] Android Firefox
- [x] Safari
- [ ] iOS Safari

