### PR TITLE
Remove titles from `authors.json` data

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -40,7 +40,6 @@ export const collections = {
 			z.object({
 				image: image().optional(),
 				name: z.string(),
-				title: z.string().optional(),
 				twitter: z.string().optional(),
 				mastodon: z.string().optional(),
 			}),

--- a/src/data/authors/authors.json
+++ b/src/data/authors/authors.json
@@ -1,25 +1,21 @@
 {
 	"astro-team": {
 		"name": "Astro Team",
-		"title": "Developer",
 		"image": "./astro-team.webp",
 		"twitter": "https://twitter.com/astrodotbuild"
 	},
 	"ben": {
 		"name": "Ben Holmes",
-		"title": "Developer",
 		"image": "./ben.webp",
 		"twitter": "https://twitter.com/bholmesdev"
 	},
 	"bjorn": {
 		"name": "Bjorn Lu",
-		"title": "Developer",
 		"image": "./bjorn.webp",
 		"twitter": "https://twitter.com/bluwyoo"
 	},
 	"chris": {
 		"name": "Chris Swithinbank",
-		"title": "Developer",
 		"image": "./chris.webp",
 		"twitter": "https://twitter.com/swithinbank"
 	},
@@ -30,109 +26,91 @@
 	},
 	"drew": {
 		"name": "Drew Powers",
-		"title": "Developer",
 		"image": "./drew.webp",
 		"twitter": "https://twitter.com/drwpow"
 	},
 	"elian": {
 		"name": "Elian Van Cutsem",
-		"title": "DX & Community Relations",
 		"image": "./elian.webp",
 		"twitter": "https://twitter.com/eliancodes",
 		"mastodon": "https://webtoo.ls/@eliancodes"
 	},
 	"ema": {
 		"name": "Emanuele Stoppa",
-		"title": "Developer",
 		"image": "./ema.webp",
 		"twitter": "https://twitter.com/ematipico"
 	},
 	"erika": {
 		"name": "Erika",
-		"title": "Developer",
 		"image": "./erika.webp",
 		"mastodon": "https://m.webtoo.ls/@erika"
 	},
 	"fred": {
 		"name": "Fred Schott",
-		"title": "Founder & CTO",
 		"image": "./fred.webp",
 		"twitter": "https://twitter.com/FredKSchott"
 	},
 	"fuzzy": {
 		"name": "Fuzzy",
-		"title": "Community Manager",
 		"image": "./fuzzy.webp",
 		"twitter": "https://twitter.com/aFuzzyBear2"
 	},
 	"hideoo": {
 		"name": "HiDeoo",
-		"title": "Core Maintainer",
 		"image": "./hideoo.png",
 		"twitter": "https://twitter.com/hideoo"
 	},
 	"jon": {
 		"name": "Jonathan Neal",
-		"title": "Developer",
 		"image": "./jon.webp",
 		"twitter": "https://twitter.com/jon_neal"
 	},
 	"mark": {
 		"name": "Mark Peck",
-		"title": "Designer",
 		"image": "./mark.jpeg",
 		"twitter": "https://twitter.com/doodlemarks"
 	},
 	"martrapp": {
 		"name": "Martin Trapp",
-		"title": "Developer",
 		"image": "./martrapp.webp"
 	},
 	"matt": {
 		"name": "Matt Kane",
-		"title": "Developer",
 		"image": "./matt.webp",
 		"twitter": "https://x.com/ascorbic"
 	},
 	"matthew": {
 		"name": "Matthew Phillips",
-		"title": "Developer",
 		"image": "./matthew.webp",
 		"twitter": "https://twitter.com/matthewcp"
 	},
 	"nate": {
 		"name": "Nate Moore",
-		"title": "Developer",
 		"image": "./nate.webp",
 		"twitter": "https://twitter.com/n_moore"
 	},
 	"reuben": {
 		"name": "Reuben Tier",
-		"title": "Core Maintainer",
 		"image": "./reuben.png",
 		"twitter": "https://twitter.com/theotterlord"
 	},
 	"sarah": {
 		"name": "Sarah Rainsberger",
-		"title": "Docs Lead",
 		"image": "./sarah.webp",
 		"twitter": "https://twitter.com/sarah11918"
 	},
 	"thuy": {
 		"name": "Thuy Doan",
-		"title": "Head of Partnerships",
 		"image": "./thuy.webp",
 		"twitter": "https://twitter.com/clearlyTHUYDOAN"
 	},
 	"tony": {
 		"name": "Tony Sullivan",
-		"title": "Developer",
 		"image": "./tony.webp",
 		"twitter": "https://twitter.com/tonysull_co"
 	},
 	"yan": {
 		"name": "Yan Thomas",
-		"title": "i18n Core Maintainer",
 		"image": "./yan.webp",
 		"twitter": "https://twitter.com/yanthomasdev"
 	}


### PR DESCRIPTION
This PR removes the unused `title` property from the Astro blog's authors data.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [X] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

