### PR TITLE
Account for search params and hash in trailing slash utility

### DIFF
--- a/src/helpers/path.ts
+++ b/src/helpers/path.ts
@@ -1,2 +1,7 @@
 /** Adds a trailing `/` to the passed path if needed. */
-export const ensureTrailingSlash = (path: string) => (path.at(-1) === '/' ? path : `${path}/`);
+export const ensureTrailingSlash = (path: string) => {
+	const fakeOrigin = 'https://example.com';
+	const url = new URL(path, fakeOrigin);
+	if (url.pathname.at(-1) !== '/') url.pathname += '/';
+	return url.href.slice(fakeOrigin.length);
+};

--- a/src/helpers/path.ts
+++ b/src/helpers/path.ts
@@ -1,7 +1,6 @@
 /** Adds a trailing `/` to the passed path if needed. */
 export const ensureTrailingSlash = (path: string) => {
-	const fakeOrigin = 'https://example.com';
-	const url = new URL(path, fakeOrigin);
+	const url = new URL(path, 'https://example.com');
 	if (url.pathname.at(-1) !== '/') url.pathname += '/';
-	return url.href.slice(fakeOrigin.length);
+	return url.href.slice(url.origin.length);
 };


### PR DESCRIPTION
Fixes a bug in pagination when the URL contains a search parameter.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

