### PR TITLE
Downgrade Ubuntu in showcase update workflow

### DIFF
--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -44,7 +44,8 @@ jobs:
   showcase:
     name: Update Showcase Sites
     if: github.repository_owner == 'withastro'
-    runs-on: ubuntu-24.04
+    # Puppeteer is breaking with ubuntu-24.04, so we’re still using 22 for this workflow
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code using Git
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This PR downgrades the version of Ubuntu used to run our showcase update workflow.

#1611 updated this, but it’s causing Puppeteer to fail in that workflow: https://github.com/withastro/astro.build/actions/runs/16646443672/job/47108742183
