### PR TITLE
Fix code block styling on landing page

### DIFF
--- a/src/pages/_components/landing-page/IntegrationContent.astro
+++ b/src/pages/_components/landing-page/IntegrationContent.astro
@@ -42,4 +42,7 @@ const { id, tab, class: className } = Astro.props;
 	.code :global(:is(.expressive-code, figure, pre)) {
 		height: 100%;
 	}
+	.code :global(:is(pre)) {
+		@apply border border-astro-dark-100/20 rounded-2xl;
+	}
 </style>

--- a/src/pages/_components/landing-page/IntegrationContent.astro
+++ b/src/pages/_components/landing-page/IntegrationContent.astro
@@ -16,9 +16,7 @@ const { id, tab, class: className } = Astro.props;
 	class:list={['mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4', className]}
 >
 	<div class="lg:col-span-2 bg-[#07040F] p-1 rounded-[20px]">
-		<div
-			class="w-full h-80 xl:h-96 min-h-80 code bg-astro-dark-400 border border-astro-dark-100/20 rounded-2xl overflow-y-auto"
-		>
+		<div class="w-full h-80 xl:h-96 min-h-80 code">
 			<slot name="code" />
 		</div>
 	</div>
@@ -39,3 +37,9 @@ const { id, tab, class: className } = Astro.props;
 		</div>
 	</div>
 </section>
+
+<style>
+	.code :global(:is(.expressive-code, figure, pre)) {
+		height: 100%;
+	}
+</style>


### PR DESCRIPTION
We added some additional Expressive Code styles in #1514, but I missed that we were using it on the homepage too. @hippotastic spotted that the new styles clashed with the homepage usage. This PR fixes that.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

