### PR TITLE
Group Astro dependencies in a single update for Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,18 +1,18 @@
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [
-    ":dependencyDashboard",
-    ":semanticPrefixFixDepsChoreOthers",
-    ":ignoreModulesAndTests",
-    "workarounds:all",
-    'helpers:pinGitHubActionDigestsToSemver',
-  ],
-  rangeStrategy: 'bump',
-  ignorePaths: ['**/node_modules/**'],
-  packageRules: [
-    {
-      groupName: 'github-actions',
-      matchManagers: ['github-actions'],
-    },
-  ],
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		":dependencyDashboard",
+		":semanticPrefixFixDepsChoreOthers",
+		":ignoreModulesAndTests",
+		"workarounds:all",
+		"helpers:pinGitHubActionDigestsToSemver"
+	],
+	"rangeStrategy": "bump",
+	"ignorePaths": ["**/node_modules/**"],
+	"packageRules": [
+		{
+			"groupName": "github-actions",
+			"matchManagers": ["github-actions"]
+		}
+	]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,9 +15,7 @@
 			"matchManagers": ["github-actions"]
 		},
 		{
-			"groupName": "Astro",
-			"description": "Group Astro packages together",
-			"groupSlug": "astro",
+			"groupName": "astro",
 			"matchDatasources": ["npm"],
 			"matchPackageNames": ["astro", "@astrojs/**"]
 		}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,13 @@
 		{
 			"groupName": "github-actions",
 			"matchManagers": ["github-actions"]
+		},
+		{
+			"groupName": "Astro",
+			"description": "Group Astro packages together",
+			"groupSlug": "astro",
+			"matchDatasources": ["npm"],
+			"matchPackageNames": ["astro", "@astrojs/**"]
 		}
 	]
 }


### PR DESCRIPTION
I noticed that when we release linked patches for multiple Astro packages (e.g. Astro + Netlify adapter + MDX integration) each of these will generate a separate PR when probably merging them together makes sense. IIUC this config change should group `astro` and `@astrojs/**` packages together into a single Renovate PR to keep them in sync and reduce the number of PRs to wrangle.

(I also reformatted the file to regular JSON as my editor was complaining about the `.json5` formatting and I guess that would be the same for other contributors.)