### PR TITLE
Remove unnecessary Tailwind plugin

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -85,45 +85,6 @@ export default {
 		container: false,
 	},
 	plugins: [
-		plugin(function fontPlugin({ addBase }) {
-			addBase({
-				'font-sans': {
-					fontFamily: ['Inter', 'inter-fallback', 'system-ui', 'sans-serif'],
-					fontVariationSettings: 'var(--sans-wght)',
-					fontFeatureSettings: [
-						'var(--sans-case)',
-						'var(--sans-ss03)',
-						'var(--sans-cpsp)',
-						'var(--sans-cv03)',
-						'var(--cv04)',
-						'var(--cv05)',
-						'var(--cv06)',
-					],
-				},
-				'font-mono': {
-					fontFamily: ['MDIO', 'md-io-fallback', 'monospace'],
-					fontVariationSettings: 'var(--mono-ital)',
-					fontFeatureSettings: ['var(--mono-calt)', 'var(--mono-ital)', 'var(--mono-zero)'],
-				},
-				'font-heading': {
-					fontFamily: ['Obviously', 'obviously-fallback', 'system-ui', 'sans-serif'],
-					fontVariationSettings: [
-						'var(--heading-wdth)',
-						'var(--heading-wght)',
-						'var(--heading-slnt)',
-					],
-					fontFeatureSettings: [
-						'var(--heading-salt)',
-						'var(--heading-ss06)',
-						'var(--heading-ss11)',
-						'var(--heading-cv09)',
-						'var(--heading-liga)',
-						'var(--heading-calt)',
-					],
-				},
-			});
-		}),
-
 		// adds a `s-*` utility to apply the same width and height
 		plugin(function sizePlugin(api) {
 			api.matchUtilities(


### PR DESCRIPTION
This plugin was always misconfigured and the same CSS was added correctly in `tailwind.css`.

<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

