### PR TITLE
Enable Expressive Code’s `frames` feature

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -22,7 +22,17 @@ export default defineConfig({
 		}),
 		astroExpressiveCode({
 			themes: [houston],
-			frames: false,
+			styleOverrides: {
+				borderRadius: '0.375rem',
+				borderColor: 'rgb(84 88 100)',
+			},
+			defaultProps: {
+				overridesByLang: {
+					'bash,sh,shell': {
+						frame: 'none',
+					},
+				},
+			},
 		}),
 		icon({
 			svgoOptions: {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -72,8 +72,8 @@
 		text-decoration: inherit;
 	}
 
-	.prose .expressive-code > pre {
-		@apply my-6 rounded-md border border-astro-gray-400;
+	.prose .expressive-code {
+		@apply my-6;
 	}
 
 	.prose table {


### PR DESCRIPTION
This PR enables Expressive Code’s `frames` feature, which includes file titles and copy code buttons.

I disabled it by default still for `sh`, `bash`, and `shell` code blocks to not add the terminal window bar (but this can still be added back with a `frame="terminal"` attribute if we ever need it).

In blog post code blocks that included a filename at the top of a snippet (e.g. `// astro.config.mjs`), these will now show that filename in the snippet title bar.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

