### PR TITLE
Remove `<BlogSummary>` component

### DIFF
--- a/src/components/BlogSummary.astro
+++ b/src/components/BlogSummary.astro
@@ -1,7 +1,0 @@
----
-
----
-
-<p class="text-xl">
-	<strong><slot /></strong>
-</p>

--- a/src/content/blog/astro-4100.mdx
+++ b/src/content/blog/astro-4100.mdx
@@ -13,11 +13,8 @@ lang: "en"
 ---
 
 import { YouTube } from '@astro-community/astro-embed-youtube';
-import BlogSummary from "/src/components/BlogSummary.astro";
 
-<BlogSummary>
-  Astro 4.10 is out with experimental type-safe environment variables, as well as enhancements to the Container API and Rewrites.
-</BlogSummary>
+**Astro 4.10 is out with experimental type-safe environment variables, as well as enhancements to the Container API and Rewrites.**
 
 Full release highlights include:
 

--- a/src/content/blog/astro-4110.mdx
+++ b/src/content/blog/astro-4110.mdx
@@ -9,11 +9,7 @@ socialImage: "/src/content/blog/_images/astro-4110/og-image-4.11.webp"
 lang: "en"
 ---
 
-import BlogSummary from "/src/components/BlogSummary.astro";
-
-<BlogSummary>
-  Astro 4.11 is out with custom 500 page improvements and Shiki transformers in the Code component.
-</BlogSummary>
+**Astro 4.11 is out with custom 500 page improvements and Shiki transformers in the Code component.**
 
 Learn more on each of these:
 

--- a/src/content/blog/astro-4120.mdx
+++ b/src/content/blog/astro-4120.mdx
@@ -14,13 +14,10 @@ lang: "en"
 ---
 
 import BlogContentImage from "/src/components/BlogContentImage.astro";
-import BlogSummary from "/src/components/BlogSummary.astro";
 import islandDiag from "/src/content/blog/_images/future-of-astro-server-islands/dark-mode-server-islands-diag.webp";
 import Note from "/src/components/Note.astro";
 
-<BlogSummary>
-  Astro 4.12 is out now! This release includes the first experimental release of Server Islands, our new solution to integrate high performance static HTML and dynamic server-generated components together. Improvements to pagination and syntax highlighting are also included.
-</BlogSummary>
+**Astro 4.12 is out now! This release includes the first experimental release of Server Islands, our new solution to integrate high performance static HTML and dynamic server-generated components together. Improvements to pagination and syntax highlighting are also included.**
 
 This release includes the following highlights:
 

--- a/src/content/blog/astro-4130.mdx
+++ b/src/content/blog/astro-4130.mdx
@@ -10,12 +10,9 @@ lang: "en"
 ---
 
 import BlogContentImage from "/src/components/BlogContentImage.astro";
-import BlogSummary from "/src/components/BlogSummary.astro";
 import slowPageImage from "/src/content/blog/_images/astro-4130/slow-page.webp";
 
-<BlogSummary>
-  Astro 4.13 is out now! This release includes stabilized experimental features, logging improvements, and more.
-</BlogSummary>
+**Astro 4.13 is out now! This release includes stabilized experimental features, logging improvements, and more.**
 
 This release includes the following highlights:
 

--- a/src/content/blog/astro-4140.mdx
+++ b/src/content/blog/astro-4140.mdx
@@ -14,12 +14,9 @@ lang: "en"
 ---
 
 import BlogContentImage from "/src/components/BlogContentImage.astro";
-import BlogSummary from "/src/components/BlogSummary.astro";
 import frontmatterIntellisense from "/src/content/blog/_images/astro-4140/frontmatter-intellisense.png";
 
-<BlogSummary>
-  Astro 4.14 is out now! This release includes the first experimental release of the Content Layer API, our new super-flexible solution for managing content in Astro projects, support for Intellisense inside content files, and more.
-</BlogSummary>
+**Astro 4.14 is out now! This release includes the first experimental release of the Content Layer API, our new super-flexible solution for managing content in Astro projects, support for Intellisense inside content files, and more.**
 
 This release includes the following highlights:
 

--- a/src/content/blog/astro-4150.mdx
+++ b/src/content/blog/astro-4150.mdx
@@ -15,12 +15,9 @@ lang: "en"
 ---
 
 import BlogContentImage from "/src/components/BlogContentImage.astro";
-import BlogSummary from "/src/components/BlogSummary.astro";
 import frontmatterIntellisense from "/src/content/blog/_images/astro-4140/frontmatter-intellisense.png";
 
-<BlogSummary>
-  Astro 4.15 is out now! This release stabilizes Astro Actions — our solution for fully type-safe backend functions. Also included: support for libSQL remotes in Astro DB, a new timeout option for `client:idle`, and more.
-</BlogSummary>
+**Astro 4.15 is out now! This release stabilizes Astro Actions — our solution for fully type-safe backend functions. Also included: support for libSQL remotes in Astro DB, a new timeout option for `client:idle`, and more.**
 
 This release includes the following highlights:
 

