### PR TITLE
Fix card overflow

### DIFF
--- a/src/pages/_components/landing-page/Sponsors.astro
+++ b/src/pages/_components/landing-page/Sponsors.astro
@@ -72,7 +72,7 @@ const sponsors = [
 						href={sponsor.href}
 						rel="sponsored"
 						target="_blank"
-						class="size-full basis-1/3 flex flex-col lg:grid lg:grid-rows-subgrid lg:row-span-full items-center justify-center gap-2 sm:gap-4 -outline-offset-2 hover:bg-astro-gray-100/5 transition-colors duration-400"
+						class="overflow-hidden size-full basis-1/3 flex flex-col lg:grid lg:grid-rows-subgrid lg:row-span-full items-center justify-center gap-2 sm:gap-4 -outline-offset-2 hover:bg-astro-gray-100/5 transition-colors duration-400"
 					>
 						<Icon
 							class="lg:row-start-2 lg:mx-auto"


### PR DESCRIPTION
Fix an overflow in the sponsor cards on desktop.
![image](https://github.com/user-attachments/assets/62146b4b-0d7c-49e0-9fa9-a15ae88cc968)


## Browser Test Checklist

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [x] Android Firefox
- [ ] Safari
- [ ] iOS Safari

