### PR TITLE
replace studio with sponsors

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -36,12 +36,12 @@ const groups: LinkGroup[] = [
 	{
 		title: 'Ecosystem',
 		links: [
-			{ label: 'Studio', href: 'https://studio.astro.build/' },
 			{ label: 'Community', href: 'https://community.astro.build' },
 			{
 				label: 'Contributing',
 				href: 'https://github.com/withastro/astro/blob/main/CONTRIBUTING.md',
 			},
+			{ label: 'Sponsors', href: 'https://opencollective.com/astrodotbuild#category-CONTRIBUTE' },
 		],
 	},
 	{


### PR DESCRIPTION
 replaces the footer link to Studio with a link for "Sponsors" that right now goes to the Open Collective page.

In future, we may want a dedicated Sponsors page so that we can offer placement here as a benefit for certain sponsorship amounts. For now, the open collective is both a call to action to sponsor and our list of sponsors.


## Browser Test Checklist

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

