### PR TITLE
Automate homepage link with frontmatter field in blog posts

### DIFF
--- a/src/content/blog/astro-4100.mdx
+++ b/src/content/blog/astro-4100.mdx
@@ -1,6 +1,9 @@
 ---
 title: "Astro 4.10"
 description: "Astro 4.10 is out with experimental type-safe environment variables, as well as enhancements to the Container API and Rewrites."
+homepageLink:
+  title: Astro 4.10
+  subtitle: New "astro:env" environment variable management
 publishDate: "June 6, 2024"
 authors:
   - matthew

--- a/src/content/blog/astro-4120.mdx
+++ b/src/content/blog/astro-4120.mdx
@@ -1,6 +1,9 @@
 ---
 title: "Astro 4.12: Server Islands"
 description: Astro 4.12 is now available! This release includes includes the first experimental release of Server Islands, improvements to pagination and syntax highlighting, and more.
+homepageLink:
+  title: Astro 4.12
+  subtitle: New experimental Server Islands
 publishDate: "July 18, 2024"
 authors:
   - erika

--- a/src/content/blog/astro-4140.mdx
+++ b/src/content/blog/astro-4140.mdx
@@ -1,6 +1,9 @@
 ---
 title: "Astro 4.14"
 description: Astro 4.14 is available now! This release includes the first experimental version of the Content Layer API, experimental support for Intellisense inside content files, and more.
+homepageLink:
+  title: Astro 4.14
+  subtitle: New experimental Content Layer API
 publishDate: "August 15, 2024"
 authors:
   - erika

--- a/src/content/blog/netlify-official-deployment-partner.mdx
+++ b/src/content/blog/netlify-official-deployment-partner.mdx
@@ -5,6 +5,9 @@ authors:
   - fred
 description: |
   We are happy to announce that Netlify has become Astro’s official deployment partner, donating $12,500 each month towards the ongoing open source maintenance and development of Astro.
+homepageLink:
+  title: Astro ❤️ Netlify
+  subtitle: Announcing Our Official Deployment Partner
 publishDate: "July 15, 2024"
 socialImage: "/src/content/blog/_images/netlify-official-deployment-partner/astro-netlify-social.webp"
 coverImage: "/src/content/blog/_images/netlify-official-deployment-partner/astro-netlify-header.webp"

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -49,6 +49,19 @@ export const collections = {
 				.describe(
 					'Summary of this blog post. Appears on the blog index as well as in metadata displayed on social media.',
 				),
+			homepageLink: z
+				.object({
+					title: z.string().max(16).describe('Very short call-out, e.g. `Astro 4.14` or `New!`.'),
+					subtitle: z
+						.string()
+						.max(50)
+						.optional()
+						.describe(
+							'Short tagline attracting attention to the post, e.g. `New experimental Content Layer API` or `Announcing Astro DB`. Avoid punctuation and keep things punchy.',
+						),
+				})
+				.optional()
+				.describe('Configure the homepage banner link for this post if it’s the most recent post.'),
 			publishDate: z.coerce
 				.date()
 				.describe(

--- a/src/pages/_components/LatestBlogPostLink.astro
+++ b/src/pages/_components/LatestBlogPostLink.astro
@@ -1,0 +1,21 @@
+---
+import { getCollection } from 'astro:content';
+import PillLink from './PillLink.astro';
+
+/** Blog posts with a banner configured in their frontmatter. */
+const blogPostsWithBanner = await getCollection('blog', (entry) => !!entry.data.homepageLink);
+/** The most recent blog post. */
+const latestBlogPost = blogPostsWithBanner
+	.sort((a, b) => (a.data.publishDate > b.data.publishDate ? 1 : -1))
+	.pop();
+---
+
+{
+	latestBlogPost && (
+		<PillLink
+			href={`https://astro.build/blog/${latestBlogPost.slug}/`}
+			title={latestBlogPost.data.homepageLink!.title}
+			subtitle={latestBlogPost.data.homepageLink!.subtitle}
+		/>
+	)
+}

--- a/src/pages/_components/landing-page/Hero.astro
+++ b/src/pages/_components/landing-page/Hero.astro
@@ -1,8 +1,8 @@
 ---
 import CodeBlock from '~/components/CodeBlock.astro';
 import PageTitleBlock from '~/components/PageTitleBlock.astro';
+import LatestBlogPostLink from '../LatestBlogPostLink.astro';
 import Link from '../Link.astro';
-import PillLink from '../PillLink.astro';
 import HeroBackground from './HeroBackground.astro';
 import Teams from './Teams.astro';
 ---
@@ -11,11 +11,7 @@ import Teams from './Teams.astro';
 	<div
 		class="mt-16 md:mt-20 lg:mt-24 px-4 sm:px-8 mx-auto w-full sm:max-w-screen-md flex flex-col items-center justify-center gap-5 md:gap-6 lg:gap-8"
 	>
-		<PillLink
-			href="https://astro.build/blog/astro-4140/"
-			title="Astro 4.14"
-			subtitle="New experimental Content Layer API"
-		/>
+		<LatestBlogPostLink />
 		<PageTitleBlock
 			wide
 			lg


### PR DESCRIPTION
This PR automates the homepage link to the latest blog post by adding a new `homepageLink` field to blog post frontmatter.

A blog post can include this and if it is the most recent post, it will automatically be used for the link on the landing page. For example, frontmatter can include something like

```yml
homepageLink:
  title: Astro 4.14
  subtitle: New experimental Content Layer API
```

And the homepage will render it as 

<img width="391" alt="element with rounded corners reading Astro 4.14: New experimental Content Layer API, followed by an arrow pointing right" src="https://github.com/user-attachments/assets/4cf4909d-5f0a-41ca-8d3c-437c89892c89">

From what I could tell, we forgot to update this every single time we blogged for the last 2 months, so seems worth integrating it into the blog post frontmatter instead.

If a blog post is not considered important enough to link from the homepage, you can simply omit `homepageLink` and the post will be ignored.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [x] Safari
- [ ] iOS Safari

