### PR TITLE
Make pill link on homepage relative

### DIFF
--- a/src/pages/_components/LatestBlogPostLink.astro
+++ b/src/pages/_components/LatestBlogPostLink.astro
@@ -13,7 +13,7 @@ const latestBlogPost = blogPostsWithBanner
 {
 	latestBlogPost && (
 		<PillLink
-			href={`https://astro.build/blog/${latestBlogPost.slug}/`}
+			href={`/blog/${latestBlogPost.slug}/`}
 			title={latestBlogPost.data.homepageLink!.title}
 			subtitle={latestBlogPost.data.homepageLink!.subtitle}
 		/>


### PR DESCRIPTION
This PR fixes the URL used for the homepage latest blog post link to use a relative `/blog/[slug]` URL instead of the current absolute `https://astro.build/` URL.

This means it will also work in deploy previews and locally.

As requested by @Princesseuh 🫡 

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

