### PR TITLE
Update StudioCMS Image on Integration list

### DIFF
--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -339,10 +339,10 @@
 		"astro-vtbot": {
 			"image": "/assets/integrations/bag-of-tricks.svg"
 		},
-		"@astrolicious/studiocms-blog": {
+		"@studiocms/blog": {
 			"image": "/assets/integrations/studiocms-master.svg"
 		},
-		"@astrolicious/studiocms": {
+		"studiocms": {
 			"image": "/assets/integrations/studiocms-master.svg"
 		}
 	}

--- a/src/content/integrations/@studiocmsblog.md
+++ b/src/content/integrations/@studiocmsblog.md
@@ -5,6 +5,7 @@ description: Add a blog to your StudioCMS project with ease!
 categories:
   - css+ui
   - recent
+image: "/assets/integrations/studiocms-master.svg"
 npmUrl: https://www.npmjs.com/package/@studiocms/blog
 repoUrl: https://github.com/astrolicious/studiocms
 homepageUrl: https://astro-studiocms.xyz

--- a/src/content/integrations/studiocms.md
+++ b/src/content/integrations/studiocms.md
@@ -5,6 +5,7 @@ description: A dedicated CMS for Astro DB. Built from the ground up by the Astro
 categories:
   - css+ui
   - recent
+image: "/assets/integrations/studiocms-master.svg"
 npmUrl: https://www.npmjs.com/package/studiocms
 repoUrl: https://github.com/astrolicious/studiocms
 homepageUrl: https://astro-studiocms.xyz


### PR DESCRIPTION
StudioCMS was recently renamed from `@astrolicious/studiocms` to `studiocms`.

This PR fixes the image link between the packages and their respective image, this is using the same image from #1214 