### PR TITLE
Move `sharp` back to prod dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"only-allow": "1.2.1",
 		"prettier-plugin-astro": "^0.14.1",
 		"prettier": "^3.3.3",
+		"sharp": "^0.33.5",
 		"smartypants": "^0.2.2",
 		"solid-js": "^1.8.21",
 		"tailwindcss": "^3.4.10",
@@ -62,7 +63,6 @@
 		"mdast-util-from-markdown": "^2.0.1",
 		"mdast-util-to-string": "^4.0.0",
 		"puppeteer": "^21.6.0",
-		"sharp": "^0.33.5",
 		"slugify": "^1.6.6",
 		"tiny-glob": "^0.2.9"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
       smartypants:
         specifier: ^0.2.2
         version: 0.2.2
@@ -126,9 +129,6 @@ importers:
       puppeteer:
         specifier: ^21.6.0
         version: 21.11.0(typescript@5.5.4)
-      sharp:
-        specifier: ^0.33.5
-        version: 0.33.5
       slugify:
         specifier: ^1.6.6
         version: 1.6.6


### PR DESCRIPTION
Fixes an issue with on-demand optimized images.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [x] Android Firefox
- [x] Safari
- [ ] iOS Safari

