### PR TITLE
Remove broken Youtube Link

### DIFF
--- a/src/content/blog/whats-new-july-2024.mdx
+++ b/src/content/blog/whats-new-july-2024.mdx
@@ -93,7 +93,6 @@ Because you can never get tired of Astro, here's even more community content!
     { id: 'https://www.youtube.com/watch?v=UmvT6GYlHgE', title: 'Astro.js! Inseln und SPA vs MPA #short #shorts #programmieren #javascript #astrojs' },
     { id: 'https://www.youtube.com/watch?v=1qI17x0rpd0', title: 'Astro.js und die Islands Architektur #astrojs #astro #programmieren' },
     { id: 'https://www.youtube.com/watch?v=byWuX848O8U', title: 'Tutorial: Proyecto con Astro Build y Tailwind CSS en Visual Studio Code' },
-    { id: 'https://www.youtube.com/watch?v=G0lZBJlF1P4', title: "Let's build link in bio using astro, tailwind" },
     { id: 'https://www.youtube.com/watch?v=AvtySUwGBTQ', title: 'Clon de la Página de Starbucks con Astro.js y Mejora Animaciones con CSS 🚀☕️' },
     { id: 'https://www.youtube.com/watch?v=1K8dMuJa8f4', title: "Let's Build blog website using Astro" },
     { id: 'https://www.youtube.com/watch?v=g09ZNLn3gEM', title: 'Responsive Store Template using Astro JS and Tailwind CSS' },


### PR DESCRIPTION
<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->
- Removes 1 broken youtube link titled `Let's build link in bio using astro, tailwind`
## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

