### PR TITLE
Ensure showcase titles are not "Just a moment..."

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -162,7 +162,13 @@ export const collections = {
 		type: 'data',
 		schema: ({ image }) =>
 			z.object({
-				title: z.string().min(1),
+				title: z
+					.string()
+					.min(1)
+					.refine((value) => value !== 'Just a moment...', {
+						message:
+							"A showcase entry's title cannot be 'Just a moment...' which usually indicates a loading error.\nMake sure to update the title manually.\n",
+					}),
 				image: image(),
 				url: z.string().url(),
 				featured: z.number().min(1).optional(),


### PR DESCRIPTION
As discussed on Discord, this PR ensures that the showcase titles are not "Just a moment..." by enforcing that in the `showcase` collection schema.

This title usually means that fetching infos was blocked, e.g. on Cloudflare hosted sites and that the title will need to be updated manually.

Happy to discuss the wording of the error message as usual.

## Test Checklist

I have tested this PR by building the website locally to ensure no entries have the title "Just a moment...".

I also changed the title of one of the showcase entries to "Just a moment..." to ensure that the build fails.

<img width="629" alt="image" src="https://github.com/user-attachments/assets/c9672f68-b402-416f-9638-1dd934d4120a" />

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

This change does not affect the browser output.