### PR TITLE
Fix 404 link in Astro 4.14 blog post

### DIFF
--- a/src/content/blog/astro-4140.mdx
+++ b/src/content/blog/astro-4140.mdx
@@ -139,7 +139,7 @@ const countries = defineCollection({
 export const collections = { countries };
 ```
 
-For more advanced loading logic, you can define an object loader. This allows incremental updates and conditional loading while also giving full access to the data store. It also allows a loader to define its own schema, including generating it dynamically based on the source API. See the [the Content Layer API RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0047-content-layer.md#loaders) for more details.
+For more advanced loading logic, you can define an object loader. This allows incremental updates and conditional loading while also giving full access to the data store. It also allows a loader to define its own schema, including generating it dynamically based on the source API. See the [the Content Layer API RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0050-content-layer.md#loaders) for more details.
 
 ### Sharing your loaders
 
@@ -161,7 +161,7 @@ export const collections = { podcasts };
 
 ### Learn more
 
-To find out more about using the Content Layer API, check out [the Content Layer RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0047-content-layer.md) and [share your feedback](https://github.com/withastro/roadmap/pull/982).
+To find out more about using the Content Layer API, check out [the Content Layer RFC](https://github.com/withastro/roadmap/blob/content-layer/proposals/0050-content-layer.md) and [share your feedback](https://github.com/withastro/roadmap/pull/982).
 
 ## Experimental: Intellisense inside content files
 


### PR DESCRIPTION
Looks like the RFC number changed from 47 to 50.

