### PR TITLE
Fix incorrect path in example code in Astro 4.14 blog post

### DIFF
--- a/src/content/blog/astro-4140.mdx
+++ b/src/content/blog/astro-4140.mdx
@@ -68,7 +68,7 @@ We plan to continue improving the performance of the Content Layer API in future
 To try out the new Content Layer API, enable it in your Astro config:
 
 ```js
-import { defineConfig } from 'astro';
+import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   experimental: {


### PR DESCRIPTION
I kept getting the following error while following the instructions in the blog post to try out the new Content Layer API on a newly created Astro project (created using `pnpm create astro@latest`).

```
❯ pnpm run dev

> notion-loader-test@0.0.1 dev /Users/crcastle/Code/github.com/crcastle/notion-loader-test
> astro dev

2:46:57 PM [vite] Error when evaluating SSR module /Users/crcastle/Code/github.com/crcastle/notion-loader-test/astro.config.mjs: failed to import "astro"
|- SyntaxError: [vite] The requested module 'astro' does not provide an export named 'defineConfig'
    at analyzeImportedModDifference (file:///Users/crcastle/Code/github.com/crcastle/notion-loader-test/node_modules/.pnpm/vite@5.4.2_@types+node@22.5.0/node_modules/vite/dist/node/chunks/dep-BzOvws4Y.js:51946:15)
    at nodeImport (file:///Users/crcastle/Code/github.com/crcastle/notion-loader-test/node_modules/.pnpm/vite@5.4.2_@types+node@22.5.0/node_modules/vite/dist/node/chunks/dep-BzOvws4Y.js:52958:5)
    at async ssrImport (file:///Users/crcastle/Code/github.com/crcastle/notion-loader-test/node_modules/.pnpm/vite@5.4.2_@types+node@22.5.0/node_modules/vite/dist/node/chunks/dep-BzOvws4Y.js:52812:16)
    at async eval (/Users/crcastle/Code/github.com/crcastle/notion-loader-test/astro.config.mjs:3:44)
    at async instantiateModule (file:///Users/crcastle/Code/github.com/crcastle/notion-loader-test/node_modules/.pnpm/vite@5.4.2_@types+node@22.5.0/node_modules/vite/dist/node/chunks/dep-BzOvws4Y.js:52870:5)

[astro] Unable to load your Astro config

[vite] The requested module 'astro' does not provide an export named 'defineConfig'
  Stack trace:
    at analyzeImportedModDifference (file:///Users/crcastle/Code/github.com/crcastle/notion-loader-test/node_modules/.pnpm/vite@5.4.2_@types+node@22.5.0/node_modules/vite/dist/node/chunks/dep-BzOvws4Y.js:51946:15)
    at async ssrImport (file:///Users/crcastle/Code/github.com/crcastle/notion-loader-test/node_modules/.pnpm/vite@5.4.2_@types+node@22.5.0/node_modules/vite/dist/node/chunks/dep-BzOvws4Y.js:52812:16)
    at async instantiateModule (file:///Users/crcastle/Code/github.com/crcastle/notion-loader-test/node_modules/.pnpm/vite@5.4.2_@types+node@22.5.0/node_modules/vite/dist/node/chunks/dep-BzOvws4Y.js:52870:5)
 ELIFECYCLE  Command failed with exit code 1.
```

I believe a `/config` is missing from an import.

