### PR TITLE
Add bot token to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Check out code using Git
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          token: ${{ secrets.FREDKBOT_GITHUB_TOKEN }}
 
       - name: Setup Node.js & install dependencies
         uses: ./.github/actions/setup-node-pnpm


### PR DESCRIPTION
Follow up to #1820 that uses the bot token in the nightly workflow to give permission for it to push to `main`. (Our nightly workflow has been failing since #1820 — e.g. https://github.com/withastro/astro.build/actions/runs/17762206537/job/50477388358#step:7:36)
