### PR TITLE
Dynamically generate seo metadata for theme author pages

### DIFF
--- a/src/pages/themes/author/[id]/[...page].astro
+++ b/src/pages/themes/author/[id]/[...page].astro
@@ -46,9 +46,17 @@ if (allPages.length && !page) {
 }
 
 const themes = page.data;
+
+const author = themes[0].Author.name || 'Unknown Author';
+const title = `Themes by ${author}`;
+const description =
+	'Explore a variety of Astro themes — designed to help you launch quickly, with flexible layouts, practical features, and customization built in.';
 ---
 
-<MainLayout title="Themes" image={{ src: '/og/themes.jpg', alt: 'Explore the possibilities' }}>
+<MainLayout
+	title={title}
+	description={description}
+	image={{ src: '/og/themes.jpg', alt: 'Explore the possibilities' }}>
 	<SidebarLayout>
 		<Fragment slot="sidebar">
 			<SidebarPanel>
@@ -58,8 +66,7 @@ const themes = page.data;
 		</Fragment>
 
 		<div
-			class="flex flex-col items-center gap-8 pb-10 pt-8 sm:px-4 sm:pb-12 md:gap-10 md:pb-16 lg:gap-12 lg:px-8 lg:pb-20 lg:pt-10 xl:px-10"
-		>
+			class="flex flex-col items-center gap-8 pb-10 pt-8 sm:px-4 sm:pb-12 md:gap-10 md:pb-16 lg:gap-12 lg:px-8 lg:pb-20 lg:pt-10 xl:px-10">
 			<CardGridGroup>
 				<header class="w-full">
 					<h1 class="heading-3 max-lg:hidden">{themes[0].Author.name}</h1>

--- a/src/pages/themes/author/[id]/[...page].astro
+++ b/src/pages/themes/author/[id]/[...page].astro
@@ -49,8 +49,7 @@ const themes = page.data;
 
 const author = themes[0].Author.name || 'Unknown Author';
 const title = `Themes by ${author}`;
-const description =
-	'Explore a variety of Astro themes — designed to help you launch quickly, with flexible layouts, practical features, and customization built in.';
+const description = `Explore Astro themes by ${author}. Find a design to launch your next site quickly, with flexible layouts, practical features, and more.`;
 ---
 
 <MainLayout


### PR DESCRIPTION
This PR introduces dynamic `title` and `description` for the author page to improve SEO and Open Graph metadata.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [x] Android Firefox
- [ ] Safari
- [ ] iOS Safari