### PR TITLE
Add `rel="nofollow ugc"` to links to external showcase sites and integrations

### DIFF
--- a/src/components/charts/CWVCLSChart.astro
+++ b/src/components/charts/CWVCLSChart.astro
@@ -5,7 +5,7 @@ import CardLabel from '../CardLabel.astro';
 ---
 
 <Card className="mx-auto max-w-2xl">
-	<CardBody>
+	<CardBody :any>
 		<CardLabel>% Sites Passing CLS</CardLabel>
 		<canvas id="chart-cwv-cls"></canvas>
 	</CardBody>

--- a/src/components/charts/CWVCLSChart.astro
+++ b/src/components/charts/CWVCLSChart.astro
@@ -5,7 +5,7 @@ import CardLabel from '../CardLabel.astro';
 ---
 
 <Card className="mx-auto max-w-2xl">
-	<CardBody :any>
+	<CardBody>
 		<CardLabel>% Sites Passing CLS</CardLabel>
 		<canvas id="chart-cwv-cls"></canvas>
 	</CardBody>

--- a/src/content/blog/_whats-new-components/ShowcaseCard.astro
+++ b/src/content/blog/_whats-new-components/ShowcaseCard.astro
@@ -17,7 +17,7 @@ const { url, title } = Astro.props;
 		'!m-0 before:!hidden',
 	]}
 >
-	<a href={url} class="h-full w-full text-astro-gray-100" rel="nofollow">
+	<a href={url} class="h-full w-full text-astro-gray-100" rel="nofollow ugc">
 		<Image
 			src={`https://v1.screenshot.11ty.dev/${encodeURIComponent(url)}/opengraph/_wait:3`}
 			width={450}

--- a/src/content/blog/_whats-new-components/ShowcaseCard.astro
+++ b/src/content/blog/_whats-new-components/ShowcaseCard.astro
@@ -17,7 +17,7 @@ const { url, title } = Astro.props;
 		'!m-0 before:!hidden',
 	]}
 >
-	<a href={url} class="h-full w-full text-astro-gray-100">
+	<a href={url} class="h-full w-full text-astro-gray-100" rel="nofollow">
 		<Image
 			src={`https://v1.screenshot.11ty.dev/${encodeURIComponent(url)}/opengraph/_wait:3`}
 			width={450}

--- a/src/helpers/themes.ts
+++ b/src/helpers/themes.ts
@@ -1,5 +1,12 @@
 import xss from 'xss';
 
+/** Matches `https://*.astro.build/*` and `https://github.com/withastro/*` */
+const officialDomainRE =
+	/^https:\/\/(?:(?:[^\/]+\.)?astro.build|github\.com\/withastro)(?:\/.*)?$/i;
+
+/** Extracts the value of a link’s `href` attribute to a named `href` group. */
+const hrefRE = /<a .*href="(?<href>[^"]+)".*>/i;
+
 export const sanitizeThemeDescription = (text: string) =>
 	xss(text, {
 		whiteList: {
@@ -17,5 +24,15 @@ export const sanitizeThemeDescription = (text: string) =>
 			h3: [],
 			a: ['href'],
 			span: [],
+		},
+		onTag(tag, html, options) {
+			if (tag !== 'a' || options.isClosing) return;
+			const matches = html.match(hrefRE);
+			if (matches?.groups?.href && officialDomainRE.test(matches.groups.href)) {
+				// Don’t modify links to official domains
+				return;
+			}
+			// Add `rel` attribute to unofficial links.
+			return html.replace(/>$/, ' rel="nofollow ugc">');
 		},
 	});

--- a/src/pages/integrations/_components/IntegrationCard.astro
+++ b/src/pages/integrations/_components/IntegrationCard.astro
@@ -37,7 +37,12 @@ const IconBackgrounds = [
 
 <Card isLink>
 	{!!integration.data.badge && <CardBadge>{integration.data.badge}</CardBadge>}
-	<CardBody as="a" href={integration.data.homepageUrl || integration.data.npmUrl} target="_blank">
+	<CardBody
+		as="a"
+		href={integration.data.homepageUrl || integration.data.npmUrl}
+		rel={isOfficial ? undefined : 'nofollow'}
+		target="_blank"
+	>
 		<div class="flex h-full flex-col">
 			<header class="flex items-center justify-between">
 				<div

--- a/src/pages/integrations/_components/IntegrationCard.astro
+++ b/src/pages/integrations/_components/IntegrationCard.astro
@@ -40,7 +40,7 @@ const IconBackgrounds = [
 	<CardBody
 		as="a"
 		href={integration.data.homepageUrl || integration.data.npmUrl}
-		rel={isOfficial ? undefined : 'nofollow'}
+		rel={isOfficial ? undefined : 'nofollow ugc'}
 		target="_blank"
 	>
 		<div class="flex h-full flex-col">

--- a/src/pages/showcase/_components/ShowcaseCard.astro
+++ b/src/pages/showcase/_components/ShowcaseCard.astro
@@ -14,7 +14,7 @@ const { image } = site.data;
 		'group relative flex aspect-video h-full w-full cursor-pointer flex-col overflow-hidden bg-astro-gray-600',
 	]}
 >
