### PR TITLE
Include `astro-integration` keyword in integrations catalogue

### DIFF
--- a/scripts/update-integrations.mjs
+++ b/scripts/update-integrations.mjs
@@ -105,7 +105,7 @@ async function fetchWithOverrides(pkg, includeDownloads = true) {
 }
 
 async function unsafeUpdateAllIntegrations() {
-	const keyword = 'astro-component,withastro';
+	const keyword = 'astro-component,withastro,astro-integration';
 
 	const packagesMap = await searchByKeyword(keyword);
 	const searchResults = new Set(

--- a/src/content/integrations/@angiusastro-jsonc.md
+++ b/src/content/integrations/@angiusastro-jsonc.md
@@ -1,0 +1,11 @@
+---
+name: "@angius/astro-jsonc"
+title: "@angius/astro-jsonc"
+description: A simple JSON With Comments parser to allow its usage in Astro.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@angius/astro-jsonc
+repoUrl: https://github.com/Atulin/astro-jsonc
+homepageUrl: https://github.com/Atulin/astro-jsonc#readme
+downloads: 9
+---

--- a/src/content/integrations/@astro-contentfaker.md
+++ b/src/content/integrations/@astro-contentfaker.md
@@ -1,0 +1,11 @@
+---
+name: "@astro-content/faker"
+title: "@astro-content/faker"
+description: Quickly populate content collections from your schemas.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@astro-content/faker
+repoUrl: https://github.com/JulianCataldo/astro-content
+homepageUrl: https://astro-content.dev
+downloads: 3
+---

--- a/src/content/integrations/@astro-contentvalidator.md
+++ b/src/content/integrations/@astro-contentvalidator.md
@@ -1,0 +1,11 @@
+---
+name: "@astro-content/validator"
+title: "@astro-content/validator"
+description: A fail-safe way to ingest your project content.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@astro-content/validator
+repoUrl: https://github.com/JulianCataldo/astro-content
+homepageUrl: https://astro-content.dev
+downloads: 3
+---

--- a/src/content/integrations/@astro-openapiclient.md
+++ b/src/content/integrations/@astro-openapiclient.md
@@ -1,0 +1,12 @@
+---
+name: "@astro-openapi/client"
+title: "@astro-openapi/client"
+description: |-
+  Generate helpers for fetching an OpenAPI endpoint.
+  Supports vanilla fetchers, React Queries, Nano stores…
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@astro-openapi/client
+homepageUrl: https://www.npmjs.com/package/@astro-openapi/client
+downloads: 30
+---

--- a/src/content/integrations/@astro-openapischema-checkers.md
+++ b/src/content/integrations/@astro-openapischema-checkers.md
@@ -1,0 +1,10 @@
+---
+name: "@astro-openapi/schema-checkers"
+title: "@astro-openapi/schema-checkers"
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@astro-openapi/schema-checkers
+repoUrl: https://github.com/JulianCataldo/astro-openapi
+homepageUrl: https://juliancataldo.github.io/astro-openapi
+downloads: 9
+---

--- a/src/content/integrations/@astroliciousconfstellation.md
+++ b/src/content/integrations/@astroliciousconfstellation.md
@@ -1,0 +1,11 @@
+---
+name: "@astrolicious/confstellation"
+title: "@astrolicious/confstellation"
+description: A Conference solution built for Astro.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@astrolicious/confstellation
+repoUrl: https://github.com/UserName/@astrolicious/confstellation
+homepageUrl: https://github.com/UserName/theme-playground
+downloads: 12
+---

--- a/src/content/integrations/@besomwebcraftastro-healthcheck.md
+++ b/src/content/integrations/@besomwebcraftastro-healthcheck.md
@@ -1,0 +1,11 @@
+---
+name: "@besomwebcraft/astro-healthcheck"
+title: "@besomwebcraft/astro-healthcheck"
+description: Add healthcheck endpoint to astro site
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@besomwebcraft/astro-healthcheck
+repoUrl: https://github.com/Besom-Webcraft/astro-healthcheck
+homepageUrl: https://github.com/Besom-Webcraft/astro-healthcheck#readme
+downloads: 33
+---

--- a/src/content/integrations/@brandonaaronastro-script-embed.md
+++ b/src/content/integrations/@brandonaaronastro-script-embed.md
@@ -1,0 +1,11 @@
+---
+name: "@brandonaaron/astro-script-embed"
+title: "@brandonaaron/astro-script-embed"
+description: Embed (or inline) a script to your HTML in astro components.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@brandonaaron/astro-script-embed
+repoUrl: https://github.com/brandonaaron/astro-script-embed
+homepageUrl: https://github.com/brandonaaron/astro-script-embed#readme
+downloads: 10
+---

--- a/src/content/integrations/@brattonrossastro-playground.md
+++ b/src/content/integrations/@brattonrossastro-playground.md
@@ -1,0 +1,10 @@
+---
+name: "@brattonross/astro-playground"
+title: "@brattonross/astro-playground"
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@brattonross/astro-playground
+repoUrl: https://github.com/brattonross/astro-playground
+homepageUrl: https://github.com/brattonross/astro-playground
+downloads: 8
+---

--- a/src/content/integrations/@convocometauth-astro.md
+++ b/src/content/integrations/@convocometauth-astro.md
@@ -1,0 +1,13 @@
+---
+name: "@convocomet/auth-astro"
+title: "@convocomet/auth-astro"
+description: This is a fork of Auth Astro, including many fixes and new
+  features, which was created due to a lack of maintenance in the upstream
+  version.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@convocomet/auth-astro
+repoUrl: https://github.com/nowaythatworked/auth-astro
+homepageUrl: https://github.com/nowaythatworked/auth-astro#readme
+downloads: 12
+---

--- a/src/content/integrations/@dmnoastro-integration.md
+++ b/src/content/integrations/@dmnoastro-integration.md
@@ -1,0 +1,11 @@
+---
+name: "@dmno/astro-integration"
+title: "@dmno/astro-integration"
+description: tools for integrating dmno into astro
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@dmno/astro-integration
+repoUrl: https://github.com/dmno-dev/dmno
+homepageUrl: https://dmno.dev/docs/integrations/astro
+downloads: 214
+---

--- a/src/content/integrations/@ernxstastro-cssbundle.md
+++ b/src/content/integrations/@ernxstastro-cssbundle.md
@@ -1,0 +1,12 @@
+---
+name: "@ernxst/astro-cssbundle"
+title: "@ernxst/astro-cssbundle"
+description: An Astro integration to inject the missing link to the built CSS
+  stylesheet when Vite's CSS code splitting is disabled.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@ernxst/astro-cssbundle
+repoUrl: https://github.com/Ernxst/astro-cssbundle
+homepageUrl: https://github.com/Ernxst/astro-cssbundle
+downloads: 15
+---

--- a/src/content/integrations/@forastroremark-html-directives-integration.md
+++ b/src/content/integrations/@forastroremark-html-directives-integration.md
@@ -1,0 +1,11 @@
+---
+name: "@forastro/remark-html-directives-integration"
+title: "@forastro/remark-html-directives-integration"
+description: ""
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@forastro/remark-html-directives-integration
+repoUrl: https://github.com/louiss0/forastro
+homepageUrl: https://forastro-docs.onrender.com/libraries/remark-html-directives
+downloads: 49
+---

--- a/src/content/integrations/@frontendistaastro-html-minify.md
+++ b/src/content/integrations/@frontendistaastro-html-minify.md
@@ -1,0 +1,11 @@
+---
+name: "@frontendista/astro-html-minify"
+title: "@frontendista/astro-html-minify"
+description: HTML minifier for statically rendered files in Astro
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@frontendista/astro-html-minify
+repoUrl: https://github.com/frontendista/astro-html-minify
+homepageUrl: https://github.com/frontendista/astro-html-minify
+downloads: 107
+---

--- a/src/content/integrations/@inox-toolsaik-mod.md
+++ b/src/content/integrations/@inox-toolsaik-mod.md
@@ -1,0 +1,11 @@
+---
+name: "@inox-tools/aik-mod"
+title: "@inox-tools/aik-mod"
+description: AIK Plugin for inline modules
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@inox-tools/aik-mod
+repoUrl: https://github.com/Fryuni/inox-tools
+homepageUrl: https://github.com/Fryuni/inox-tools#readme
+downloads: 271
+---

--- a/src/content/integrations/@inox-toolsaik-route-config.md
+++ b/src/content/integrations/@inox-toolsaik-route-config.md
@@ -1,0 +1,13 @@
+---
+name: "@inox-tools/aik-route-config"
+title: "@inox-tools/aik-route-config"
+description: <p align="center">     <img alt="InoxTools" width="350px"
+  src="https://github.com/Fryuni/inox-tools/blob/main/assets/shield.png?raw=true"/>
+  </p>
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@inox-tools/aik-route-config
+repoUrl: https://github.com/Fryuni/inox-tools
+homepageUrl: https://github.com/Fryuni/inox-tools#readme
+downloads: 1375
+---

--- a/src/content/integrations/@inox-toolsastro-when.md
+++ b/src/content/integrations/@inox-toolsastro-when.md
@@ -1,0 +1,11 @@
+---
+name: "@inox-tools/astro-when"
+title: "@inox-tools/astro-when"
+description: Integration that informs when in Astro's lifecycle the code is running
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@inox-tools/astro-when
+repoUrl: https://github.com/Fryuni/inox-tools
+homepageUrl: https://github.com/Fryuni/inox-tools#readme
+downloads: 48958
+---

--- a/src/content/integrations/@inox-toolsmodular-station.md
+++ b/src/content/integrations/@inox-toolsmodular-station.md
@@ -1,0 +1,10 @@
+---
+name: "@inox-tools/modular-station"
+title: "@inox-tools/modular-station"
+description: Simplifying Astro integrations with a flexible docking system.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@inox-tools/modular-station
+homepageUrl: https://www.npmjs.com/package/@inox-tools/modular-station
+downloads: 837
+---

--- a/src/content/integrations/@inox-toolssitemap-ext.md
+++ b/src/content/integrations/@inox-toolssitemap-ext.md
@@ -1,0 +1,12 @@
+---
+name: "@inox-tools/sitemap-ext"
+title: "@inox-tools/sitemap-ext"
+description: Higher level extension over Astro's official sitemap integration
+categories:
+  - css+ui
+  - performance+seo
+npmUrl: https://www.npmjs.com/package/@inox-tools/sitemap-ext
+repoUrl: https://github.com/Fryuni/inox-tools
+homepageUrl: https://github.com/Fryuni/inox-tools#readme
+downloads: 928
+---

--- a/src/content/integrations/@j_csea-cat-chain_astro-openapi-validation.md
+++ b/src/content/integrations/@j_csea-cat-chain_astro-openapi-validation.md
@@ -1,0 +1,12 @@
+---
+name: "@j_c/sea-cat-chain_astro-openapi--validation"
+title: "@j_c/sea-cat-chain_astro-openapi--validation"
+description: "Provides useful code generation for where you need to pass
+  serializabled data.   Very useful for:"
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@j_c/sea-cat-chain_astro-openapi--validation
+repoUrl: https://github.com/JulianCataldo/astro-content
+homepageUrl: https://astro-content.dev
+downloads: 3
+---

--- a/src/content/integrations/@jcayzacastro-markdown-tree-dump.md
+++ b/src/content/integrations/@jcayzacastro-markdown-tree-dump.md
@@ -1,0 +1,13 @@
+---
+name: "@jcayzac/astro-markdown-tree-dump"
+title: "@jcayzac/astro-markdown-tree-dump"
+description: Dumps rehype and remark trees to files
+categories:
+  - css+ui
+  - recent
+npmUrl: https://www.npmjs.com/package/@jcayzac/astro-markdown-tree-dump
+repoUrl: https://github.com/jcayzac/copepod-modules
+homepageUrl: https://github.com/jcayzac/copepod-modules/tree/main/packages/astro-markdown-tree-dump#readme
+badge: new
+downloads: 346
+---

--- a/src/content/integrations/@keystaticastro.md
+++ b/src/content/integrations/@keystaticastro.md
@@ -1,0 +1,10 @@
+---
+name: "@keystatic/astro"
+title: "@keystatic/astro"
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@keystatic/astro
+repoUrl: https://github.com/Thinkmill/keystatic
+homepageUrl: https://github.com/Thinkmill/keystatic#readme
+downloads: 4511
+---

--- a/src/content/integrations/@lightnetdecap-admin.md
+++ b/src/content/integrations/@lightnetdecap-admin.md
@@ -1,0 +1,9 @@
+---
+name: "@lightnet/decap-admin"
+title: "@lightnet/decap-admin"
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@lightnet/decap-admin
+homepageUrl: https://www.npmjs.com/package/@lightnet/decap-admin
+downloads: 85
+---

--- a/src/content/integrations/@lightnetlibrary.md
+++ b/src/content/integrations/@lightnetlibrary.md
@@ -1,0 +1,9 @@
+---
+name: "@lightnet/library"
+title: "@lightnet/library"
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@lightnet/library
+homepageUrl: https://www.npmjs.com/package/@lightnet/library
+downloads: 356
+---

--- a/src/content/integrations/@orgajsastro.md
+++ b/src/content/integrations/@orgajsastro.md
@@ -1,0 +1,11 @@
+---
+name: "@orgajs/astro"
+title: "@orgajs/astro"
+description: Add support for org-mode pages in your Astro site
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@orgajs/astro
+repoUrl: https://github.com/orgapp/orgajs
+homepageUrl: https://github.com/orgapp/orgajs#readme
+downloads: 12
+---

--- a/src/content/integrations/@pietervdwerkauth-astro.md
+++ b/src/content/integrations/@pietervdwerkauth-astro.md
@@ -1,0 +1,13 @@
+---
+name: "@pietervdwerk/auth-astro"
+title: "@pietervdwerk/auth-astro"
+description: Auth Astro is the easiest way to add Authentication to your Astro
+  Project. It wraps the core of Auth.js into an Astro integration which
+  automatically adds the endpoints and handles everything else.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@pietervdwerk/auth-astro
+repoUrl: https://github.com/nowaythatworked/auth-astro
+homepageUrl: https://github.com/nowaythatworked/auth-astro#readme
+downloads: 40
+---

--- a/src/content/integrations/@sailhouseastro.md
+++ b/src/content/integrations/@sailhouseastro.md
@@ -1,0 +1,9 @@
+---
+name: "@sailhouse/astro"
+title: "@sailhouse/astro"
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@sailhouse/astro
+homepageUrl: https://www.npmjs.com/package/@sailhouse/astro
+downloads: 4
+---

--- a/src/content/integrations/@toshikurauchiactive-handout.md
+++ b/src/content/integrations/@toshikurauchiactive-handout.md
@@ -1,0 +1,10 @@
+---
+name: "@toshikurauchi/active-handout"
+title: "@toshikurauchi/active-handout"
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@toshikurauchi/active-handout
+repoUrl: https://github.com/insper-edu/active-handout-astro
+homepageUrl: https://github.com/insper-edu/active-handout-astro#readme
+downloads: 188
+---

--- a/src/content/integrations/@vite-pwaastro.md
+++ b/src/content/integrations/@vite-pwaastro.md
@@ -1,0 +1,11 @@
+---
+name: "@vite-pwa/astro"
+title: "@vite-pwa/astro"
+description: Zero-config PWA for Astro
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@vite-pwa/astro
+repoUrl: https://github.com/vite-pwa/astro
+homepageUrl: https://github.com/vite-pwa/astro#readme
+downloads: 8069
+---

--- a/src/content/integrations/@vl07flare-docs.md
+++ b/src/content/integrations/@vl07flare-docs.md
@@ -1,0 +1,11 @@
+---
+name: "@vl07/flare-docs"
+title: "@vl07/flare-docs"
+description: A documentation framework
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/@vl07/flare-docs
+repoUrl: https://github.com/VL07/flare-docs
+homepageUrl: https://github.com/VL07/flare-docs#readme
+downloads: 3
+---

--- a/src/content/integrations/astro-beep.md
+++ b/src/content/integrations/astro-beep.md
@@ -1,0 +1,11 @@
+---
+name: astro-beep
+title: astro-beep
+description: Trigger a system notification when your Astro build is complete
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-beep
+repoUrl: https://github.com/natemoo-re/astro-beep
+homepageUrl: https://github.com/natemoo-re/astro-beep#README
+downloads: 4
+---

--- a/src/content/integrations/astro-clerk-auth.md
+++ b/src/content/integrations/astro-clerk-auth.md
@@ -1,0 +1,11 @@
+---
+name: astro-clerk-auth
+title: astro-clerk-auth
+description: Unofficial package Clerk SDK for Asto
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-clerk-auth
+repoUrl: https://github.com/panteliselef/astro-with-clerk-auth
+homepageUrl: https://github.com/panteliselef/astro-with-clerk-auth/blob/main/packages/astro-clerk-auth/README.md
+downloads: 2131
+---

--- a/src/content/integrations/astro-common.md
+++ b/src/content/integrations/astro-common.md
@@ -1,0 +1,11 @@
+---
+name: astro-common
+title: astro-common
+description: Injecting common css to any page in astro.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-common
+repoUrl: https://github.com/findlay-best-wishes/astro-common
+homepageUrl: https://github.com/findlay-best-wishes/astro-common#readme
+downloads: 1
+---

--- a/src/content/integrations/astro-console-cleaner.md
+++ b/src/content/integrations/astro-console-cleaner.md
@@ -1,0 +1,12 @@
+---
+name: astro-console-cleaner
+title: astro-console-cleaner
+description: An Astro integration that removes console.log, console.warn, and
+  console.error statements from your code during the build process.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-console-cleaner
+repoUrl: https://github.com/zachhandley/astrojs-remove-console-log
+homepageUrl: https://github.com/zachhandley/astrojs-remove-console-log#readme
+downloads: 14
+---

--- a/src/content/integrations/astro-content.md
+++ b/src/content/integrations/astro-content.md
@@ -1,0 +1,10 @@
+---
+name: astro-content
+title: astro-content
+description: <div align="center">
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-content
+homepageUrl: https://www.npmjs.com/package/astro-content
+downloads: 9
+---

--- a/src/content/integrations/astro-copy.md
+++ b/src/content/integrations/astro-copy.md
@@ -1,0 +1,10 @@
+---
+name: astro-copy
+title: astro-copy
+description: This library was generated with Nx.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-copy
+homepageUrl: https://www.npmjs.com/package/astro-copy
+downloads: 11
+---

--- a/src/content/integrations/astro-d2.md
+++ b/src/content/integrations/astro-d2.md
@@ -1,0 +1,12 @@
+---
+name: astro-d2
+title: astro-d2
+description: Astro integration and remark plugin to transform D2 Markdown code
+  blocks into diagrams.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-d2
+repoUrl: https://github.com/HiDeoo/astro-d2
+homepageUrl: https://github.com/HiDeoo/astro-d2
+downloads: 2440
+---

--- a/src/content/integrations/astro-dev-plugin-reboot.md
+++ b/src/content/integrations/astro-dev-plugin-reboot.md
@@ -1,0 +1,10 @@
+---
+name: astro-dev-plugin-reboot
+title: astro-dev-plugin-reboot
+description: Reboot your computer, right from the Astro dev overlay.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-dev-plugin-reboot
+homepageUrl: https://github.com/florian-lefebvre/astro-dev-plugin-reboot
+downloads: 3
+---

--- a/src/content/integrations/astro-directives.md
+++ b/src/content/integrations/astro-directives.md
@@ -1,0 +1,11 @@
+---
+name: astro-directives
+title: astro-directives
+description: An astro integration for more client directives.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-directives
+repoUrl: https://github.com/QuentinDutot/astro-directives
+homepageUrl: https://github.com/QuentinDutot/astro-directives#readme
+downloads: 2
+---

--- a/src/content/integrations/astro-expressive-code.md
+++ b/src/content/integrations/astro-expressive-code.md
@@ -1,0 +1,12 @@
+---
+name: astro-expressive-code
+title: astro-expressive-code
+description: Astro integration for Expressive Code, a text marking & annotation
+  engine for presenting source code on the web.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-expressive-code
+repoUrl: https://github.com/expressive-code/expressive-code
+homepageUrl: https://github.com/expressive-code/expressive-code#readme
+downloads: 150872
+---

--- a/src/content/integrations/astro-fetch-redirects.md
+++ b/src/content/integrations/astro-fetch-redirects.md
@@ -1,0 +1,9 @@
+---
+name: astro-fetch-redirects
+title: astro-fetch-redirects
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-fetch-redirects
+homepageUrl: https://www.npmjs.com/package/astro-fetch-redirects
+downloads: 2
+---

--- a/src/content/integrations/astro-fluidcube.md
+++ b/src/content/integrations/astro-fluidcube.md
@@ -1,0 +1,9 @@
+---
+name: astro-fluidcube
+title: astro-fluidcube
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-fluidcube
+homepageUrl: https://www.npmjs.com/package/astro-fluidcube
+downloads: 8
+---

--- a/src/content/integrations/astro-htaccess.md
+++ b/src/content/integrations/astro-htaccess.md
@@ -1,0 +1,11 @@
+---
+name: astro-htaccess
+title: astro-htaccess
+description: Astro integration to generate an Apache .htaccess file
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-htaccess
+repoUrl: https://github.com/BadMannersXYZ/astro-htaccess
+homepageUrl: https://github.com/BadMannersXYZ/astro-htaccess
+downloads: 33
+---

--- a/src/content/integrations/astro-i18n-pages.md
+++ b/src/content/integrations/astro-i18n-pages.md
@@ -1,0 +1,11 @@
+---
+name: astro-i18n-pages
+title: astro-i18n-pages
+description: An astro integration to sync i18n pages.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-i18n-pages
+repoUrl: https://github.com/QuentinDutot/astro-i18n-pages
+homepageUrl: https://github.com/QuentinDutot/astro-i18n-pages#readme
+downloads: 2
+---

--- a/src/content/integrations/astro-i18n-routes.md
+++ b/src/content/integrations/astro-i18n-routes.md
@@ -1,0 +1,11 @@
+---
+name: astro-i18n-routes
+title: astro-i18n-routes
+description: An astro integration to sync i18n routes.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-i18n-routes
+repoUrl: https://github.com/QuentinDutot/astro-i18n-routes
+homepageUrl: https://github.com/QuentinDutot/astro-i18n-routes#readme
+downloads: 4
+---

--- a/src/content/integrations/astro-icons.md
+++ b/src/content/integrations/astro-icons.md
@@ -1,0 +1,11 @@
+---
+name: astro-icons
+title: astro-icons
+description: Access thousands of icons as components on-demand in your astro projects.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-icons
+repoUrl: https://github.com/panchaow/astro-icons
+homepageUrl: https://github.com/panchaow/astro-icons#readme
+downloads: 17
+---

--- a/src/content/integrations/astro-imports.md
+++ b/src/content/integrations/astro-imports.md
@@ -1,0 +1,10 @@
+---
+name: astro-imports
+title: astro-imports
+description: Auto imports for Astro.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-imports
+homepageUrl: https://www.npmjs.com/package/astro-imports
+downloads: 3
+---

--- a/src/content/integrations/astro-integration-windicss.md
+++ b/src/content/integrations/astro-integration-windicss.md
@@ -1,0 +1,11 @@
+---
+name: astro-integration-windicss
+title: astro-integration-windicss
+description: Windicss + Astro Integration
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-integration-windicss
+repoUrl: ttps://github.com/dv-dn/astro-integration-windicss
+homepageUrl: https://github.com/dv-dn/astro-integration-windicss
+downloads: 4
+---

--- a/src/content/integrations/astro-markdoc-ssr.md
+++ b/src/content/integrations/astro-markdoc-ssr.md
@@ -1,0 +1,10 @@
+---
+name: astro-markdoc-ssr
+title: astro-markdoc-ssr
+description: " npm create astro@latest -- --template minimal"
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-markdoc-ssr
+homepageUrl: https://www.npmjs.com/package/astro-markdoc-ssr
+downloads: 3
+---

--- a/src/content/integrations/astro-md-image-integration.md
+++ b/src/content/integrations/astro-md-image-integration.md
@@ -1,0 +1,11 @@
+---
+name: astro-md-image-integration
+title: astro-md-image-integration
+description: Use your images outside your src project folder.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-md-image-integration
+repoUrl: https://github.com/userquin/astro-md-image-integration
+homepageUrl: https://github.com/userquin/astro-md-image-integration
+downloads: 4
+---

--- a/src/content/integrations/astro-minify-html.md
+++ b/src/content/integrations/astro-minify-html.md
@@ -1,0 +1,11 @@
+---
+name: astro-minify-html
+title: astro-minify-html
+description: Astro integration to minify HTML
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-minify-html
+repoUrl: https://github.com/leoortizz/astro-minify-html
+homepageUrl: https://github.com/leoortizz/astro-minify-html.git
+downloads: 41
+---

--- a/src/content/integrations/astro-org.md
+++ b/src/content/integrations/astro-org.md
@@ -1,0 +1,11 @@
+---
+name: astro-org
+title: astro-org
+description: Astro plugin to import org-mode files.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-org
+repoUrl: https://github.com/rasendubi/uniorg
+homepageUrl: https://github.com/rasendubi/uniorg#readme
+downloads: 142
+---

--- a/src/content/integrations/astro-pages-hmr.md
+++ b/src/content/integrations/astro-pages-hmr.md
@@ -1,0 +1,12 @@
+---
+name: astro-pages-hmr
+title: astro-pages-hmr
+description: Adds HMR support to pages in Astro (src/pages/*). Supports .astro,
+  .html, .md, .mdx, etc pages and Content Collections.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-pages-hmr
+repoUrl: https://github.com/bluwy/astro-pages-hmr
+homepageUrl: https://github.com/bluwy/astro-pages-hmr#readme
+downloads: 7
+---

--- a/src/content/integrations/astro-pdf.md
+++ b/src/content/integrations/astro-pdf.md
@@ -1,0 +1,11 @@
+---
+name: astro-pdf
+title: astro-pdf
+description: A simple Astro integration to generate PDFs from built pages
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-pdf
+repoUrl: https://github.com/lameuler/astro-pdf
+homepageUrl: https://github.com/lameuler/astro-pdf#readme
+downloads: 368
+---

--- a/src/content/integrations/astro-prettify-html.md
+++ b/src/content/integrations/astro-prettify-html.md
@@ -1,0 +1,9 @@
+---
+name: astro-prettify-html
+title: astro-prettify-html
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-prettify-html
+homepageUrl: https://www.npmjs.com/package/astro-prettify-html
+downloads: 3
+---

--- a/src/content/integrations/astro-react-navigation.md
+++ b/src/content/integrations/astro-react-navigation.md
@@ -1,0 +1,11 @@
+---
+name: astro-react-navigation
+title: astro-react-navigation
+description: Hijack your Astro MPA with React Navigation's native-like routing
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-react-navigation
+repoUrl: https://github.com/jkhaui/castro
+homepageUrl: https://github.com/jkhaui/castro/tree/main/packages/astro-integrations/astro-react-navigation#astro-react-navigation
+downloads: 26
+---

--- a/src/content/integrations/astro-reading-time.md
+++ b/src/content/integrations/astro-reading-time.md
@@ -1,0 +1,11 @@
+---
+name: astro-reading-time
+title: astro-reading-time
+description: An Astro integration for calculate reading time of Markdown/MDX files
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-reading-time
+repoUrl: https://github.com/mogeko/mogeko
+homepageUrl: https://github.com/mogeko/mogeko/tree/master/packages/astro-reading-time#readme
+downloads: 147
+---

--- a/src/content/integrations/astro-rehype-img2pic.md
+++ b/src/content/integrations/astro-rehype-img2pic.md
@@ -1,0 +1,11 @@
+---
+name: astro-rehype-img2pic
+title: astro-rehype-img2pic
+description: Astro Integraton that automatically optimizes images referenced in
+  markdown files.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-rehype-img2pic
+homepageUrl: https://www.npmjs.com/package/astro-rehype-img2pic
+downloads: 143
+---

--- a/src/content/integrations/astro-relatinator.md
+++ b/src/content/integrations/astro-relatinator.md
@@ -1,0 +1,11 @@
+---
+name: astro-relatinator
+title: astro-relatinator
+description: Find related content in your Astro website or app
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-relatinator
+repoUrl: https://github.com/DBozhinovski/relatinator
+homepageUrl: https://github.com/DBozhinovski/relatinator#readme
+downloads: 24
+---

--- a/src/content/integrations/astro-responsive-image.md
+++ b/src/content/integrations/astro-responsive-image.md
@@ -1,0 +1,10 @@
+---
+name: astro-responsive-image
+title: astro-responsive-image
+description: This library was generated with Nx.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-responsive-image
+homepageUrl: https://www.npmjs.com/package/astro-responsive-image
+downloads: 8
+---

--- a/src/content/integrations/astro-run.md
+++ b/src/content/integrations/astro-run.md
@@ -1,0 +1,12 @@
+---
+name: astro-run
+title: astro-run
+description: This Astro integration exposes user-friendly hooks into the astro
+  build process using zx.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-run
+repoUrl: https://github.com/natemoo-re/astro-run
+homepageUrl: https://github.com/natemoo-re/astro-run/tree/main/packages/core#readme
+downloads: 3
+---

--- a/src/content/integrations/astro-screen-recorder.md
+++ b/src/content/integrations/astro-screen-recorder.md
@@ -1,0 +1,12 @@
+---
+name: astro-screen-recorder
+title: astro-screen-recorder
+description: astro dev toolbar button for screen recording
+categories:
+  - css+ui
+  - adapters
+npmUrl: https://www.npmjs.com/package/astro-screen-recorder
+repoUrl: https://github.com/Cspeisman/astro-screen-recorder
+homepageUrl: https://github.com/Cspeisman/astro-screen-recorder#readme
+downloads: 12
+---

--- a/src/content/integrations/astro-selfie.md
+++ b/src/content/integrations/astro-selfie.md
@@ -1,0 +1,11 @@
+---
+name: astro-selfie
+title: astro-selfie
+description: Astro integration to generate page screenshots to show as Open Graph images
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-selfie
+repoUrl: https://github.com/vadimdemedes/astro-selfie
+homepageUrl: https://github.com/vadimdemedes/astro-selfie#readme
+downloads: 5
+---

--- a/src/content/integrations/astro-seo-images.md
+++ b/src/content/integrations/astro-seo-images.md
@@ -1,0 +1,10 @@
+---
+name: astro-seo-images
+title: astro-seo-images
+description: Use Astro templates to generate social images for your Astro build
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-seo-images
+homepageUrl: https://github.com/davidwarrington/astro-seo-images
+downloads: 14
+---

--- a/src/content/integrations/astro-subsites.md
+++ b/src/content/integrations/astro-subsites.md
@@ -1,0 +1,12 @@
+---
+name: astro-subsites
+title: astro-subsites
+description: This Astro integration allows developers to treat an Astro
+  project's folder as sub-website.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-subsites
+repoUrl: ssh://git@gitlab.com/aimedev/astro-subsites
+homepageUrl: https://gitlab.com/aimedev/astro-subsites#readme
+downloads: 2
+---

--- a/src/content/integrations/astro-suspense.md
+++ b/src/content/integrations/astro-suspense.md
@@ -1,0 +1,11 @@
+---
+name: astro-suspense
+title: astro-suspense
+description: Out of order streaming support for Astro.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-suspense
+repoUrl: https://github.com/charlie-hadden/astro-suspense
+homepageUrl: https://github.com/charlie-hadden/astro-suspense#readme
+downloads: 83
+---

--- a/src/content/integrations/astro-theme-mecure.md
+++ b/src/content/integrations/astro-theme-mecure.md
@@ -1,0 +1,10 @@
+---
+name: astro-theme-mecure
+title: astro-theme-mecure
+description: A beautiful Astro theme for personal blog
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-theme-mecure
+homepageUrl: https://www.npmjs.com/package/astro-theme-mecure
+downloads: 665
+---

--- a/src/content/integrations/astro-toml.md
+++ b/src/content/integrations/astro-toml.md
@@ -1,0 +1,11 @@
+---
+name: astro-toml
+title: astro-toml
+description: A simple TOML parser to allow usage of TOML as a collection in Astro.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-toml
+repoUrl: https://github.com/cmgriffing/astro-toml
+homepageUrl: https://github.com/cmgriffing/astro-toml#readme
+downloads: 7
+---

--- a/src/content/integrations/astro-typed-routes.md
+++ b/src/content/integrations/astro-typed-routes.md
@@ -1,0 +1,11 @@
+---
+name: astro-typed-routes
+title: astro-typed-routes
+description: Type-safe pages links for Astro
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-typed-routes
+repoUrl: https://github.com/bartoszkrawczyk2/astro-typed-routes
+homepageUrl: https://github.com/bartoszkrawczyk2/astro-typed-routes#readme
+downloads: 3
+---

--- a/src/content/integrations/astro-typesafe-routes.md
+++ b/src/content/integrations/astro-typesafe-routes.md
@@ -1,0 +1,11 @@
+---
+name: astro-typesafe-routes
+title: astro-typesafe-routes
+description: Astro Integration for typesafe URLs
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-typesafe-routes
+repoUrl: https://github.com/feelixe/astro-typesafe-routes
+homepageUrl: https://github.com/feelixe/astro-typesafe-routes
+downloads: 237
+---

--- a/src/content/integrations/astro-unminify-cloudflare.md
+++ b/src/content/integrations/astro-unminify-cloudflare.md
@@ -1,0 +1,11 @@
+---
+name: astro-unminify-cloudflare
+title: astro-unminify-cloudflare
+description: Astro integration to unminify the generated Cloudflare worker.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-unminify-cloudflare
+repoUrl: https://github.com/altipla-consulting/astro-unminify-cloudflare
+homepageUrl: https://github.com/altipla-consulting/astro-unminify-cloudflare#readme
+downloads: 2
+---

--- a/src/content/integrations/astro-ununura.md
+++ b/src/content/integrations/astro-ununura.md
@@ -1,0 +1,11 @@
+---
+name: astro-ununura
+title: astro-ununura
+description: A Atomic CSS Engine Integration for Astro.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-ununura
+repoUrl: https://github.com/Novout/ununuracss
+homepageUrl: https://ununura.com
+downloads: 44
+---

--- a/src/content/integrations/astro-webhooks.md
+++ b/src/content/integrations/astro-webhooks.md
@@ -1,0 +1,11 @@
+---
+name: astro-webhooks
+title: astro-webhooks
+description: Receive webhooks in Astro apps
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-webhooks
+repoUrl: https://github.com/codiume/orbit
+homepageUrl: https://github.com/codiume/orbit
+downloads: 10
+---

--- a/src/content/integrations/astro-worker-links.md
+++ b/src/content/integrations/astro-worker-links.md
@@ -1,0 +1,11 @@
+---
+name: astro-worker-links
+title: astro-worker-links
+description: Automatically create shortened urls for your Astro project via worker-links
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astro-worker-links
+repoUrl: https://github.com/Ovyerus/astro-worker-links
+homepageUrl: https://github.com/Ovyerus/astro-worker-links
+downloads: 20
+---

--- a/src/content/integrations/astropix.md
+++ b/src/content/integrations/astropix.md
@@ -1,0 +1,11 @@
+---
+name: astropix
+title: astropix
+description: Astro integration for astropix.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/astropix
+repoUrl: https://github.com/alexanderniebuhr/astropix
+homepageUrl: https://github.com/alexanderniebuhr/astropix/blob/main/packages/astropix/README.md
+downloads: 2
+---

--- a/src/content/integrations/icon-prerender.md
+++ b/src/content/integrations/icon-prerender.md
@@ -1,0 +1,12 @@
+---
+name: icon-prerender
+title: icon-prerender
+description: A plugin to prerender your SVG icons at compile time, rather than
+  making the client fetch them during runtime.
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/icon-prerender
+repoUrl: https://github.com/Ernxst/icon-prerender
+homepageUrl: https://github.com/Ernxst/icon-prerender/packages/core
+downloads: 7
+---

--- a/src/content/integrations/is-wdsssx.md
+++ b/src/content/integrations/is-wdsssx.md
@@ -1,0 +1,11 @@
+---
+name: is-wdsssx
+title: is-wdsssx
+description: Is the string WDS?
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/is-wdsssx
+repoUrl: ssh://git@github.com/apophis51/package
+homepageUrl: https://github.com/apophis51/package#readme
+downloads: 2
+---

--- a/src/content/integrations/porfolio-dev.md
+++ b/src/content/integrations/porfolio-dev.md
@@ -1,0 +1,10 @@
+---
+name: porfolio-dev
+title: porfolio-dev
+description: "!Instalar las dependencias: npm install"
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/porfolio-dev
+homepageUrl: https://www.npmjs.com/package/porfolio-dev
+downloads: 1
+---

--- a/src/content/integrations/unplugin-fonts.md
+++ b/src/content/integrations/unplugin-fonts.md
@@ -1,0 +1,12 @@
+---
+name: unplugin-fonts
+title: unplugin-fonts
+description: Universal Webfont loader
+categories:
+  - css+ui
+npmUrl: https://www.npmjs.com/package/unplugin-fonts
+repoUrl: https://github.com/cssninjaStudio/unplugin-fonts
+homepageUrl: https://github.com/cssninjaStudio/unplugin-fonts#readme
+downloads: 205311
+downloadFactor: 0.001
+---

--- a/src/content/integrations/zastro-service-worker.md
+++ b/src/content/integrations/zastro-service-worker.md
@@ -1,0 +1,14 @@
+---
+name: zastro-service-worker
+title: zastro-service-worker
+description: An Astro integration that adds service worker functionality to your
+  Astro project, powered by Workbox.
+categories:
+  - css+ui
+  - recent
+npmUrl: https://www.npmjs.com/package/zastro-service-worker
+repoUrl: https://github.com/zachhandley/astro-service-worker
+homepageUrl: https://github.com/zachhandley/astro-service-worker#readme
+badge: new
+downloads: 267
+---


### PR DESCRIPTION
We require the `astro-integration` keyword to make an npm package work with `astro add` ([docs](https://docs.astro.build/en/reference/integrations-reference/#allow-installation-with-astro-add)), but never actually tracked that in the integrations catalogue, requiring one of `withastro` or `astro-component` instead. This PR updates the integrations script to also treat `astro-integration` as a sufficient keyword to include a package in our catalogue and runs the update script to add a bunch of missing integrations.

Most notably this includes Expressive Code!