### PR TITLE
Fixes broken links on Astro Integrations page 

### DIFF
--- a/src/content/integrations/@advanced-astrotoast.md
+++ b/src/content/integrations/@advanced-astrotoast.md
@@ -5,6 +5,6 @@ description: "astro-toast is a simple component for displaying toasts on your we
 categories:
   - "css+ui"
 npmUrl: "https://www.npmjs.com/package/@advanced-astro/toast"
-homepageUrl: "https://github.com/advenced-astro/toast"
+homepageUrl: "https://github.com/advanced-astro/toast"
 downloads: 8
 ---


### PR DESCRIPTION
Fixed issue where GitHub URL was spelled "advenced" instead of "advanced", linking to 404 page on GitHub visible here: https://astro.build/integrations/?search=toast 

I have tested this PR on at least three of the following browsers:

- [✔] Chrome / Chromium
- [✔] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

