### PR TITLE
Use Houston as commit author for weekly and nightly workflows

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -32,3 +32,6 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
         with:
           commit_message: "ci: safe update for existing themes & integrations"
+          commit_author: Houston (Bot) <108291165+astrobot-houston@users.noreply.github.com>
+          commit_user_name: Houston (Bot)
+          commit_user_email: <108291165+astrobot-houston@users.noreply.github.com>

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           branch: ci/docgen-integrations
           token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          author: Houston (Bot) <108291165+astrobot-houston@users.noreply.github.com>
           add-paths: src/content/**/*.md
           commit-message: "ci: update integrations"
           title: "ci: update integrations"
@@ -71,6 +72,7 @@ jobs:
         with:
           branch: ci/docgen-showcase
           token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
+          author: Houston (Bot) <108291165+astrobot-houston@users.noreply.github.com>
           add-paths: src/content/**/*.yml,src/content/**/*.webp
           commit-message: "ci: update showcase"
           title: "ci: update showcase"


### PR DESCRIPTION
This PR updates our weekly and nightly GitHub Actions workflows to commit as Houston rather than the default of whoever created/last committed.