### PR TITLE
Remove `width="auto"` attribute from sponsor icons

### DIFF
--- a/src/pages/_components/landing-page/Sponsors.astro
+++ b/src/pages/_components/landing-page/Sponsors.astro
@@ -96,9 +96,8 @@ const sponsors = [
 						class="h-40 p-4 size-full basis-1/3 flex flex-col lg:grid lg:grid-rows-subgrid lg:row-span-full items-center justify-center gap-4 -outline-offset-2 hover:bg-astro-gray-100/5 bg-clip-padding transition-colors duration-400"
 					>
 						<Icon
-							class="lg:row-start-2 lg:mx-auto max-w-full"
+							class="lg:row-start-2 lg:mx-auto w-auto max-w-full"
 							name={sponsor.src}
-							width="auto"
 							height={sponsor.height}
 							aria-hidden="true"
 						/>
@@ -120,10 +119,9 @@ const sponsors = [
 					>
 						<Icon
 							name={sponsor.src}
-							width="auto"
 							height={sponsor.height}
 							aria-hidden="true"
-							class="max-w-full"
+							class="max-w-full w-auto"
 						/>
 						<span class="sr-only">{sponsor.label}</span>
 					</a>


### PR DESCRIPTION
This PR fixes a small “bug” in the markup for our sponsors grid. When updating to Astro Icon to v1, I fudged the sponsor grid layout using `width="auto"` because v1 of Astro Icon _always_ includes a `width` attribute which broke our responsive layout. `width="auto"` is invalid HTML, but it did fix things because it stopped Astro Icon adding a valid `width` attribute.

This PR fixes it properly by allowing Astro Icon to add its `width` attribute and then overriding it with `width: auto` CSS.

Not a big deal, but this “bug” did call console warnings so wanted to get it cleaned up.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

