### PR TITLE
Fix formatting

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -123,20 +123,22 @@ const structuredData = {
 					<Content />
 				</article>
 				<hr class="2xl:hidden -mx-16 basis-[calc(100%+8rem)] border-astro-gray-500" />
-				<div
-					class="w-full 2xl:w-0 2xl:mt-24 flex flex-col 2xl:before:h-full"
-				>
+				<div class="w-full 2xl:w-0 2xl:mt-24 flex flex-col 2xl:before:h-full">
 					<div class="2xl:ml-[9rem] 2xl:w-56 2xl:sticky 2xl:bottom-12">
 						<Promo />
 					</div>
 				</div>
 				{
 					data.related.length > 0 && (
-						<hr class="-mx-16 basis-[calc(100%+8rem)] border-astro-gray-500" />
-						<nav aria-labelledby="_related-posts">
-							<h2 class="heading-3" id="_related-posts">Related Posts</h2>
-							<RelatedPosts posts={data.related} />
-						</nav>
+						<>
+							<hr class="-mx-16 basis-[calc(100%+8rem)] border-astro-gray-500" />
+							<nav aria-labelledby="_related-posts">
+								<h2 class="heading-3" id="_related-posts">
+									Related Posts
+								</h2>
+								<RelatedPosts posts={data.related} />
+							</nav>
+						</>
 					)
 				}
 			</div>


### PR DESCRIPTION
#1715 introduced some code that broke the auto-formatter (see https://github.com/withastro/astro.build/actions/runs/16577504217/job/46885303684). This PR fixes that.

<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

