### PR TITLE
Fix theme links in landing page component

### DIFF
--- a/src/pages/_components/landing-page/ecosystem-tabs/Blogs.astro
+++ b/src/pages/_components/landing-page/ecosystem-tabs/Blogs.astro
@@ -10,42 +10,42 @@ import ThemeContainer from './ThemeContainer.astro';
 
 const themes = [
 	{
-		href: 'https://astro.build/themes/details/astronano/',
+		href: '/themes/details/astronano/',
 		title: 'Astro Nano',
 		author: 'Mark Horn',
 		src: astroNano,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/stablo-blog-template/',
+		href: '/themes/details/stablo-blog-template/',
 		title: 'Stablo',
 		author: 'Web3Templates',
 		src: stablo,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/microblog/',
+		href: '/themes/details/microblog/',
 		title: 'Microblog',
 		author: 'Lexington Themes',
 		src: microblog,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/dante/',
+		href: '/themes/details/dante/',
 		title: 'Dante',
 		author: 'Asta Bankauske',
 		src: dante,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/brutal/',
+		href: '/themes/details/brutal/',
 		title: 'Brutal',
 		author: 'ElianCodes',
 		src: brutal,
 		isSeenOnMobile: false,
 	},
 	{
-		href: 'https://astro.build/themes/details/openblog/',
+		href: '/themes/details/openblog/',
 		title: 'OpenBlog',
 		author: 'danielcgilibert',
 		src: openblog,
@@ -60,7 +60,7 @@ const themes = [
 	</div>
 
 	<a
-		href="https://astro.build/themes/?search=&categories%5B%5D=blog"
+		href="/themes/1/?search=&categories%5B%5D=blog"
 		class="mt-4 px-2 sm:px-4 group flex items-center justify-start gap-2 text-astro-gray-200 hover:text-astro-gray-100"
 	>
 		<span

--- a/src/pages/_components/landing-page/ecosystem-tabs/Docs.astro
+++ b/src/pages/_components/landing-page/ecosystem-tabs/Docs.astro
@@ -7,21 +7,21 @@ import ThemeContainer from './ThemeContainer.astro';
 
 const themes = [
 	{
-		href: 'https://astro.build/themes/details/starlight/',
+		href: '/themes/details/starlight/',
 		title: 'Starlight',
 		author: 'Astro',
 		src: starlight,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/astro-design-system-docs/',
+		href: '/themes/details/astro-design-system-docs/',
 		title: 'Astro Design System',
 		author: 'jordi',
 		src: astroDS,
 		isSeenOnMobile: false,
 	},
 	{
-		href: 'https://astro.build/themes/details/ion/',
+		href: '/themes/details/ion/',
 		title: 'Ion',
 		author: 'Louis Escher',
 		src: ion,
@@ -36,7 +36,7 @@ const themes = [
 	</div>
 
 	<a
-		href="https://astro.build/themes/?search=&categories%5B%5D=docs"
+		href="/themes/1/?search=&categories%5B%5D=docs"
 		class="mt-4 px-2 sm:px-4 group flex items-center justify-start gap-2 text-astro-gray-200 hover:text-astro-gray-100"
 	>
 		<span

--- a/src/pages/_components/landing-page/ecosystem-tabs/Ecommerce.astro
+++ b/src/pages/_components/landing-page/ecosystem-tabs/Ecommerce.astro
@@ -7,21 +7,21 @@ import ThemeContainer from './ThemeContainer.astro';
 
 const themes = [
 	{
-		href: 'https://astro.build/themes/details/astro-shopify/',
+		href: '/themes/details/astro-shopify/',
 		title: 'Astro Shopify',
 		author: 'thomasKn',
 		src: astroShopify,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/quick-store/',
+		href: '/themes/details/quick-store/',
 		title: 'Quick Store',
 		author: 'Lexington Themes',
 		src: quickStore,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/skncre-a-hygraph-cosmetics-brand-e-commerce/',
+		href: '/themes/details/skncre-a-hygraph-cosmetics-brand-e-commerce/',
 		title: 'SKNCRE',
 		author: 'Bryan Robinson',
 		src: skincare,
@@ -36,7 +36,7 @@ const themes = [
 	</div>
 
 	<a
-		href="https://astro.build/themes/?search=&categories%5B%5D=ecommerce"
+		href="/themes/1/?search=&categories%5B%5D=ecommerce"
 		class="mt-4 px-2 sm:px-4 group flex items-center justify-start gap-2 text-astro-gray-200 hover:text-astro-gray-100"
 	>
 		<span

--- a/src/pages/_components/landing-page/ecosystem-tabs/LandingPages.astro
+++ b/src/pages/_components/landing-page/ecosystem-tabs/LandingPages.astro
@@ -12,35 +12,35 @@ import ThemeContainer from './ThemeContainer.astro';
 
 const themes = [
 	{
-		href: 'https://astro.build/themes/details/sendit/',
+		href: '/themes/details/sendit/',
 		title: 'Sendit',
 		author: 'CloudCannon',
 		src: sendit,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/stone/',
+		href: '/themes/details/stone/',
 		title: 'Stone',
 		author: 'm6v3l9',
 		src: stone,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/positivus/',
+		href: '/themes/details/positivus/',
 		title: 'Positivus',
 		author: 'Manul Thanura',
 		src: positivus,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/atom/',
+		href: '/themes/details/atom/',
 		title: 'Atom',
 		author: 'Méschac Irung',
 		src: atom,
 		isSeenOnMobile: false,
 	},
 	{
-		href: 'https://astro.build/themes/details/astroplate/',
+		href: '/themes/details/astroplate/',
 		title: 'Astroplate',
 		author: 'Zeon Studio',
 		src: astroplate,

--- a/src/pages/_components/landing-page/ecosystem-tabs/Portfolios.astro
+++ b/src/pages/_components/landing-page/ecosystem-tabs/Portfolios.astro
@@ -12,35 +12,35 @@ import ThemeContainer from './ThemeContainer.astro';
 
 const themes = [
 	{
-		href: 'https://astro.build/themes/details/astrofy-personal-porfolio-website-template/',
+		href: '/themes/details/astrofy-personal-porfolio-website-template/',
 		title: 'Astrofy',
 		author: 'manuelernestog',
 		src: astrofy,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/swissfolio/',
+		href: '/themes/details/swissfolio/',
 		title: 'Swissfolio',
 		author: 'Lexington Themes',
 		src: swissfolio,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/gurido/',
+		href: '/themes/details/gurido/',
 		title: 'Gurido',
 		author: 'Lexington Themes',
 		src: gurido,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/shareyourlinks/',
+		href: '/themes/details/shareyourlinks/',
 		title: 'ShareYourLinks',
 		author: 'Angela Sofia Osorio',
 		src: shareLinks,
 		isSeenOnMobile: false,
 	},
 	{
-		href: 'https://astro.build/themes/details/esquelete-cv/',
+		href: '/themes/details/esquelete-cv/',
 		title: 'Esquelete CV',
 		author: 'Martín',
 		src: esqueleteCV,
@@ -61,7 +61,7 @@ const themes = [
 		<div
 			class="m-auto size-full landing-section absolute inset-0 z-10 bg-gradient-to-b from-transparent to-30% to-astro-dark-900/20 group-hover:to-astro-dark-900/50 rounded-xl"
 		>
-			<Link href="https://astro.build/themes/?search=&categories%5B%5D=portfolio" class="secondary">
+			<Link href="/themes/1/?search=&categories%5B%5D=portfolio" class="secondary">
 				<span>Browse more portfolio themes</span>
 				<Icon name="ri:arrow-right-line" size={18} />
 			</Link>

--- a/src/pages/_components/landing-page/ecosystem-tabs/Trending.astro
+++ b/src/pages/_components/landing-page/ecosystem-tabs/Trending.astro
@@ -12,35 +12,35 @@ import ThemeContainer from './ThemeContainer.astro';
 
 const themes = [
 	{
-		href: 'https://astro.build/themes/details/starlight/',
+		href: '/themes/details/starlight/',
 		title: 'Starlight',
 		author: 'Astro',
 		src: starlight,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/astroship/',
+		href: '/themes/details/astroship/',
 		title: 'AstroShip',
 		author: 'Web3Templates',
 		src: astroShip,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/astrolus/',
+		href: '/themes/details/astrolus/',
 		title: 'Astrolus',
 		author: 'Tailus-UI',
 		src: astrolus,
 		isSeenOnMobile: true,
 	},
 	{
-		href: 'https://astro.build/themes/details/prima-persona/',
+		href: '/themes/details/prima-persona/',
 		title: 'Prima Persona',
 		author: 'Lexington Themes',
 		src: primaPersona,
 		isSeenOnMobile: false,
 	},
 	{
-		href: 'https://astro.build/themes/details/tailcast/',
+		href: '/themes/details/tailcast/',
 		title: 'Tailcast',
 		author: 'matt765',
 		src: tailcast,


### PR DESCRIPTION
This PR fixes links in the “Ecosystem: Themes” section on the astro.build landing page.

Two fixes are included:

- Some tabs in this section include “Browse more…” links. These were no longer working as intended since we moved the full catalogue to `/themes/1/` instead of `/themes/`. This PR updates those links to point to `/themes/1/`.

- Links in these components were hardcoded to use `astro.build` origins meaning they’d take you out of a dev/preview environment if you clicked one. This PR changes them to relative links to avoid that.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

