### PR TITLE
Remove Cloudinary from home page pill

### DIFF
--- a/src/content/blog/cloudinary-astro-sdk-launch.mdx
+++ b/src/content/blog/cloudinary-astro-sdk-launch.mdx
@@ -4,9 +4,6 @@ authors:
   - thuy
 description: |
   We are happy to partner with Cloudinary to launch the Astro x Cloudinary SDK: a comprehensive API for building with images and videos in Astro.
-homepageLink:
-  title: "Astro x Cloudinary SDK"
-  subtitle: "Now available to try!"
 publishDate: "October 3, 2024"
 socialImage: "/src/content/blog/_images/cloudinary-sdk-launch/og-cloudinary.webp"
 coverImage: "/src/content/blog/_images/cloudinary-loader/blog-post-cloudinary.webp"


### PR DESCRIPTION
## Description

We worked with Cloudinary for a short time period to help push the Astro Cloudinary SDK. Now that that is over, remove Cloudinary SDK link and return home page pill to Astro 5.0 (or whatever we want to promote).