### PR TITLE
Fetch integration data in parallel for update

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"linkedom": "^0.16.4",
 		"mdast-util-from-markdown": "^2.0.1",
 		"mdast-util-to-string": "^4.0.0",
+		"p-limit": "^6.1.0",
 		"puppeteer": "^21.6.0",
 		"slugify": "^1.6.6",
 		"tiny-glob": "^0.2.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       mdast-util-to-string:
         specifier: ^4.0.0
         version: 4.0.0
+      p-limit:
+        specifier: ^6.1.0
+        version: 6.1.0
       puppeteer:
         specifier: ^21.6.0
         version: 21.11.0(typescript@5.5.4)

--- a/scripts/npm.mjs
+++ b/scripts/npm.mjs
@@ -1,14 +1,19 @@
 import { format, subDays } from 'date-fns';
+import pLimit from 'p-limit';
 
-async function fetchJson(url) {
-	const res = await fetch(url);
+const fetchLimit = pLimit(10);
 
-	if (!res.ok) {
-		console.error(`[${url}] ${res.status} ${res.statusText}`);
-		throw new Error();
-	}
+function fetchJson(url) {
+	return fetchLimit(async () => {
+		const res = await fetch(url);
 
-	return await res.json();
+		if (!res.ok) {
+			console.error(`[${url}] ${res.status} ${res.statusText}`);
+			throw new Error();
+		}
+
+		return await res.json();
+	})
 }
 
 const API_BASE_URL = 'https://api.npmjs.org/';

--- a/scripts/update-integrations.mjs
+++ b/scripts/update-integrations.mjs
@@ -113,7 +113,7 @@ async function unsafeUpdateAllIntegrations() {
 	const deprecatedIntegrations = [];
 
 	// loop through all integrations already published to the catalog
-	for (const entry of entries) {
+	await Promise.all(entries.map(async entry => {
 		const { data } = matter.read(entry);
 		existingIntegrations.add(data.name);
 
@@ -139,14 +139,14 @@ async function unsafeUpdateAllIntegrations() {
 ${frontmatter}---\n`,
 			);
 		}
-	}
+	}));
 
 	// find new integrations that haven't been published yet
 	const newIntegrations = Array.from(searchResults.keys()).filter(
 		(pkg) => !existingIntegrations.has(pkg),
 	);
 
-	for (const entry of newIntegrations) {
+	await Promise.all(newIntegrations.map(async (entry) => {
 		const details = await fetchWithOverrides(entry);
 
 		const frontmatter = yaml.stringify(details);
@@ -162,7 +162,7 @@ ${frontmatter}---\n`,
 			`---
 ${frontmatter}---\n`,
 		);
-	}
+	}));
 
 	updateLastModified();
 


### PR DESCRIPTION
- Update integrations in parallel, reduce the time for `update:integrations --unsafe` from 4 minutes to 10 seconds
- Use `p-limit` to avoid rate-limit errors by limiting the number of concurrent calls to NPM API to 10
	- `p-limit` is a already a dependency of Astro, so it is not an extra dependency to install