### PR TITLE
Remove unused deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
 	"version": "0.0.1",
 	"private": true,
 	"scripts": {
-		"preinstall": "npx only-allow pnpm",
 		"dev": "astro dev",
 		"start": "astro dev",
 		"build": "astro build",
@@ -39,10 +38,8 @@
 		"astro-expressive-code": "^0.40.2",
 		"astro-icon": "^1.1.5",
 		"chart.js": "4.4.8",
-		"cobe": "^0.6.3",
 		"date-fns": "^4.1.0",
 		"dotenv": "^16.4.7",
-		"only-allow": "1.2.1",
 		"prettier": "^3.5.3",
 		"prettier-plugin-astro": "^0.14.1",
 		"sharp": "^0.33.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,18 +65,12 @@ importers:
       chart.js:
         specifier: 4.4.8
         version: 4.4.8
-      cobe:
-        specifier: ^0.6.3
-        version: 0.6.3
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
-      only-allow:
-        specifier: 1.2.1
-        version: 1.2.1
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -1558,9 +1552,6 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  cobe@0.6.3:
-    resolution: {integrity: sha512-WHr7X4o1ym94GZ96h7b1pNemZJacbOzd02dZtnVwuC4oWBaLg96PBmp2rIS1SAhUDhhC/QyS9WEqkpZIs/ZBTg==}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -3317,10 +3308,6 @@ packages:
   oniguruma-to-es@4.1.0:
     resolution: {integrity: sha512-SNwG909cSLo4vPyyPbU/VJkEc9WOXqu2ycBlfd1UCXLqk1IijcQktSBb2yRQ2UFPsDhpkaf+C1dtT3PkLK/yWA==}
 
-  only-allow@1.2.1:
-    resolution: {integrity: sha512-M7CJbmv7UCopc0neRKdzfoGWaVZC+xC1925GitKH9EAqYFzX9//25Q7oX4+jw0tiCCj+t5l6VZh8UPH23NZkMA==}
-    hasBin: true
-
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
@@ -3452,9 +3439,6 @@ packages:
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
-  phenomenon@1.6.0:
-    resolution: {integrity: sha512-7h9/fjPD3qNlgggzm88cY58l9sudZ6Ey+UmZsizfhtawO6E3srZQXywaNm2lBwT72TbpHYRPy7ytIHeBUD/G0A==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -6624,10 +6608,6 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cobe@0.6.3:
-    dependencies:
-      phenomenon: 1.6.0
-
   collapse-white-space@2.1.0: {}
 
   color-convert@1.9.3:
@@ -8897,10 +8877,6 @@ snapshots:
       regex: 6.0.1
       regex-recursion: 6.0.2
 
-  only-allow@1.2.1:
-    dependencies:
-      which-pm-runs: 1.1.0
-
   open@8.4.2:
     dependencies:
       define-lazy-prop: 2.0.0
@@ -9051,8 +9027,6 @@ snapshots:
   pathe@2.0.3: {}
 
   pend@1.2.0: {}
-
-  phenomenon@1.6.0: {}
 
   picocolors@1.1.1: {}
 


### PR DESCRIPTION
This PR removes two dependencies:

- `cobe` which was unused
- `only-allow` which was used to enforce `pnpm` use, but we now do that with a `packageManager` field instead