### PR TITLE
Update to 18 themes per page

### DIFF
--- a/src/pages/themes/[page].astro
+++ b/src/pages/themes/[page].astro
@@ -86,7 +86,7 @@ const allThemes: ThemeAndAuthor[] = await fetch(
 // take all matching themes and create a paginated list of results
 const paginatedResults = paginate({
 	data: allThemes.filter((theme) => !theme.Theme.featured),
-	pageSize: 12,
+	pageSize: 24,
 	currentPage,
 	route: '/themes/[...page]',
 	searchParams: Astro.url.searchParams,

--- a/src/pages/themes/[page].astro
+++ b/src/pages/themes/[page].astro
@@ -86,7 +86,7 @@ const allThemes: ThemeAndAuthor[] = await fetch(
 // take all matching themes and create a paginated list of results
 const paginatedResults = paginate({
 	data: allThemes.filter((theme) => !theme.Theme.featured),
-	pageSize: 24,
+	pageSize: 18,
 	currentPage,
 	route: '/themes/[...page]',
 	searchParams: Astro.url.searchParams,


### PR DESCRIPTION
Updating the number of themes shown per page.

This allows more themes to be discovered without the friction of navigating to a new page.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

