### PR TITLE
Ensure that themes with exactly 2 images display both images

### DIFF
--- a/src/pages/themes/details/[slug].astro
+++ b/src/pages/themes/details/[slug].astro
@@ -32,7 +32,7 @@ const relatedThemes: Array<ThemeAndAuthor> = await fetch(
 >
 	<div class="grid-container gap-y-0">
 		{
-			theme.Theme.images.length > 1 ? (
+			theme.Theme.images.length > 0 ? (
 				<ImageGallery
 					images={[theme.Theme.image, ...theme.Theme.images]}
 					class="bleed-full mx-auto w-full border-astro-gray-500 xl:border-x xl:border-b"


### PR DESCRIPTION
This PR fixes an issue where themes with only 1 extra image would not display the extra image.

The default image is defined in the `image` field of a `Theme` object and extra images are defined in the `images` array. The current condition to display the image gallery component is `theme.Theme.images.length > 1` which is incorrect as it means that the gallery component will not be displayed if there is only 1 extra image.

This PR fixes the issue by changing the condition to `theme.Theme.images.length > 0` so that the gallery component will be displayed if there is at least 1 extra image (and bring it on par with the condition [used in the portal UI](https://github.com/withastro/astro-dev-portal/blob/c375f9e2d7b6118cfafc78587dff503e0ea4190e/apps/site/src/pages/themes/%5Bslug%5D.astro#L85))

## Preview

A preview of the fix can be seen with the Starlight Flexoki theme that has only 1 extra image.

- Current version: https://astro.build/themes/details/starlight-flexoki
- Preview with the fix: https://deploy-preview-1469--astro-www-2.netlify.app/themes/details/starlight-flexoki/

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [x] Safari
- [x] iOS Safari
