### PR TITLE
Fix integrations script

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"mdast-util-from-markdown": "^2.0.2",
 		"mdast-util-to-string": "^4.0.0",
 		"p-limit": "^6.1.0",
+		"p-retry": "^6.2.1",
 		"puppeteer": "^21.6.0",
 		"slugify": "^1.6.6",
 		"tiny-glob": "^0.2.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       p-limit:
         specifier: ^6.1.0
         version: 6.1.0
+      p-retry:
+        specifier: ^6.2.1
+        version: 6.2.1
       puppeteer:
         specifier: ^21.6.0
         version: 21.11.0(typescript@5.7.2)
@@ -1388,6 +1391,9 @@ packages:
 
   '@types/node@20.12.13':
     resolution: {integrity: sha512-gBGeanV41c1L171rR7wjbMiEpEI/l5XFQdLLfhr/REwpgDy/4U8y89+i8kRiLzDyZdOkXh+cRaTetUnCYutoXA==}
+
+  '@types/retry@0.12.2':
+    resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
@@ -3092,6 +3098,10 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-network-error@1.1.0:
+    resolution: {integrity: sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==}
+    engines: {node: '>=16'}
+
   is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
     engines: {node: '>= 0.4'}
@@ -3277,7 +3287,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lighthouse-logger@1.4.2:
@@ -3821,6 +3830,10 @@ packages:
     resolution: {integrity: sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==}
     engines: {node: '>=18'}
 
+  p-retry@6.2.1:
+    resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
+    engines: {node: '>=16.17'}
+
   p-timeout@6.1.2:
     resolution: {integrity: sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==}
     engines: {node: '>=14.16'}
@@ -4294,6 +4307,10 @@ packages:
 
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -6674,6 +6691,8 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/retry@0.12.2': {}
+
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 20.12.13
@@ -8747,6 +8766,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-network-error@1.1.0: {}
+
   is-number-object@1.0.7:
     dependencies:
       has-tostringtag: 1.0.2
@@ -9728,6 +9749,12 @@ snapshots:
       eventemitter3: 5.0.1
       p-timeout: 6.1.2
 
+  p-retry@6.2.1:
+    dependencies:
+      '@types/retry': 0.12.2
+      is-network-error: 1.1.0
+      retry: 0.13.1
+
   p-timeout@6.1.2: {}
 
   p-try@2.2.0: {}
@@ -10293,6 +10320,8 @@ snapshots:
       retext-latin: 4.0.0
       retext-stringify: 4.0.0
       unified: 11.0.5
+
+  retry@0.13.1: {}
 
   reusify@1.0.4: {}
 

