### PR TITLE
SEO improvements for blog posts

### DIFF
--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -91,3 +91,12 @@ function formatCanonicalURL(url: string | URL) {
 <meta name="twitter:description" content={twitter.description} />
 {twitter.image && <meta name="twitter:image" content={twitter.image.src} />}
 {twitter.image && <meta name="twitter:image:alt" content={twitter.image.alt} />}
+
+{
+	/*
+	Robots meta tag for Google Search.
+	Enables a large image preview in Google search results, most pertinently in Chrome’s “Discover” view on mobile.
+	See: https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#max-image-preview
+*/
+}
+<meta name="robots" content="max-image-preview:large" />

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -68,12 +68,11 @@ function formatCanonicalURL(url: string | URL) {
 }
 ---
 
-<!-- Page Metadata -->{
-	canonicalURL && <link rel="canonical" href={formatCanonicalURL(canonicalURL)} />
-}
+{/* Page Metadata */}
+{canonicalURL && <link rel="canonical" href={formatCanonicalURL(canonicalURL)} />}
 <meta name="description" content={description} />
 
-<!-- OpenGraph Tags -->
+{/* OpenGraph Tags */}
 <meta property="og:title" content={og.title} />
 <meta property="og:type" content={og.type} />
 {og.canonicalURL && <meta property="og:url" content={formatCanonicalURL(og.canonicalURL)} />}
@@ -83,10 +82,9 @@ function formatCanonicalURL(url: string | URL) {
 {og.image && <meta property="og:image" content={og.image.src} />}
 {og.image && <meta property="og:image:alt" content={og.image.alt} />}
 
-<!-- Twitter Tags -->
+{/* Twitter Tags */}
 {twitter.card && <meta name="twitter:card" content={twitter.card} />}
 {twitter.handle && <meta name="twitter:site" content={twitter.handle} />}
-
 <meta name="twitter:title" content={twitter.title} />
 <meta name="twitter:description" content={twitter.description} />
 {twitter.image && <meta name="twitter:image" content={twitter.image.src} />}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -40,9 +40,9 @@ export const collections = {
 			z.object({
 				image: image().optional(),
 				name: z.string(),
-				twitter: z.string().optional(),
-				mastodon: z.string().optional(),
-				github: z.string().optional(),
+				twitter: z.string().url().optional(),
+				mastodon: z.string().url().optional(),
+				github: z.string().url().optional(),
 			}),
 	}),
 	blog: defineCollection({

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -42,6 +42,7 @@ export const collections = {
 				name: z.string(),
 				twitter: z.string().optional(),
 				mastodon: z.string().optional(),
+				github: z.string().optional(),
 			}),
 	}),
 	blog: defineCollection({

--- a/src/data/authors/authors.json
+++ b/src/data/authors/authors.json
@@ -17,7 +17,7 @@
 	"chris": {
 		"name": "Chris Swithinbank",
 		"image": "./chris.webp",
-		"twitter": "https://twitter.com/swithinbank"
+		"mastodon": "https://m.webtoo.ls/@swithinbank"
 	},
 	"dan": {
 		"name": "Dan Jutan",
@@ -58,7 +58,7 @@
 	"hideoo": {
 		"name": "HiDeoo",
 		"image": "./hideoo.png",
-		"twitter": "https://twitter.com/hideoo"
+		"twitter": "https://github.com/HiDeoo"
 	},
 	"jon": {
 		"name": "Jonathan Neal",
@@ -72,7 +72,8 @@
 	},
 	"martrapp": {
 		"name": "Martin Trapp",
-		"image": "./martrapp.webp"
+		"image": "./martrapp.webp",
+		"github": "https://github.com/martrapp"
 	},
 	"matt": {
 		"name": "Matt Kane",
@@ -97,7 +98,7 @@
 	"sarah": {
 		"name": "Sarah Rainsberger",
 		"image": "./sarah.webp",
-		"twitter": "https://twitter.com/sarah11918"
+		"mastodon": "https://mastodon.social/@sarah11918"
 	},
 	"thuy": {
 		"name": "Thuy Doan",
@@ -107,7 +108,7 @@
 	"tony": {
 		"name": "Tony Sullivan",
 		"image": "./tony.webp",
-		"twitter": "https://twitter.com/tonysull_co"
+		"mastodon": "https://indieweb.social/@tonysull"
 	},
 	"yan": {
 		"name": "Yan Thomas",

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -51,6 +51,7 @@ const structuredData = {
 	description: data.description,
 	...(socialImageUrl && { thumbnailUrl: socialImageUrl, image: [socialImageUrl] }),
 	datePublished: data.publishDate.toISOString(),
+	potentialAction: [{ '@type': 'ReadAction', target: [Astro.url] }],
 	author: authors.map(({ id, data }) => ({
 		'@type': id === 'astro-team' ? 'Organization' : 'Person',
 		'@id': `https://astro.build/blog/#/author/${id}`,

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -47,6 +47,7 @@ const structuredData = {
 	'@type': 'BlogPosting',
 	'@id': Astro.url,
 	headline: data.title,
+	description: data.description,
 	image: socialImage ? [new URL(socialImage.src, Astro.site)] : undefined,
 	datePublished: data.publishDate.toISOString(),
 	author: authors.map(({ id, data }) => ({

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -40,6 +40,23 @@ const gradients = [
 ];
 
 const placeholderGradient = randomFromArray(gradients);
+
+/** Data describing the current blog post for use in a JSON-LD script tag that Google can slurp up. */
+const structuredData = {
+	'@context': 'https://schema.org',
+	'@type': 'BlogPosting',
+	'@id': Astro.url,
+	headline: data.title,
+	image: socialImage ? [new URL(socialImage.src, Astro.site)] : undefined,
+	datePublished: data.publishDate.toISOString(),
+	author: authors.map(({ id, data }) => ({
+		'@type': id === 'astro-team' ? 'Organization' : 'Person',
+		'@id': `https://astro.build/blog/#/author/${id}`,
+		name: data.name,
+		sameAs: data.twitter || data.mastodon || data.github,
+		image: data.image && new URL(data.image.src, Astro.site),
+	})),
+};
 ---
 
 <Layout
@@ -101,6 +118,7 @@ const placeholderGradient = randomFromArray(gradients);
 			</article>
 		</div>
 	</div>
+	<script is:inline type="application/ld+json" set:html={JSON.stringify(structuredData)} />
 </Layout>
 
 <script>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -27,6 +27,7 @@ const { Content } = await render();
 
 const coverImage = await resolveCoverImage(post);
 const socialImage = await resolveSocialImage(post);
+const socialImageUrl = socialImage && new URL(socialImage.src, Astro.site);
 
 const authors = await Promise.all(data.authors.map((author) => getEntry('authors', author))).then(
 	(authors) => authors.filter(Boolean) as CollectionEntry<'authors'>[],
@@ -48,7 +49,7 @@ const structuredData = {
 	'@id': Astro.url,
 	headline: data.title,
 	description: data.description,
-	image: socialImage ? [new URL(socialImage.src, Astro.site)] : undefined,
+	...(socialImageUrl && { thumbnailUrl: socialImageUrl, image: [socialImageUrl] }),
 	datePublished: data.publishDate.toISOString(),
 	author: authors.map(({ id, data }) => ({
 		'@type': id === 'astro-team' ? 'Organization' : 'Person',


### PR DESCRIPTION
This PR adds some extra metadata for Google search:

- Adds a `<meta name="robots" content="max-image-preview:large" />` tag to permit large image previews in search results — most pertinent to Chrome’s “Discover” view ([docs](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#max-image-preview), [case study](https://developers.google.com/search/case-studies/large-images-case-study)).
- Adds JSON-LD structured data for blog posts to help Google find the right image to display ([docs](https://developers.google.com/search/docs/appearance/structured-data/article)).
- In the process, tweaked our authors metadata slightly to ensure we had a URL for each author by adding an optional `github` URL field to the data (and ensuring all URLs in the author schema are correctly formatted).

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

