### PR TITLE
Update “popular posts” in blog

### DIFF
--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -29,10 +29,10 @@ const allPages = [...Array(page.lastPage).keys()].map((num) => {
 const allPosts = await getCollection('blog');
 
 const featuredPosts = [
-	'images',
-	'2023-web-framework-performance-report',
-	'hybrid-rendering',
+	'year-in-review-2024',
+	'content-layer-deep-dive',
 	'netlify-official-deployment-partner',
+	'2023-web-framework-performance-report',
 ]
 	.map((slug) => allPosts.find((post) => post.slug === slug))
 	.filter(Boolean) as CollectionEntry<'blog'>[];


### PR DESCRIPTION
Updates the “popular posts” section of our blog:

<img width="378" height="331" alt="popular posts: 2024 year in review; Content Layer: A Deep Dive; Netlify: Our Official Deployment Partner; 2023 Web Framework Performance Report" src="https://github.com/user-attachments/assets/e728efa9-c2b7-48ce-b95a-2977ba517546" />


## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

