### PR TITLE
Limit concurrency & retry errors when testing for integration 404s

### DIFF
--- a/scripts/fetch.mjs
+++ b/scripts/fetch.mjs
@@ -19,7 +19,7 @@ export function limitedFetch(url, init = {}) {
 				headers: { 'User-Agent': 'astro.build/integrations; v1', ...init.headers },
 			});
 
-			if (!res.ok) {
+			if (!res.ok && res.status !== 404) {
 				console.error(`[${url}] ${res.status} ${res.statusText} (Attempt ${attempt})`);
 				throw new Error();
 			}

--- a/scripts/fetch.mjs
+++ b/scripts/fetch.mjs
@@ -1,0 +1,30 @@
+import pLimit from 'p-limit';
+import pRetry from 'p-retry';
+
+const fetchLimit = pLimit(10);
+
+/**
+ * `fetch()` a URL with limited concurrency and retries for error responses.
+ * @param {string | URL} url
+ * @param {RequestInit} init
+ * @returns {Promise<Response>}
+ */
+export function limitedFetch(url, init = {}) {
+	return pRetry(async (attempt) => {
+		// Back off retries to give time to recover from 429 Too Many Requests errors.
+		await new Promise((resolve) => setTimeout(resolve, 2000 * (attempt - 1)));
+		return fetchLimit(async () => {
+			const res = await fetch(url, {
+				...init,
+				headers: { 'User-Agent': 'astro.build/integrations; v1', ...init.headers },
+			});
+
+			if (!res.ok) {
+				console.error(`[${url}] ${res.status} ${res.statusText} (Attempt ${attempt})`);
+				throw new Error();
+			}
+
+			return res;
+		});
+	});
+}

--- a/scripts/update-integrations.mjs
+++ b/scripts/update-integrations.mjs
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import matter from 'gray-matter';
-import pLimit from 'p-limit';
 import slugify from 'slugify';
 import glob from 'tiny-glob';
 import * as yaml from 'yaml';
@@ -123,8 +122,6 @@ async function unsafeUpdateAllIntegrations() {
 	const existingIntegrations = new Set();
 	/** @type {string[]} */
 	const deprecatedIntegrations = [];
-
-	const fetchLimit = pLimit(10);
 
 	// loop through all integrations already published to the catalog
 	await Promise.all(


### PR DESCRIPTION
Our integrations update script that runs each week fetches the homepage URL reported by NPM to double check it’s not a 404 (or other error). This was previously done concurrently inside one massive `Promise.all()`. Unsurprisingly, we’ve been seeing false negatives with GitHub in particular returning errors due to us spamming them even when the repo URL is valid.

This PR updates those fetches to have a maximum concurrency of 10 requests at a time and to retry on errors just to be sure an error is not a fluke.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