--- a/scripts/npm.mjs
+++ b/scripts/npm.mjs
@@ -77,32 +77,38 @@ export async function fetchDetailsForPackage(pkg) {
 /**
  * Searches npm for a specific keyword and returns a map, keyed by package name.
  *
- * @param {string} keyword The keyword used to search npm, ex: `astro-component`
+ * @param {string[]} keywords The keywords used to search npm, ex: `astro-component`
  * @param {string | undefined} ranking The sort order for results, default: `quality`
  * @returns {Promise<Map<string, any>>} Map of search results, keyed by package name
  */
-export async function searchByKeyword(keyword, ranking = 'quality') {
+export async function searchByKeywords(keywords, ranking = 'quality') {
 	const objects = [];
-	let total = -1;
-	let page = 0;
 
-	do {
-		const url = new URL(`${REGISTRY_BASE_URL}-/v1/search`);
-		url.searchParams.set('text', `keywords:${keyword}`);
-		url.searchParams.set('ranking', ranking);
-		url.searchParams.set('size', String(PAGE_SIZE));
-		url.searchParams.set('from', String(page++ * PAGE_SIZE));
+	for (const keyword of keywords) {
+		const keywordObjects = [];
+		let total = -1;
+		let page = 0;
 
-		const results = await fetchJson(url.toString());
+		do {
+			const url = new URL(`${REGISTRY_BASE_URL}-/v1/search`);
+			url.searchParams.set('text', `keywords:${keyword}`);
+			url.searchParams.set('ranking', ranking);
+			url.searchParams.set('size', String(PAGE_SIZE));
+			url.searchParams.set('from', String(page++ * PAGE_SIZE));
 
-		// just in case, bail if no objects were returned for the page
-		if (results.objects.length === 0) {
-			break;
-		}
+			const results = await fetchJson(url.toString());
 
-		objects.push(...results.objects);
-		total = results.total;
-	} while (total > objects.length);
+			// just in case, bail if no objects were returned for the page
+			if (results.objects.length === 0) {
+				break;
+			}
+
+			keywordObjects.push(...results.objects);
+			total = results.total;
+		} while (total > keywordObjects.length);
+
+		objects.push(...keywordObjects);
+	}
 
 	return objects
 		.filter(({ package: pkg }) => {

--- a/scripts/npm.mjs
+++ b/scripts/npm.mjs
@@ -9,7 +9,7 @@ const fetchLimit = pLimit(10);
  */
 function fetchJson(url) {
 	return fetchLimit(async () => {
-		const res = await fetch(url);
+		const res = await fetch(url, { headers: { 'User-Agent': 'astro.build/integrations; v1' } });
 
 		if (!res.ok) {
 			console.error(`[${url}] ${res.status} ${res.statusText}`);

--- a/scripts/update-integrations.mjs
+++ b/scripts/update-integrations.mjs
@@ -14,7 +14,7 @@ import {
 	isNewPackage,
 } from './integrations.mjs';
 import { markdownToPlainText } from './markdown.mjs';
-import { fetchDetailsForPackage, fetchDownloadsForPackage, searchByKeyword } from './npm.mjs';
+import { fetchDetailsForPackage, fetchDownloadsForPackage, searchByKeywords } from './npm.mjs';
 
 /** @param {string} pkg */
 function isOfficial(pkg) {
@@ -111,9 +111,9 @@ async function fetchWithOverrides(pkg, includeDownloads = true) {
 }
 
 async function unsafeUpdateAllIntegrations() {
-	const keyword = 'astro-component,withastro,astro-integration';
+	const keywords = ['astro-component', 'withastro', 'astro-integration'];
 
-	const packagesMap = await searchByKeyword(keyword);
+	const packagesMap = await searchByKeywords(keywords);
 	const searchResults = new Set([...packagesMap.keys()].filter((pkg) => !blocklist.includes(pkg)));
 
 	const entries = await getIntegrationFiles();

--- a/scripts/update-integrations.mjs
+++ b/scripts/update-integrations.mjs
@@ -201,11 +201,11 @@ ${frontmatter}---\n`,
 Updated: ${existingIntegrations.size - deprecatedIntegrations.length} integrations`;
 
 	if (newIntegrations.length) {
-		stats += `\n\nAdded:${newIntegrations.map((pkg) => `\n  + ${pkg}`)}`;
+		stats += `\n\nAdded:\n${newIntegrations.map((pkg) => `+ ${pkg}`).join('\n')}`;
 	}
 
 	if (deprecatedIntegrations.length) {
-		stats += `\n\nRemoved:${deprecatedIntegrations.map((pkg) => `\n  - ${pkg}`)}`;
+		stats += `\n\nRemoved:\n${deprecatedIntegrations.map((pkg) => `- ${pkg}`).join('\n')}`;
 	}
 
 	stats += '\n---------------------------';


### PR DESCRIPTION
This PR fixes our script which updates integrations based on the npm registry.

We use a search endpoint in the npm registry API to look up integrations with one of our keywords. Previously we did this with a single call combining keywords into the query parameter: `text=keyword:astro-component,withastro,astro-integration`.

Some time around November 30, the response to this query changed. It looks like previously npm treated the list of keywords as “one of these” (i.e. OR), but is now treating it as “all of these” (i.e. AND). This meant our query only returned the ~100 packages that include all three keywords and the script tried to delete all the others we knew about.

This PR updates the script to run the search query separately for each keyword. This caused some “too many request” errors (at least running locally), so I’ve also added some retry logic to avoid that.

## Browser Test Checklist

n/a — data change only