### PR TITLE
More integration catalogue improvements

### DIFF
--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -26,6 +26,9 @@
 		},
 		"utilities": {
 			"keywords": ["tooling", "utils", "utility"]
+		},
+		"media": {
+			"keywords": ["media", "image", "images", "video", "audio"]
 		}
 	},
 	"featured": [

--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -49,7 +49,6 @@
 		"astro-json-element"
 	],
 	"toolbar": ["@storyblok/astro", "@spotlightjs/astro"],
-	"allowlist": [],
 	"blocklist": [
 		"@advanced-astro/capo",
 		"@astrojs/db",

--- a/scripts/integrations.mjs
+++ b/scripts/integrations.mjs
@@ -1,20 +1,26 @@
+// @ts-check
+
 import { differenceInDays } from 'date-fns';
 import integrations from './integrations.json' assert { type: 'json' };
 
 const NEW_THRESHOLD_DAYS = 28;
 
-const keywordToCategories = Object.entries(integrations.categories).reduce((acc, [key, value]) => {
-	const { keywords = [] } = value;
+const keywordToCategories = Object.entries(integrations.categories).reduce(
+	(acc, [key, value]) => {
+		const { keywords = [] } = value;
 
-	for (const keyword of keywords) {
-		const set = acc.has(keyword) ? acc.get(keyword) : new Set();
-		set.add(key);
-		acc.set(keyword, set);
-	}
+		for (const keyword of keywords) {
+			const set = acc.get(keyword) || new Set();
+			set.add(key);
+			acc.set(keyword, set);
+		}
 
-	return acc;
-}, new Map());
+		return acc;
+	},
+	/** @type {Map<string, Set<string>>} */ (new Map()),
+);
 
+/** @param {{ time?: { created: string } }} pkg  */
 export function isNewPackage(pkg) {
 	if (!pkg.time?.created) {
 		return false;
@@ -25,29 +31,31 @@ export function isNewPackage(pkg) {
 	return differenceInDays(today, date) <= NEW_THRESHOLD_DAYS;
 }
 
-export const allowlist = integrations.allowlist;
 export const blocklist = integrations.blocklist;
 
 /**
  * Gets the overridden integration properties for an npm package, or undefined if not found.
  *
- * @param {String} packageName Name of the NPM package
- * @returns {Partial<AppendMode.Integration> | undefined}
+ * @param {string} packageName Name of the NPM package
+ * @returns {undefined | { image?: string; description?: string; repoUrl?: string; homepageUrl?: string; categories?: string[] }}
  */
 export function getOverrides(packageName) {
-	return packageName in integrations.overrides ? integrations.overrides[packageName] : undefined;
+	return packageName in integrations.overrides
+		? integrations.overrides[/** @type {keyof typeof integrations.overrides} */ (packageName)]
+		: undefined;
 }
 
 /**
  * Gets a list of integration categories for an npm keyword.
  *
- * @param {String} keyword NPM package keyword
- * @returns {String[]}
+ * @param {string} keyword NPM package keyword
+ * @returns {string[]}
  */
 export function getCategoriesForKeyword(keyword) {
-	return keywordToCategories.has(keyword) ? Array.from(keywordToCategories.get(keyword)) : [];
+	return [...(keywordToCategories.get(keyword) || [])];
 }
 
+/** @param {Parameters<typeof isNewPackage>[0]} pkg */
 export function badgeForPackage(pkg) {
 	if (isNewPackage(pkg)) {
 		return 'new';
@@ -56,6 +64,7 @@ export function badgeForPackage(pkg) {
 	return undefined;
 }
 
+/** @param {string} pkg */
 export function getToolbarPackagePriority(pkg) {
 	const index = integrations.toolbar.indexOf(pkg) + 1;
 	return index > 0 ? index : undefined;

--- a/scripts/npm.mjs
+++ b/scripts/npm.mjs
@@ -43,9 +43,17 @@ export async function fetchDownloadsForPackage(pkg) {
 const npmRegistrySchema = z.object({
 	name: z.string(),
 	description: z.string().optional(),
-	homepage: z.string().optional(),
+	homepage: z.string().url().optional(),
 	keywords: z.string().array().default([]),
-	repository: z.object({ url: z.string() }).optional(),
+	repository: z
+		.union([
+			z.string().url(),
+			// If the package.json’s repo field is an object, convert it to a string:
+			z
+				.object({ url: z.string().url() })
+				.transform(({ url }) => url),
+		])
+		.optional(),
 	time: z.object({ created: z.string(), modified: z.string() }),
 });
 

--- a/scripts/npm.mjs
+++ b/scripts/npm.mjs
@@ -1,8 +1,12 @@
+import { z } from 'astro/zod';
 import { format, subDays } from 'date-fns';
 import pLimit from 'p-limit';
 
 const fetchLimit = pLimit(10);
 
+/**
+ * @param {string | URL} url
+ */
 function fetchJson(url) {
 	return fetchLimit(async () => {
 		const res = await fetch(url);
@@ -36,14 +40,24 @@ export async function fetchDownloadsForPackage(pkg) {
 		.catch(() => 0);
 }
 
+const npmRegistrySchema = z.object({
+	name: z.string(),
+	description: z.string().optional(),
+	homepage: z.string().optional(),
+	keywords: z.string().array().default([]),
+	repository: z.object({ url: z.string() }).optional(),
+	time: z.object({ created: z.string(), modified: z.string() }),
+});
+
 /**
  * Gets details for a package from the npm registry
  *
  * @param {string} pkg Name of the package published to npm
- * @returns {Promise<any>} JSON data as returned by the npm registry
+ * @returns JSON data as returned by the npm registry
  */
-export function fetchDetailsForPackage(pkg) {
-	return fetchJson(`${REGISTRY_BASE_URL}${pkg}`);
+export async function fetchDetailsForPackage(pkg) {
+	const registryData = await fetchJson(`${REGISTRY_BASE_URL}${pkg}`);
+	return npmRegistrySchema.parse(registryData);
 }
 
 /**
@@ -62,8 +76,8 @@ export async function searchByKeyword(keyword, ranking = 'quality') {
 		const url = new URL(`${REGISTRY_BASE_URL}-/v1/search`);
 		url.searchParams.set('text', `keywords:${keyword}`);
 		url.searchParams.set('ranking', ranking);
-		url.searchParams.set('size', PAGE_SIZE);
-		url.searchParams.set('from', page++ * PAGE_SIZE);
+		url.searchParams.set('size', String(PAGE_SIZE));
+		url.searchParams.set('from', String(page++ * PAGE_SIZE));
 
 		const results = await fetchJson(url.toString());
 

--- a/scripts/update-integrations.mjs
+++ b/scripts/update-integrations.mjs
@@ -73,7 +73,7 @@ function normalizePackageDetails(data, pkg) {
 
 	const npmUrl = `https://www.npmjs.com/package/${pkg}`;
 
-	const repoUrl = data.repository?.url && sanitizeGitHubUrl(data.repository.url);
+	const repoUrl = data.repository && sanitizeGitHubUrl(data.repository);
 
 	let homepageUrl = npmUrl;
 	// The `homepage` field is user-authored, so sometimes funky values can end up here.

--- a/scripts/update-integrations.mjs
+++ b/scripts/update-integrations.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -95,13 +97,20 @@ function normalizePackageDetails(data, pkg) {
 /** @param {string} pkg */
 async function fetchWithOverrides(pkg, includeDownloads = true) {
 	const details = await fetchDetailsForPackage(pkg);
-	const integrationOverrides = getOverrides(pkg) || {};
+	const { categories, ...integrationOverrides } = getOverrides(pkg) || {};
 
 	const badge = badgeForPackage(details);
 	const toolbar = getToolbarPackagePriority(pkg);
+	const normalizedDetails = normalizePackageDetails(details, pkg);
+
+	for (const category of categories || []) {
+		if (!normalizedDetails.categories.includes(category)) {
+			normalizedDetails.categories.push(category);
+		}
+	}
 
 	return {
-		...normalizePackageDetails(details, pkg),
+		...normalizedDetails,
 		...integrationOverrides,
 		badge,
 		toolbar,

--- a/scripts/update-integrations.mjs
+++ b/scripts/update-integrations.mjs
@@ -1,5 +1,3 @@
-// @ts-check
-
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -98,20 +96,13 @@ function normalizePackageDetails(data, pkg) {
 async function fetchWithOverrides(pkg, includeDownloads = true) {
 	const details = await fetchDetailsForPackage(pkg);
 	if (!details) return;
-	const { categories, ...integrationOverrides } = getOverrides(pkg) || {};
+	const integrationOverrides = getOverrides(pkg) || {};
 
 	const badge = badgeForPackage(details);
 	const toolbar = getToolbarPackagePriority(pkg);
-	const normalizedDetails = normalizePackageDetails(details, pkg);
-
-	for (const category of categories || []) {
-		if (!normalizedDetails.categories.includes(category)) {
-			normalizedDetails.categories.push(category);
-		}
-	}
 
 	return {
-		...normalizedDetails,
+		...normalizePackageDetails(details, pkg),
 		...integrationOverrides,
 		badge,
 		toolbar,

--- a/scripts/update-integrations.mjs
+++ b/scripts/update-integrations.mjs
@@ -50,7 +50,7 @@ async function getIntegrationFiles() {
 }
 
 /**
- * @param {Awaited<ReturnType<typeof fetchDetailsForPackage>>} data
+ * @param {NonNullable<Awaited<ReturnType<typeof fetchDetailsForPackage>>>} data
  * @param {string} pkg
  */
 function normalizePackageDetails(data, pkg) {
@@ -97,6 +97,7 @@ function normalizePackageDetails(data, pkg) {
 /** @param {string} pkg */
 async function fetchWithOverrides(pkg, includeDownloads = true) {
 	const details = await fetchDetailsForPackage(pkg);
+	if (!details) return;
 	const { categories, ...integrationOverrides } = getOverrides(pkg) || {};
 
 	const badge = badgeForPackage(details);
@@ -145,6 +146,7 @@ async function unsafeUpdateAllIntegrations() {
 				// skipping download counts here since existing integrations will be updated
 				// automatically in a separate GitHub Action.
 				const details = await fetchWithOverrides(data.name, false);
+				if (!details) return;
 
 				const frontmatter = yaml.stringify({
 					...data,
@@ -169,6 +171,7 @@ ${frontmatter}---\n`,
 	await Promise.all(
 		newIntegrations.map(async (entry) => {
 			const details = await fetchWithOverrides(entry);
+			if (!details) return;
 
 			const frontmatter = yaml.stringify(details);
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -7,7 +7,7 @@ export const IntegrationCategories = new Map([
 	['recent', 'Recently Added'],
 	['official', 'Official'],
 	['frameworks', 'Frameworks'],
-	['loaders', 'Loaders'],
+	['loaders', 'Content Loaders'],
 	['adapters', 'Adapters'],
 	['css+ui', 'CSS + UI'],
 	['performance+seo', 'Performance + SEO'],

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -13,6 +13,7 @@ export const IntegrationCategories = new Map([
 	['performance+seo', 'Performance + SEO'],
 	['analytics', 'Analytics'],
 	['accessibility', 'Accessibility'],
+	['media', 'Images + Media'],
 	['toolbar', 'Dev Toolbar'],
 	['utilities', 'Utilities'],
 	['uncategorized', 'Uncategorized'],

--- a/src/content/integrations/@astro-communityastro-embed-link-preview.md
+++ b/src/content/integrations/@astro-communityastro-embed-link-preview.md
@@ -3,7 +3,7 @@ name: "@astro-community/astro-embed-link-preview"
 title: "@astro-community/astro-embed-link-preview"
 description: Component to embed a website’s OpenGraph image and metadata on your Astro site
 categories:
-  - uncategorized
+  - css+ui
 npmUrl: https://www.npmjs.com/package/@astro-community/astro-embed-link-preview
 repoUrl: https://github.com/delucis/astro-embed
 homepageUrl: https://astro-embed.netlify.app/components/link-preview/

--- a/src/content/integrations/@astro-communityastro-embed-twitter.md
+++ b/src/content/integrations/@astro-communityastro-embed-twitter.md
@@ -3,7 +3,7 @@ name: "@astro-community/astro-embed-twitter"
 title: "@astro-community/astro-embed-twitter"
 description: Component to easily embed Tweets on your Astro site
 categories:
-  - uncategorized
+  - css+ui
 npmUrl: https://www.npmjs.com/package/@astro-community/astro-embed-twitter
 repoUrl: https://github.com/delucis/astro-embed
 homepageUrl: https://astro-embed.netlify.app/components/twitter/

--- a/src/content/integrations/@astro-communityastro-embed-vimeo.md
+++ b/src/content/integrations/@astro-communityastro-embed-vimeo.md
@@ -3,7 +3,7 @@ name: "@astro-community/astro-embed-vimeo"
 title: "@astro-community/astro-embed-vimeo"
 description: Component to easily embed Vimeo videos on your Astro site
 categories:
-  - uncategorized
+  - css+ui
 npmUrl: https://www.npmjs.com/package/@astro-community/astro-embed-vimeo
 repoUrl: https://github.com/delucis/astro-embed
 homepageUrl: https://astro-embed.netlify.app/components/vimeo/

--- a/src/content/integrations/@astro-communityastro-embed-youtube.md
+++ b/src/content/integrations/@astro-communityastro-embed-youtube.md
@@ -3,7 +3,7 @@ name: "@astro-community/astro-embed-youtube"
 title: "@astro-community/astro-embed-youtube"
 description: Component to easily embed YouTube videos on your Astro site
 categories:
-  - uncategorized
+  - css+ui
 npmUrl: https://www.npmjs.com/package/@astro-community/astro-embed-youtube
 repoUrl: https://github.com/delucis/astro-embed
 homepageUrl: https://astro-embed.netlify.app/components/youtube/

--- a/src/content/integrations/@azhirovastro-icon.md
+++ b/src/content/integrations/@azhirovastro-icon.md
@@ -3,6 +3,7 @@ name: "@azhirov/astro-icon"
 title: "@azhirov/astro-icon"
 description: This Astro integration provides a straight-forward Icon component for Astro.
 categories:
+  - media
   - css+ui
   - performance+seo
 npmUrl: https://www.npmjs.com/package/@azhirov/astro-icon

--- a/src/content/integrations/@cyberkoalastudiosog-image-generator.md
+++ b/src/content/integrations/@cyberkoalastudiosog-image-generator.md
@@ -5,6 +5,7 @@ description: Astro integration to generate Social Images from Astro Content
   Collections with custom blurry background that can be loaded via frontmatter.
 categories:
   - performance+seo
+  - media
 npmUrl: https://www.npmjs.com/package/@cyberkoalastudios/og-image-generator
 repoUrl: https://github.com/CyberKoalaStudios/og-image-generator
 homepageUrl: https://github.com/CyberKoalaStudios/og-image-generator#readme

--- a/src/content/integrations/@futurefabricastro-imagetools.md
+++ b/src/content/integrations/@futurefabricastro-imagetools.md
@@ -3,6 +3,7 @@ name: "@futurefabric/astro-imagetools"
 title: "@futurefabric/astro-imagetools"
 description: Image Optimization tools for the Astro JS framework
 categories:
+  - media
   - performance+seo
 npmUrl: https://www.npmjs.com/package/@futurefabric/astro-imagetools
 repoUrl: https://github.com/RafidMuhymin/astro-imagetools

--- a/src/content/integrations/@jcayzacastro-image-service-ng.md
+++ b/src/content/integrations/@jcayzacastro-image-service-ng.md
@@ -4,7 +4,7 @@ title: "@jcayzac/astro-image-service-ng"
 description: A drop-in replacement for Astro's default image service, with art
   direction support.
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/@jcayzac/astro-image-service-ng
 repoUrl: https://github.com/jcayzac/copepod-modules
 homepageUrl: https://github.com/jcayzac/copepod-modules/tree/main/packages/astro-image-service-ng#readme

--- a/src/content/integrations/@jcayzacastro-minify-html.md
+++ b/src/content/integrations/@jcayzacastro-minify-html.md
@@ -4,10 +4,8 @@ title: "@jcayzac/astro-minify-html"
 description: Minifies Astro's generated HTML, including inline scripts & styles.
 categories:
   - uncategorized
-  - recent
 npmUrl: https://www.npmjs.com/package/@jcayzac/astro-minify-html
 repoUrl: https://github.com/jcayzac/copepod-modules
 homepageUrl: https://github.com/jcayzac/copepod-modules/tree/main/packages/astro-minify-html#readme
-badge: new
 downloads: 212
 ---

--- a/src/content/integrations/@jcblwastro-site-integration.md
+++ b/src/content/integrations/@jcblwastro-site-integration.md
@@ -3,6 +3,7 @@ name: "@jcblw/astro-site-integration"
 title: "@jcblw/astro-site-integration"
 description: A way to leverage Vercel's Image Optimization API in Astro
 categories:
+  - media
   - performance+seo
 npmUrl: https://www.npmjs.com/package/@jcblw/astro-site-integration
 repoUrl: ssh://git@github.com/jcblw/astro-vercel-image

--- a/src/content/integrations/@julian_cataldoastro-lightbox.md
+++ b/src/content/integrations/@julian_cataldoastro-lightbox.md
@@ -3,7 +3,7 @@ name: "@julian_cataldo/astro-lightbox"
 title: "@julian_cataldo/astro-lightbox"
 description: Simple lightbox component.
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/@julian_cataldo/astro-lightbox
 repoUrl: https://github.com/JulianCataldo/web-garden
 homepageUrl: https://code.juliancataldo.com/component/astro-lightbox

--- a/src/content/integrations/@otterstacksanity-img-astro.md
+++ b/src/content/integrations/@otterstacksanity-img-astro.md
@@ -4,7 +4,7 @@ title: "@otterstack/sanity-img-astro"
 description: An Astro component for rendering a responsive <img> element for an
   image fetched from Sanity
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/@otterstack/sanity-img-astro
 repoUrl: https://github.com/otterdev-io/otterstack
 homepageUrl: https://github.com/otterdev-io/otterstack/tree/main/astro#readme

--- a/src/content/integrations/@playformcompress.md
+++ b/src/content/integrations/@playformcompress.md
@@ -4,6 +4,7 @@ title: "@playform/compress"
 description: 🗜️ Compress —
 categories:
   - css+ui
+  - media
   - performance+seo
 npmUrl: https://www.npmjs.com/package/@playform/compress
 image: /assets/integrations/@playform/compress.svg

--- a/src/content/integrations/@senseimarvastro-icon.md
+++ b/src/content/integrations/@senseimarvastro-icon.md
@@ -3,6 +3,7 @@ name: "@senseimarv/astro-icon"
 title: "@senseimarv/astro-icon"
 description: This is a fork of Astro Icon with @iconify/json as peer dependency.
 categories:
+  - media
   - css+ui
   - performance+seo
 npmUrl: https://www.npmjs.com/package/@senseimarv/astro-icon

--- a/src/content/integrations/@simpleauthorityastro-icon-ssr.md
+++ b/src/content/integrations/@simpleauthorityastro-icon-ssr.md
@@ -3,6 +3,7 @@ name: "@simpleauthority/astro-icon-ssr"
 title: "@simpleauthority/astro-icon-ssr"
 description: A straight-forward Icon component for Astro.
 categories:
+  - media
   - css+ui
   - performance+seo
 npmUrl: https://www.npmjs.com/package/@simpleauthority/astro-icon-ssr

--- a/src/content/integrations/@unpicastro.md
+++ b/src/content/integrations/@unpicastro.md
@@ -3,7 +3,7 @@ name: "@unpic/astro"
 title: "@unpic/astro"
 description: A high-performance, responsive image service and component library for Astro
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/@unpic/astro
 repoUrl: https://github.com/ascorbic/unpic-img
 homepageUrl: https://unpic.pics/img/astro

--- a/src/content/integrations/@uramiastro.md
+++ b/src/content/integrations/@uramiastro.md
@@ -3,6 +3,7 @@ name: "@urami/astro"
 title: "@urami/astro"
 description: Astro integration for automatic image optimization
 categories:
+  - media
   - performance+seo
 npmUrl: https://www.npmjs.com/package/@urami/astro
 repoUrl: https://github.com/rayriffy/urami

--- a/src/content/integrations/@wticonsastro.md
+++ b/src/content/integrations/@wticonsastro.md
@@ -7,4 +7,5 @@ categories:
 npmUrl: https://www.npmjs.com/package/@wticons/astro
 homepageUrl: https://www.npmjs.com/package/@wticons/astro
 downloads: 22
+repoUrl: https://github.com/OzzyCzech/wticons
 ---

--- a/src/content/integrations/astro-auto-import.md
+++ b/src/content/integrations/astro-auto-import.md
@@ -3,7 +3,7 @@ name: astro-auto-import
 title: astro-auto-import
 description: Auto-import components in Astro projects
 categories:
-  - uncategorized
+  - utilities
 npmUrl: https://www.npmjs.com/package/astro-auto-import
 repoUrl: https://github.com/delucis/astro-auto-import
 homepageUrl: https://github.com/delucis/astro-auto-import#readme

--- a/src/content/integrations/astro-better-image-service.md
+++ b/src/content/integrations/astro-better-image-service.md
@@ -4,7 +4,7 @@ title: astro-better-image-service
 description: Astro integration for image compression and conversion, superseding
   Astro's default image service.
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/astro-better-image-service
 repoUrl: https://github.com/risu729/astro-better-image-service
 homepageUrl: https://github.com/risu729/astro-better-image-service#readme

--- a/src/content/integrations/astro-carousel.md
+++ b/src/content/integrations/astro-carousel.md
@@ -4,6 +4,7 @@ title: astro-carousel
 description: An accessible carousel component for Astro 🚀 that works by using
   browser navigation.
 categories:
+  - media
   - accessibility
 npmUrl: https://www.npmjs.com/package/astro-carousel
 homepageUrl: https://www.npmjs.com/package/astro-carousel

--- a/src/content/integrations/astro-cloudinary-image.md
+++ b/src/content/integrations/astro-cloudinary-image.md
@@ -3,6 +3,7 @@ name: astro-cloudinary-image
 title: astro-cloudinary-image
 description: Adds a Cloudinary image component to Astro
 categories:
+  - media
   - performance+seo
 npmUrl: https://www.npmjs.com/package/astro-cloudinary-image
 repoUrl: https://github.com/ericrisco/astro-cloudinary-image

--- a/src/content/integrations/astro-compress.md
+++ b/src/content/integrations/astro-compress.md
@@ -4,6 +4,7 @@ title: astro-compress
 description: 🗜️ Compress —
 categories:
   - css+ui
+  - media
   - performance+seo
 npmUrl: https://www.npmjs.com/package/astro-compress
 repoUrl: https://github.com/PlayForm/Compress

--- a/src/content/integrations/astro-eleventy-img.md
+++ b/src/content/integrations/astro-eleventy-img.md
@@ -4,6 +4,7 @@ title: astro-eleventy-img
 description: Astro + eleventy-img
 categories:
   - performance+seo
+  - media
 npmUrl: https://www.npmjs.com/package/astro-eleventy-img
 repoUrl: https://github.com/Princesseuh/astro-eleventy-img
 homepageUrl: https://github.com/Princesseuh/astro-eleventy-img#readme

--- a/src/content/integrations/astro-embed.md
+++ b/src/content/integrations/astro-embed.md
@@ -3,7 +3,7 @@ name: astro-embed
 title: astro-embed
 description: Astro components to easily embed common media formats
 categories:
-  - uncategorized
+  - css+ui
 npmUrl: https://www.npmjs.com/package/astro-embed
 repoUrl: https://github.com/delucis/astro-embed
 homepageUrl: https://astro-embed.netlify.app/

--- a/src/content/integrations/astro-geo-map.md
+++ b/src/content/integrations/astro-geo-map.md
@@ -5,7 +5,7 @@ description: |-
   Embed an interactive map in your webpage.
   Using Leaflet.js under the hood.
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/astro-geo-map
 repoUrl: https://github.com/JulianCataldo/web-garden
 homepageUrl: https://code.juliancataldo.com/component/astro-geo-map

--- a/src/content/integrations/astro-icon.md
+++ b/src/content/integrations/astro-icon.md
@@ -3,6 +3,7 @@ name: astro-icon
 title: astro-icon
 description: This Astro integration provides a straight-forward `Icon` component for Astro.
 categories:
+  - media
   - css+ui
   - performance+seo
 npmUrl: https://www.npmjs.com/package/astro-icon

--- a/src/content/integrations/astro-iconify.md
+++ b/src/content/integrations/astro-iconify.md
@@ -4,6 +4,7 @@ title: astro-iconify
 description: Fork of astro-icon. Lets you easily use the up to date iconify
   service as a straight forward astro icon component.
 categories:
+  - media
   - css+ui
   - performance+seo
 npmUrl: https://www.npmjs.com/package/astro-iconify

--- a/src/content/integrations/astro-image-processor.md
+++ b/src/content/integrations/astro-image-processor.md
@@ -3,7 +3,7 @@ name: astro-image-processor
 title: astro-image-processor
 description: Astro integartion for image optimization and art direction for static builds
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/astro-image-processor
 repoUrl: https://github.com/macropygia/astro-image-processor
 homepageUrl: https://macropygia.github.io/astro-image-processor/

--- a/src/content/integrations/astro-imagekit.md
+++ b/src/content/integrations/astro-imagekit.md
@@ -4,7 +4,7 @@ title: astro-imagekit
 description: Integrate the ImageKit media provider in your Astro projects.
   Auto-synchronization, CLI, Component.
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/astro-imagekit
 homepageUrl: https://www.npmjs.com/package/astro-imagekit
 downloads: 2

--- a/src/content/integrations/astro-imagetools.md
+++ b/src/content/integrations/astro-imagetools.md
@@ -3,6 +3,7 @@ name: astro-imagetools
 title: astro-imagetools
 description: Image Optimization tools for the Astro JS framework
 categories:
+  - media
   - performance+seo
 npmUrl: https://www.npmjs.com/package/astro-imagetools
 repoUrl: https://github.com/RafidMuhymin/astro-imagetools

--- a/src/content/integrations/astro-infinity.md
+++ b/src/content/integrations/astro-infinity.md
@@ -4,6 +4,7 @@ title: astro-infinity
 description: An Image Component for Astro. Works With SSR.
 categories:
   - css+ui
+  - media
   - performance+seo
 npmUrl: https://www.npmjs.com/package/astro-infinity
 repoUrl: https://github.com/alteredorange/astro-infinity

--- a/src/content/integrations/astro-mapped-images.md
+++ b/src/content/integrations/astro-mapped-images.md
@@ -5,7 +5,7 @@ description: An Astro image component that handles both local and external
   images and includes the correct width and height attributes using
   pre-generated image maps.
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/astro-mapped-images
 repoUrl: https://github.com/techaurelian/astro-mapped-images
 homepageUrl: https://github.com/techaurelian/astro-mapped-images

--- a/src/content/integrations/astro-md-image-integration.md
+++ b/src/content/integrations/astro-md-image-integration.md
@@ -3,7 +3,7 @@ name: astro-md-image-integration
 title: astro-md-image-integration
 description: Use your images outside your src project folder.
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/astro-md-image-integration
 repoUrl: https://github.com/userquin/astro-md-image-integration
 homepageUrl: https://github.com/userquin/astro-md-image-integration

--- a/src/content/integrations/astro-og-canvas.md
+++ b/src/content/integrations/astro-og-canvas.md
@@ -4,6 +4,7 @@ title: astro-og-canvas
 description: Generate OpenGraph images for your Astro site
 categories:
   - performance+seo
+  - media
 npmUrl: https://www.npmjs.com/package/astro-og-canvas
 repoUrl: https://github.com/delucis/astro-og-canvas
 homepageUrl: https://github.com/delucis/astro-og-canvas#readme

--- a/src/content/integrations/astro-preload.md
+++ b/src/content/integrations/astro-preload.md
@@ -3,6 +3,7 @@ name: astro-preload
 title: astro-preload
 description: Download images at build time! Supports Iconify icons and arbitrary images.
 categories:
+  - media
   - css+ui
 npmUrl: https://www.npmjs.com/package/astro-preload
 repoUrl: https://github.com/lyonsyonii/astro-preload

--- a/src/content/integrations/astro-remark-eleventy-image.md
+++ b/src/content/integrations/astro-remark-eleventy-image.md
@@ -6,6 +6,7 @@ description: Remark plugin for Astro that automatically optimizes images
 categories:
   - accessibility
   - performance+seo
+  - media
 npmUrl: https://www.npmjs.com/package/astro-remark-eleventy-image
 repoUrl: https://github.com/ChrisOh431/astro-remark-eleventy-image
 homepageUrl: https://github.com/ChrisOh431/astro-remark-eleventy-image#readme

--- a/src/content/integrations/astro-simple-art-direction.md
+++ b/src/content/integrations/astro-simple-art-direction.md
@@ -3,7 +3,7 @@ name: astro-simple-art-direction
 title: astro-simple-art-direction
 description: A simple art direction for Astro.
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/astro-simple-art-direction
 repoUrl: https://github.com/hollyteds/astro-simple-art-direction
 homepageUrl: https://github.com/hollyteds/astro-simple-art-direction/#readme

--- a/src/content/integrations/astro-thumbor-image.md
+++ b/src/content/integrations/astro-thumbor-image.md
@@ -3,6 +3,7 @@ name: astro-thumbor-image
 title: astro-thumbor-image
 description: Makes it easy to add Thumbor optimized images to your Astro app.
 categories:
+  - media
   - performance+seo
 npmUrl: https://www.npmjs.com/package/astro-thumbor-image
 repoUrl: https://github.com/KreischerPanoptic/astro-thumbor-image

--- a/src/content/integrations/astro-vercel-image.md
+++ b/src/content/integrations/astro-vercel-image.md
@@ -3,6 +3,7 @@ name: astro-vercel-image
 title: astro-vercel-image
 description: A way to leverage Vercel's Image Optimization API in Astro
 categories:
+  - media
   - performance+seo
 npmUrl: https://www.npmjs.com/package/astro-vercel-image
 repoUrl: https://github.com/jcblw/astro-vercel-image

--- a/src/content/integrations/responsive-image-astro.md
+++ b/src/content/integrations/responsive-image-astro.md
@@ -4,7 +4,7 @@ title: responsive-image-astro
 description: Experimental package - Please refer to source code if you don't
   feel comfortable using it.
 categories:
-  - uncategorized
+  - media
 npmUrl: https://www.npmjs.com/package/responsive-image-astro
 repoUrl: https://github.com/MrAmericanMike/responsive-image-astro
 homepageUrl: https://github.com/MrAmericanMike/responsive-image-astro#readme

--- a/src/data/last-modified.json
+++ b/src/data/last-modified.json
@@ -1,3 +1,3 @@
 {
-	"integrations": "Tue, 08 Oct 2024 09:20:06 GMT"
+	"integrations": "Tue, 08 Oct 2024 13:39:55 GMT"
 }


### PR DESCRIPTION
- Renamed “Loaders” category label to “Content Loaders”
- Added a new “Images + Media” category (accompanying docs PR: https://github.com/withastro/docs/pull/9598)
- Add a bunch of JSDoc types to stuff to help keep track of what’s happening where
- Validate npm registry API responses
- Updates the integration data in the repo with these changes