### PR TITLE
Fix local builds if Astro DB is not linked

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -26,8 +26,22 @@ export default defineConfig({
 		}),
 		mdx(),
 		sitemap(),
-		db(),
-		webVitals(),
+		/**
+		 * Only add Astro DB and Web Vitals integrations for `astro dev`, CI builds,
+		 * or when an explicit `WITH_DB` variable is set.
+		 */
+		{
+			name: "conditional-web-vitals",
+			hooks: {
+				"astro:config:setup"({ command, updateConfig }) {
+					if (command === "dev" || process.env.CI || process.env.WITH_DB) {
+						updateConfig({
+							integrations: [...db(), webVitals()],
+						});
+					}
+				},
+			},
+		},
 	],
 	image: {
 		domains: ["v1.screenshot.11ty.dev", "storage.googleapis.com"],

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"dev": "astro dev",
 		"start": "astro dev",
 		"build": "astro build --remote",
+		"build:force-db": "WITH_DB=true astro build --remote",
 		"preview": "astro preview",
 		"lint": "biome lint .",
 		"format": "biome check . --apply",


### PR DESCRIPTION
This PR updates how Astro DB and the web vitals configuration are added, so that local builds can be run without needing to link to Astro DB. This helps contributors who are not members of the Astro organisation on Astro DB and can’t link in the first place.

## Browser Test Checklist

n/a — no site code touched