### PR TITLE
Handle API 404 on theme details

### DIFF
--- a/src/pages/themes/details/[slug].astro
+++ b/src/pages/themes/details/[slug].astro
@@ -16,9 +16,11 @@ export const prerender = false;
 
 const slug = Astro.params.slug as string;
 
-const theme = await fetch(`${THEMES_API_URL}/api/themes/details?slug=${slug}`).then((res) =>
-	res.json(),
-);
+const res = await fetch(`${THEMES_API_URL}/api/themes/details?slug=${slug}`);
+
+if (res.status === 404) return Astro.redirect('/404');
+
+const theme = await res.json();
 
 const relatedThemes: Array<ThemeAndAuthor> = await fetch(
 	`${THEMES_API_URL}/api/themes/related?slug=${slug}`,


### PR DESCRIPTION
<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

Handle 404s from portal to prevent the route from crashing if a theme does not exist.

## Browser Test Checklist

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

