### PR TITLE
Small design detail tweaks

### DIFF
--- a/src/pages/_components/landing-page/Teams.astro
+++ b/src/pages/_components/landing-page/Teams.astro
@@ -11,13 +11,13 @@ const logos = [
 ] satisfies Array<{ icon: string; label: string; classes?: string }>;
 ---
 
-<div class="mt-8 sm:mt-16 xs:p-6 mx-auto w-full max-w-screen-xl space-y-5 sm:space-y-8 p-4 sm:p-8">
+<div
+	class="mt-8 sm:mt-16 xs:p-6 mx-auto w-full max-w-screen-md xl:max-w-full space-y-5 sm:space-y-8 p-4 sm:p-8"
+>
 	<div class="landing-section gap-4 sm:gap-6">
-		<p class="text-astro-gray-1280 font-light text-base text-balance">
-			Used by some of the largest companies around the world:
-		</p>
+		<p class="font-light text-balance">Used by some of the largest companies around the world:</p>
 
-		<div class="flex flex-wrap lg:flex-nowrap items-center justify-center gap-x-8 gap-y-6 px-4">
+		<div class="flex flex-wrap items-center justify-center gap-x-8 gap-y-6 px-4">
 			{logos.map((logo) => <Icon name={logo.icon} class={logo.classes} aria-label={logo.label} />)}
 		</div>
 	</div>

--- a/src/pages/integrations/[...page].astro
+++ b/src/pages/integrations/[...page].astro
@@ -83,7 +83,7 @@ const recentlyAddedHref = `${Astro.url.pathname}?${recentlyAddedSearch.toString(
 	<div class="bg-grid relative">
 		<div class="grid-container">
 			<h1
-				class="heading-3 mx-auto max-w-screen-lg pt-24 text-center sm:heading-2 lg:heading-1 md:pt-32 lg:pt-40"
+				class="heading-3 mx-auto w-full max-w-screen-xl pt-24 text-center text-balance sm:heading-2 lg:heading-1 md:pt-32 lg:pt-40"
 			>
 				Kick it into lightspeed with integrations
 			</h1>

--- a/src/pages/showcase/[...page].astro
+++ b/src/pages/showcase/[...page].astro
@@ -48,7 +48,7 @@ const description = "Explore what's possible with Astro and get inspired for you
 	<div class="hero relative">
 		<div class="grid-container">
 			<h1
-				class="heading-3 mx-auto max-w-screen-lg pt-24 text-center sm:heading-2 lg:heading-1 md:pt-32 lg:pt-40"
+				class="heading-3 mx-auto w-full max-w-screen-xl pt-24 text-center text-balance sm:heading-2 lg:heading-1 md:pt-32 lg:pt-40"
 			>
 				Explore the infinite possibilities of Astro
 			</h1>

--- a/src/pages/themes/[...page].astro
+++ b/src/pages/themes/[...page].astro
@@ -122,7 +122,7 @@ const recentlyAddedHref = `${Astro.url.pathname}?${recentlyAddedSearch.toString(
 	<div class="bg-grid relative">
 		<div class="grid-container">
 			<h1
-				class="heading-3 mx-auto max-w-screen-lg pt-24 text-center sm:heading-2 lg:heading-1 md:pt-32 lg:pt-40"
+				class="heading-3 mx-auto max-w-screen-xl w-full pt-24 text-center text-balance sm:heading-2 lg:heading-1 md:pt-32 lg:pt-40"
 			>
 				Jumpstart your next project with a theme
 			</h1>

--- a/src/pages/themes/_components/Avatar.astro
+++ b/src/pages/themes/_components/Avatar.astro
@@ -8,7 +8,7 @@ export type Props = {
 const { theme } = Astro.props;
 ---
 
-<div class="flex items-center gap-2">
+<div class="grid grid-cols-[auto,1fr] items-center gap-2">
 	<img
 		class="h-6 w-6 rounded-full"
 		src={theme.Author.avatar}
@@ -18,7 +18,7 @@ const { theme } = Astro.props;
 		loading="lazy"
 		decoding="async"
 	/>
-	<span class="overflow-hidden text-ellipsis">
+	<span class="overflow-hidden text-ellipsis whitespace-nowrap">
 		{theme.Author.name}
 	</span>
 </div>

--- a/src/pages/themes/_components/Badge.astro
+++ b/src/pages/themes/_components/Badge.astro
@@ -7,7 +7,13 @@ export type Props = {
 const { theme, class: className } = Astro.props;
 ---
 
-<p class:list={['code relative m-px rounded-md px-2 py-1 text-sm text-white', theme, className]}>
+<p
+	class:list={[
+		'code relative m-px rounded-md px-2 py-1 text-sm text-white whitespace-nowrap',
+		theme,
+		className,
+	]}
+>
 	<slot />
 </p>
 


### PR DESCRIPTION
This PR fixes a few tiny design details in a few spots I’ve noticed while reviewing other work the last few days.

- Fixes some awkward wrapping of the bottom part of theme cards in the theme catalogue.
  
  | Before | After |
  |---|---|
  | ![three theme cards, their footer text wraps awkwardly in the narrower layout](https://github.com/user-attachments/assets/b468f880-bdb0-4f5b-b159-7ade269c8ec4) | ![the same theme cards, now their footer text sits on a single line, truncated with ellipses when necessary](https://github.com/user-attachments/assets/442d7fe0-9b26-4725-880d-7a973f86dacd)

- Fixes some slightly tight spacing around the “used by” company logos on the homepage. This change also ensures we never have a layout where just one logo is wrapped by itself on to the second row.

  | Before | After |
  |---|---|
  | ![row of logos running right to the edge of the browser window](https://github.com/user-attachments/assets/d26f9738-493c-4cda-ad0f-3c64961c23ee) | ![logos wrapping with plenty of space around them](https://github.com/user-attachments/assets/44235d1f-30b0-4b71-8536-5d8bc5e77051) |
  | ![same logos, the last one wraps to a new row by itself](https://github.com/user-attachments/assets/ca4f34a8-e5b1-456a-9d5c-9532812af8a0) | ![same logos as before, wrapping in a balanced way](https://github.com/user-attachments/assets/ac112493-65f1-480e-8c60-dab4afa62a0a) |

- Improves layout for the large page title text on showcase, integration, and theme catalogue pages. Currently this often wraps just a single word onto a new line. This change applies `text-wrap: balance` to ensure a balanced composition when the text must wrap and also increases the minimum width so it doesn’t have to wrap on larger screens.

  #### Examples
  | Before | After |
  |---|---|
  | ![image](https://github.com/user-attachments/assets/16833bf4-9cfd-4ac2-82bf-91205162c2de) | ![image](https://github.com/user-attachments/assets/260f9ff4-bce9-4ec4-a999-463984d5f41a) |
  | ![image](https://github.com/user-attachments/assets/d99ff0d8-4b2f-4f30-af7a-935cf2c7a41b) | ![image](https://github.com/user-attachments/assets/94b13f72-e71d-4aa5-a5ba-88d7299a881a) |
  | ![image](https://github.com/user-attachments/assets/f5409b4d-71c7-4d8d-96ca-925c04a0ae9a) | ![image](https://github.com/user-attachments/assets/10f789ed-bc46-483f-a2ff-040c6c7f7201) |


## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

