### PR TITLE
Fix pagination link to /themes/1/

### DIFF
--- a/src/pages/themes/[page].astro
+++ b/src/pages/themes/[page].astro
@@ -88,7 +88,7 @@ const paginatedResults = paginate({
 	data: allThemes.filter((theme) => !theme.Theme.featured),
 	pageSize: 18,
 	currentPage,
-	route: '/themes/[...page]',
+	route: '/themes/[page]',
 	searchParams: Astro.url.searchParams,
 });
 


### PR DESCRIPTION
<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

Fixes the first two links here:
![image](https://github.com/user-attachments/assets/7e1dc5c1-50a4-4c23-b6bd-219420c9c211)

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

