### PR TITLE
remove homepage links

### DIFF
--- a/src/content/blog/cloudinary-loader.mdx
+++ b/src/content/blog/cloudinary-loader.mdx
@@ -4,9 +4,6 @@ authors:
   - matthew
 description: |
   We are happy to announce Cloudinary as a launch partner for the Astro Content Layer API.
-homepageLink:
-  title: "Cloudinary"
-  subtitle: The Cloudinary loader for Astro Content Layer.
 publishDate: "September 19, 2024 11:00:00"
 socialImage: "/src/content/blog/_images/cloudinary-loader/og-cloudinary.webp"
 coverImage: "/src/content/blog/_images/cloudinary-loader/blog-post-cloudinary.webp"

--- a/src/content/blog/hygraph-loader.mdx
+++ b/src/content/blog/hygraph-loader.mdx
@@ -4,9 +4,6 @@ authors:
   - matthew
 description: |
   We are excited to announce Hygraph as a launch partner for Astro Content Layer.
-homepageLink:
-  title: "Hygraph"
-  subtitle: The Hygraph loader for Astro Content Layer.
 publishDate: "September 19, 2024 12:00:00"
 socialImage: "/src/content/blog/_images/hygraph-loader/og-hygraph.webp"
 coverImage: "/src/content/blog/_images/hygraph-loader/blog-post-hygraph.webp"

--- a/src/content/blog/storyblok-loader.mdx
+++ b/src/content/blog/storyblok-loader.mdx
@@ -4,9 +4,6 @@ authors:
   - matthew
 description: |
   We are excited to announce Storyblok as a launch partner for Astro Content Layer.
-homepageLink:
-  title: "Storyblok loader"
-  subtitle: The Storyblok loader for Astro Content Layer.
 publishDate: "September 19, 2024 11:00:00"
 socialImage: "/src/content/blog/_images/storyblok-loader/og-storyblok.webp"
 coverImage: "/src/content/blog/_images/storyblok-loader/blog-post-storyblok.webp"


### PR DESCRIPTION
<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

Removes the `homepagelink:` frontmatter property from blog posts published after 5.0 beta, to keep the homepage linking to that post.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

