### PR TITLE
Fix missing igor.dvlpr icons

### DIFF
--- a/src/content/integrations/@igor.dvlprastro-escaped-component.md
+++ b/src/content/integrations/@igor.dvlprastro-escaped-component.md
@@ -5,7 +5,7 @@ description: 🏃🏻‍♂️‍➡️ An Astro component that holds only HTML-
 categories:
   - uncategorized
 npmUrl: https://www.npmjs.com/package/@igor.dvlpr/astro-escaped-component
-image:  /assets/integrations/@igor.dvlpr/astro-escaped-component.png
+image: /assets/integrations/@igor.dvlpr/astro-escaped-component.png
 repoUrl: https://github.com/igorskyflyer/npm-astro-escaped-component
 homepageUrl: https://github.com/igorskyflyer/npm-astro-escaped-component
 downloads: 4

--- a/src/content/integrations/@igor.dvlprastro-escaped-component.md
+++ b/src/content/integrations/@igor.dvlprastro-escaped-component.md
@@ -5,6 +5,7 @@ description: 🏃🏻‍♂️‍➡️ An Astro component that holds only HTML-
 categories:
   - uncategorized
 npmUrl: https://www.npmjs.com/package/@igor.dvlpr/astro-escaped-component
+image:  /assets/integrations/@igor.dvlpr/astro-escaped-component.png
 repoUrl: https://github.com/igorskyflyer/npm-astro-escaped-component
 homepageUrl: https://github.com/igorskyflyer/npm-astro-escaped-component
 downloads: 4

--- a/src/content/integrations/@igor.dvlprastro-render-component.md
+++ b/src/content/integrations/@igor.dvlprastro-render-component.md
@@ -8,6 +8,7 @@ categories:
   - css+ui
   - recent
 npmUrl: https://www.npmjs.com/package/@igor.dvlpr/astro-render-component
+image: /assets/integrations/@igor.dvlpr/astro-render-component.png
 repoUrl: https://github.com/igorskyflyer/npm-astro-render-component
 homepageUrl: https://github.com/igorskyflyer/npm-astro-render-component
 badge: new

--- a/src/content/integrations/@igor.dvlprastro-saferesource.md
+++ b/src/content/integrations/@igor.dvlprastro-saferesource.md
@@ -5,6 +5,7 @@ description: 🎐 Adds CSP-compliant inline scripts and styles to Astro! 🎠
 categories:
   - css+ui
 npmUrl: https://www.npmjs.com/package/@igor.dvlpr/astro-saferesource
+image: /assets/integrations/@igor.dvlpr/astro-saferesource.png
 repoUrl: https://github.com/igorskyflyer/npm-astro-saferesource
 homepageUrl: https://github.com/igorskyflyer/npm-astro-saferesource
 downloads: 16


### PR DESCRIPTION
<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

Adds missing icons for @igor.dvlpr scoped packages.
Fixes #1767 