### PR TITLE
update landing page hero for 4.14

### DIFF
--- a/src/pages/_components/landing-page/Hero.astro
+++ b/src/pages/_components/landing-page/Hero.astro
@@ -9,7 +9,7 @@ import Teams from "./Teams.astro";
 
 <section class="relative">
   <div class="mt-16 md:mt-20 lg:mt-24 px-4 sm:px-8 mx-auto w-full sm:max-w-screen-md flex flex-col items-center justify-center gap-5 md:gap-6 lg:gap-8">
-    <PillLink href='https://astro.build/blog/astro-4120/' title='Astro 4.14' subtitle='New experimental Content Layer API'/>
+    <PillLink href='https://astro.build/blog/astro-4140/' title='Astro 4.14' subtitle='New experimental Content Layer API'/>
     <PageTitleBlock wide lg
       body="Astro powers the world's fastest marketing sites, blogs, e-commerce websites, and more."
     >

--- a/src/pages/_components/landing-page/Hero.astro
+++ b/src/pages/_components/landing-page/Hero.astro
@@ -9,7 +9,7 @@ import Teams from "./Teams.astro";
 
 <section class="relative">
   <div class="mt-16 md:mt-20 lg:mt-24 px-4 sm:px-8 mx-auto w-full sm:max-w-screen-md flex flex-col items-center justify-center gap-5 md:gap-6 lg:gap-8">
-    <PillLink href='https://astro.build/blog/astro-4120/' title='Astro 4.12' subtitle='New experimental Server Islands'/>
+    <PillLink href='https://astro.build/blog/astro-4120/' title='Astro 4.14' subtitle='New experimental Content Layer API'/>
     <PageTitleBlock wide lg
       body="Astro powers the world's fastest marketing sites, blogs, e-commerce websites, and more."
     >


### PR DESCRIPTION
Updates the text/URL of the small banner in the hero pointing to the latest blog post

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [X ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