--- a/src/content/blog/astro-450.mdx
+++ b/src/content/blog/astro-450.mdx
@@ -14,10 +14,9 @@ lang: "en"
 ---
 
 import BlogContentImage from "/src/components/BlogContentImage.astro"
-import BlogSummary from "/src/components/BlogSummary.astro"
 import auditPanel from "/src/content/blog/_images/astro-450/audit-panel.webp"
 
-<BlogSummary>Astro 4.5 is now available! This release improves the developer experience with a new, first-of-its-kind [Dev Audit UI](#improved-audit-list). Automatically identify site performance and accessibility issues during development--without ever leaving your browser.</BlogSummary>
+**Astro 4.5 is now available! This release improves the developer experience with a new, first-of-its-kind [Dev Audit UI](#improved-audit-list). Automatically identify site performance and accessibility issues during development--without ever leaving your browser.**
 
 Full release highlights include:
 

--- a/src/content/blog/astro-460.mdx
+++ b/src/content/blog/astro-460.mdx
@@ -13,11 +13,7 @@ socialImage: "/src/content/blog/_images/astro-460/og-image-4.6.webp"
 lang: "en"
 ---
 
-import BlogSummary from "/src/components/BlogSummary.astro";
-
-<BlogSummary>
-  After a short break post-launch week, Astro 4.6 is now here and we're back to our regular schedule! This release includes a new manual routing strategy for internationalization, experimental support for CSRF protection, a new feature for the dev toolbar, and more.
-</BlogSummary>
+**After a short break post-launch week, Astro 4.6 is now here and we're back to our regular schedule! This release includes a new manual routing strategy for internationalization, experimental support for CSRF protection, a new feature for the dev toolbar, and more.**
 
 Full release highlights include:
 

--- a/src/content/blog/astro-470.mdx
+++ b/src/content/blog/astro-470.mdx
@@ -14,13 +14,10 @@ socialImage: "/src/content/blog/_images/astro-470/og-image-4.7.webp"
 lang: "en"
 ---
 
-import BlogSummary from "/src/components/BlogSummary.astro";
 import updateCheckerImage from "/src/content/blog/_images/astro-470/update-checker.webp";
 import BlogContentImage from "/src/components/BlogContentImage.astro"
 
-<BlogSummary>
-Astro 4.7 is now available! This release includes extensive improvements to the API for making toolbar apps, more ways to keep your Astro project up to date, and more.
-</BlogSummary>
+**Astro 4.7 is now available! This release includes extensive improvements to the API for making toolbar apps, more ways to keep your Astro project up to date, and more.**
 
 Full release highlights include:
 

--- a/src/content/blog/astro-480.mdx
+++ b/src/content/blog/astro-480.mdx
@@ -14,12 +14,7 @@ socialImage: "/src/content/blog/_images/astro-480/og_image_4_8.webp"
 lang: "en"
 ---
 
-import BlogSummary from "/src/components/BlogSummary.astro";
-
-<BlogSummary>
-  Astro 4.8 is out now! This release includes experimental support for Astro
-  actions and request rewriting, performance improvements, and more.
-</BlogSummary>
+**Astro 4.8 is out now! This release includes experimental support for Astro actions and request rewriting, performance improvements, and more.**
 
 Full release highlights include:
 

--- a/src/content/blog/astro-490.mdx
+++ b/src/content/blog/astro-490.mdx
@@ -14,11 +14,7 @@ socialImage: "/src/content/blog/_images/astro-490/og_image_4_9.webp"
 lang: "en"
 ---
 
-import BlogSummary from "/src/components/BlogSummary.astro";
-
-<BlogSummary>
-  Astro 4.9 is out! This release includes the long-awaited Container API, stabilized experimental features, and more. A small but mighty release!
-</BlogSummary>
+**Astro 4.9 is out! This release includes the long-awaited Container API, stabilized experimental features, and more. A small but mighty release!**
 
 Full release highlights include:
 

--- a/src/content/blog/dev-portal.mdx
+++ b/src/content/blog/dev-portal.mdx
@@ -10,12 +10,9 @@ lang: "en"
 ---
 
 import BlogContentImage from "/src/components/BlogContentImage.astro"
-import BlogSummary from "/src/components/BlogSummary.astro"
 import dashboard from "/src/content/blog/_images/dev-portal/dashboard.webp"
 
-<BlogSummary>
-Today, we're launching [the Astro Developer Portal](https://portal.astro.build), a platform where theme authors can submit, manage, and promote their themes built for Astro.
-</BlogSummary>
+**Today, we're launching [the Astro Developer Portal](https://portal.astro.build), a platform where theme authors can submit, manage, and promote their themes built for Astro.**
 
 At Astro, we're dedicated to crafting solutions that not only benefit our community that builds *with* Astro but also those who build *for* Astro... all while addressing our own internal challenges building Astro itself. One such solution is the new Developer Portal, which will serve as the future home for all community Astro developers.
 

--- a/src/content/blog/future-of-astro-content-layer.mdx
+++ b/src/content/blog/future-of-astro-content-layer.mdx
@@ -9,12 +9,7 @@ socialImage: "/src/content/blog/_images/future-of-astro-content-layer/og-astro-c
 lang: "en"
 ---
 
-import BlogSummary from "/src/components/BlogSummary.astro";
-
-<BlogSummary>
-  This is Part 2 of our series on *"The Future of Astro"*, covering three major advancements we have planned for the Astro web framework in 2024. This post introduces a more powerful Content Layer to Astro: a new way to work with your local and remote content sources.
-</BlogSummary>
-
+**This is Part 2 of our series on *"The Future of Astro"*, covering three major advancements we have planned for the Astro web framework in 2024. This post introduces a more powerful Content Layer to Astro: a new way to work with your local and remote content sources.**
 
 In Astro 2.0, we released the original [Content Collections API](https://docs.astro.build/en/guides/content-collections/). Content Collections were designed around our own experiences and frustrations struggling to scale up large Markdown projects in modern web frameworks, including Astro at the time. Our goal was to make it easier to work with local content (Markdown, MDX, etc.) in Astro than any other web framework. 
 

--- a/src/content/blog/future-of-astro-server-islands.mdx
+++ b/src/content/blog/future-of-astro-server-islands.mdx
@@ -11,12 +11,9 @@ lang: "en"
 ---
 
 import BlogContentImage from "/src/components/BlogContentImage.astro";
-import BlogSummary from "/src/components/BlogSummary.astro";
 import islandDiag from "/src/content/blog/_images/future-of-astro-server-islands/dark-mode-server-islands-diag.webp";
 
-<BlogSummary>
-  This is Part 3 of our series on "The Future of Astro" covering the three major features we have planned for Astro in 2024. This post introduces Server Islands: a new island architecture primitive that lets you deliver static, CDN-cached HTML page shells with injected dynamic content.
-</BlogSummary>
+**This is Part 3 of our series on "The Future of Astro" covering the three major features we have planned for Astro in 2024. This post introduces Server Islands: a new island architecture primitive that lets you deliver static, CDN-cached HTML page shells with injected dynamic content.**
 
 In 2021, Astro pioneered a new frontend architecture called [Islands](https://docs.astro.build/en/concepts/islands/). Islands are unique because they allow Astro to automatically strip all unused JavaScript from your page, delivering faster performance without forcing you to give up your favorite UI components at dev time (React, Svelte, Vue, etc). 
 

--- a/src/content/blog/future-of-astro-zero-js-view-transitions.mdx
+++ b/src/content/blog/future-of-astro-zero-js-view-transitions.mdx
@@ -9,11 +9,7 @@ socialImage: "/src/content/blog/_images/future-of-astro-zero-js-view-transitions
 lang: "en"
 ---
 
-import BlogSummary from "/src/components/BlogSummary.astro";
-
-<BlogSummary>
-  This is Part 1 of our series on "The Future of Astro" covering three major new features we have planned for Astro in 2024. This post introduces an update to the View Transitions API that Astro can now leverage for native, app-like page navigation without a single line of JavaScript required.
-</BlogSummary>
+**This is Part 1 of our series on "The Future of Astro" covering three major new features we have planned for Astro in 2024. This post introduces an update to the View Transitions API that Astro can now leverage for native, app-like page navigation without a single line of JavaScript required.**
 
 The [View Transitions API](https://developer.chrome.com/docs/web-platform/view-transitions) is a set of new platform APIs that unlock native browser transitions between pages. Historically this has only been possible in JavaScript-heavy Single Page Applications (SPAs), but recent advances are now bringing native page transitions to the web platform.
 

--- a/src/content/blog/goodbye-astro-studio.mdx
+++ b/src/content/blog/goodbye-astro-studio.mdx
@@ -9,11 +9,7 @@ socialImage: "/src/content/blog/_images/goodbye-astro-studio/og-sunsetting-studi
 lang: "en"
 ---
 
-import BlogSummary from "/src/components/BlogSummary.astro";
-
-<BlogSummary>
-  We have decided to wind down Astro Studio and open up Astro DB to connect to any libSQL database, including [Turso](https://turso.tech/). Read on to learn more about how we came to the decision, what comes next, and why we think this is the right decision for Astro and Astro DB.
-</BlogSummary>
+**We have decided to wind down Astro Studio and open up Astro DB to connect to any libSQL database, including [Turso](https://turso.tech/). Read on to learn more about how we came to the decision, what comes next, and why we think this is the right decision for Astro and Astro DB.**
 
 Earlier this year, we launched a hosted database platform called [Astro Studio](/db). Our goal was to give every Astro developer easy access to affordable, fast SQL data storage directly from within the Astro framework itself. On this point, we succeeded. Astro Studio delivered instant database access for both local development and production traffic with impressive scale and cost savings.
 


### PR DESCRIPTION
The `<BlogSummary>` component was added in #1003 to highlight the opening section. However, since then it has been incorrectly used on 15 occasions, resulting in odd markup and not the intended visual style.

This PR does the basic thing and rips it out entirely in favour of simply bolding the opening paragraphs like we already do in some other blog posts.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [x] Android Firefox
- [ ] Safari
- [ ] iOS Safari