-	<a href={site.data.url} rel="noopener nofollow" target="_blank" class="h-full w-full">
+	<a href={site.data.url} rel="noopener nofollow ugc" target="_blank" class="h-full w-full">
 		<span class="sr-only">{site.data.title}</span>
 		<Image
 			src={image}

--- a/src/pages/showcase/_components/ShowcaseCard.astro
+++ b/src/pages/showcase/_components/ShowcaseCard.astro
@@ -14,7 +14,7 @@ const { image } = site.data;
 		'group relative flex aspect-video h-full w-full cursor-pointer flex-col overflow-hidden bg-astro-gray-600',
 	]}
 >
-	<a href={site.data.url} rel="noopener" target="_blank" class="h-full w-full">
+	<a href={site.data.url} rel="noopener nofollow" target="_blank" class="h-full w-full">
 		<span class="sr-only">{site.data.title}</span>
 		<Image
 			src={image}

--- a/src/pages/themes/_components/ThemeCTAs.astro
+++ b/src/pages/themes/_components/ThemeCTAs.astro
@@ -8,6 +8,8 @@ export type Props = HTMLAttributes<'div'> & {
 };
 
 const { theme, class: className, ...attrs } = Astro.props;
+const isOfficial = theme.Author.name === 'withastro';
+const linkRel = isOfficial ? undefined : 'nofollow ugc';
 ---
 
 <div class:list={['flex flex-col gap-4', className]} {...attrs}>
@@ -17,6 +19,7 @@ const { theme, class: className, ...attrs } = Astro.props;
 				href={new URL(`${THEMES_API_URL}/api/themes/generate-checkout?themeId=${theme.Theme.id}`)}
 				class="button button-primary"
 				data-analytics-event="PDDOCXCA:1"
+				rel={linkRel}
 			>
 				<span>
 					{theme.Theme.price ? `$${theme.Theme.price / 100} - ` : null}
@@ -31,6 +34,7 @@ const { theme, class: className, ...attrs } = Astro.props;
 					href={theme.Theme.repoUrl}
 					class="button button-primary"
 					data-analytics-event="PDDOCXCA:1"
+					rel={linkRel}
 				>
 					<span>
 						{theme.Theme.price > 0 ? `$${theme.Theme.price / 100} - ` : null}
@@ -43,7 +47,12 @@ const { theme, class: className, ...attrs } = Astro.props;
 	}
 	{
 		!theme.Theme.paid && (
-			<a href={theme.Theme.repoUrl} class="button button-primary" data-analytics-event="PDDOCXCA:0">
+			<a
+				href={theme.Theme.repoUrl}
+				class="button button-primary"
+				data-analytics-event="PDDOCXCA:0"
+				rel={linkRel}
+			>
 				<span>Get started</span>
 				<ExternalLinkIcon aria-hidden="true" />
 			</a>
@@ -51,7 +60,7 @@ const { theme, class: className, ...attrs } = Astro.props;
 	}
 	{
 		theme.Theme.demoUrl && (
-			<a href={theme.Theme.demoUrl} class="button" data-analytics-event="DI9WVRXV:0">
+			<a href={theme.Theme.demoUrl} class="button" data-analytics-event="DI9WVRXV:0" rel={linkRel}>
 				<span>Live demo</span>
 				<ExternalLinkIcon aria-hidden="true" />
 			</a>


### PR DESCRIPTION
Our showcase and integration catalogues link to a bunch of external resources.

This PR adds `rel="nofollow ugc"` to these to reduce their value to the external site in terms of SEO (see [“Qualify your outbound links to Google”](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links)).

We’ve had a few signs of potential inauthentic activity using these catalogues, so worth adding these I think to discourage that.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

