### PR TITLE
Disable animated images by patching sharp image service

### DIFF
--- a/patches/astro.patch
+++ b/patches/astro.patch
@@ -1,0 +1,21 @@
+diff --git a/dist/assets/services/sharp.js b/dist/assets/services/sharp.js
+index 1971757d9732a872e4699f468d049d995999b903..e52f4641418851b9578ae29931657f7362ea263a 100644
+--- a/dist/assets/services/sharp.js
++++ b/dist/assets/services/sharp.js
+@@ -3,6 +3,7 @@ import {
+   baseService,
+   parseQuality
+ } from "./service.js";
++
+ let sharp;
+ const qualityTable = {
+   low: 25,
+@@ -41,7 +42,7 @@ const sharpService = {
+     if (transform.format === "svg") return { data: inputBuffer, format: "svg" };
+     const result = sharp(inputBuffer, {
+       failOnError: false,
+-      pages: -1,
++      // pages: -1,
+       limitInputPixels: config.service.config.limitInputPixels
+     });
+     result.rotate();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  astro:
+    hash: 30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f
+    path: patches/astro.patch
+
 importers:
 
   .:
     dependencies:
       '@astro-community/astro-embed-youtube':
         specifier: ^0.5.6
-        version: 0.5.6(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+        version: 0.5.6(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
       '@astro-github-elements/time':
         specifier: ^0.1.4
         version: 0.1.4
@@ -19,22 +24,22 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.6.2)(typescript@5.8.3)
       '@astrojs/mdx':
         specifier: ^4.3.0
-        version: 4.3.0(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+        version: 4.3.0(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
       '@astrojs/netlify':
         specifier: ^6.4.1
-        version: 6.4.1(@types/node@22.16.0)(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(jiti@1.21.6)(rollup@4.36.0)(yaml@2.8.0)
+        version: 6.4.1(@types/node@22.16.0)(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(jiti@1.21.6)(rollup@4.36.0)(yaml@2.8.0)
       '@astrojs/rss':
         specifier: ^4.0.12
         version: 4.0.12
       '@astrojs/site-kit':
         specifier: github:withastro/site-kit
-        version: https://codeload.github.com/withastro/site-kit/tar.gz/c53071893428a3069310ae7c79c4485342c364ed(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(eslint@8.57.0)(prettier@3.6.2)(tailwindcss@3.4.17)(typescript@5.8.3)
+        version: https://codeload.github.com/withastro/site-kit/tar.gz/c53071893428a3069310ae7c79c4485342c364ed(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(eslint@8.57.0)(prettier@3.6.2)(tailwindcss@3.4.17)(typescript@5.8.3)
       '@astrojs/sitemap':
         specifier: ^3.4.1
         version: 3.4.1
       '@astrojs/tailwind':
         specifier: ^6.0.2
-        version: 6.0.2(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17)
+        version: 6.0.2(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17)
       '@biomejs/biome':
         specifier: 2.0.6
         version: 2.0.6
@@ -55,13 +60,13 @@ importers:
         version: 22.16.0
       astro:
         specifier: ^5.11.0
-        version: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+        version: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
       astro-embed:
         specifier: ^0.9.0
-        version: 0.9.0(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+        version: 0.9.0(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
       astro-expressive-code:
         specifier: ^0.41.2
-        version: 0.41.2(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+        version: 0.41.2(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
       astro-icon:
         specifier: ^1.1.5
         version: 1.1.5
@@ -5627,49 +5632,49 @@ snapshots:
 
   '@antfu/utils@8.1.1': {}
 
-  '@astro-community/astro-embed-baseline-status@0.1.2(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
+  '@astro-community/astro-embed-baseline-status@0.1.2(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
       '@astro-community/astro-embed-utils': 0.1.3
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
 
-  '@astro-community/astro-embed-bluesky@0.1.2(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
+  '@astro-community/astro-embed-bluesky@0.1.2(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
       '@atproto/api': 0.13.23
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
       ts-pattern: 5.6.0
 
-  '@astro-community/astro-embed-integration@0.8.0(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
+  '@astro-community/astro-embed-integration@0.8.0(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
       '@astro-community/astro-embed-link-preview': 0.2.2
-      '@astro-community/astro-embed-twitter': 0.5.8(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
-      '@astro-community/astro-embed-vimeo': 0.3.10(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
-      '@astro-community/astro-embed-youtube': 0.5.6(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+      '@astro-community/astro-embed-twitter': 0.5.8(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+      '@astro-community/astro-embed-vimeo': 0.3.10(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+      '@astro-community/astro-embed-youtube': 0.5.6(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
       '@types/unist': 2.0.10
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
-      astro-auto-import: 0.4.4(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro-auto-import: 0.4.4(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
       unist-util-select: 4.0.3
 
   '@astro-community/astro-embed-link-preview@0.2.2':
     dependencies:
       '@astro-community/astro-embed-utils': 0.1.3
 
-  '@astro-community/astro-embed-twitter@0.5.8(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
+  '@astro-community/astro-embed-twitter@0.5.8(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
       '@astro-community/astro-embed-utils': 0.1.3
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
 
   '@astro-community/astro-embed-utils@0.1.3':
     dependencies:
       linkedom: 0.14.26
 
-  '@astro-community/astro-embed-vimeo@0.3.10(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
+  '@astro-community/astro-embed-vimeo@0.3.10(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
       '@astro-community/astro-embed-utils': 0.1.3
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
 
-  '@astro-community/astro-embed-youtube@0.5.6(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
+  '@astro-community/astro-embed-youtube@0.5.6(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
       lite-youtube-embed: 0.3.3
 
   '@astro-github-elements/time@0.1.4':
@@ -5747,12 +5752,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.0(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
+  '@astrojs/mdx@4.3.0(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.2
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       acorn: 8.14.1
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
       es-module-lexer: 1.6.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -5766,14 +5771,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/netlify@6.4.1(@types/node@22.16.0)(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(jiti@1.21.6)(rollup@4.36.0)(yaml@2.8.0)':
+  '@astrojs/netlify@6.4.1(@types/node@22.16.0)(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(jiti@1.21.6)(rollup@4.36.0)(yaml@2.8.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.6.1
       '@astrojs/underscore-redirects': 1.0.0
       '@netlify/blobs': 8.2.0
       '@netlify/functions': 3.1.8(rollup@4.36.0)
       '@vercel/nft': 0.29.2(rollup@4.36.0)
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
       esbuild: 0.25.4
       tinyglobby: 0.2.13
       vite: 6.3.5(@types/node@22.16.0)(jiti@1.21.6)(yaml@2.8.0)
@@ -5802,7 +5807,7 @@ snapshots:
       fast-xml-parser: 5.2.3
       kleur: 4.1.5
 
-  '@astrojs/site-kit@https://codeload.github.com/withastro/site-kit/tar.gz/c53071893428a3069310ae7c79c4485342c364ed(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(eslint@8.57.0)(prettier@3.6.2)(tailwindcss@3.4.17)(typescript@5.8.3)':
+  '@astrojs/site-kit@https://codeload.github.com/withastro/site-kit/tar.gz/c53071893428a3069310ae7c79c4485342c364ed(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(eslint@8.57.0)(prettier@3.6.2)(tailwindcss@3.4.17)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.8.3)
@@ -5819,7 +5824,7 @@ snapshots:
       smartypants: 0.1.6
       typescript: 5.8.3
     optionalDependencies:
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
       tailwindcss: 3.4.17
     transitivePeerDependencies:
       - '@ianvs/prettier-plugin-sort-imports'
@@ -5845,9 +5850,9 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.24.2
 
-  '@astrojs/tailwind@6.0.2(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17)':
+  '@astrojs/tailwind@6.0.2(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))(tailwindcss@3.4.17)':
     dependencies:
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
       autoprefixer: 10.4.21(postcss@8.5.3)
       postcss: 8.5.3
       postcss-load-config: 4.0.2(postcss@8.5.3)
@@ -7246,22 +7251,22 @@ snapshots:
 
   astring@1.8.6: {}
 
-  astro-auto-import@0.4.4(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)):
+  astro-auto-import@0.4.4(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)):
     dependencies:
       '@types/node': 18.19.68
       acorn: 8.14.1
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
 
-  astro-embed@0.9.0(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)):
+  astro-embed@0.9.0(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)):
     dependencies:
-      '@astro-community/astro-embed-baseline-status': 0.1.2(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
-      '@astro-community/astro-embed-bluesky': 0.1.2(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
-      '@astro-community/astro-embed-integration': 0.8.0(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+      '@astro-community/astro-embed-baseline-status': 0.1.2(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+      '@astro-community/astro-embed-bluesky': 0.1.2(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+      '@astro-community/astro-embed-integration': 0.8.0(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
       '@astro-community/astro-embed-link-preview': 0.2.2
-      '@astro-community/astro-embed-twitter': 0.5.8(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
-      '@astro-community/astro-embed-vimeo': 0.3.10(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
-      '@astro-community/astro-embed-youtube': 0.5.6(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      '@astro-community/astro-embed-twitter': 0.5.8(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+      '@astro-community/astro-embed-vimeo': 0.3.10(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+      '@astro-community/astro-embed-youtube': 0.5.6(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0))
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
 
   astro-eslint-parser@0.16.3:
     dependencies:
@@ -7277,9 +7282,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro-expressive-code@0.41.2(astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)):
+  astro-expressive-code@0.41.2(astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)):
     dependencies:
-      astro: 5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
+      astro: 5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0)
       rehype-expressive-code: 0.41.2
 
   astro-icon@1.1.5:
@@ -7291,7 +7296,7 @@ snapshots:
       - debug
       - supports-color
 
-  astro@5.11.0(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0):
+  astro@5.11.0(patch_hash=30de4f6d8536b97dc204448416f53fbf99be7ef9086f4b4ad7748a35ac728f2f)(@netlify/blobs@8.2.0)(@types/node@22.16.0)(jiti@1.21.6)(rollup@4.36.0)(typescript@5.8.3)(yaml@2.8.0):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.6.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  astro: patches/astro.patch


### PR DESCRIPTION
This is a temporary patch of the sharp image service to disable animated images on astro.build. I'm going to propose adding support for an `animated: boolean` property that would allow you to disable animation in the sharp image service, but this addresses the concerns for now.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

