### PR TITLE
Add `permissions` to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -10,6 +10,10 @@ jobs:
     name: Update Integrations
     if: github.repository_owner == 'withastro'
     runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
     steps:
       - name: Check out code using Git
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Take three at trying to get the Nightly workflow workflowing again (broken since #1820).

I’ve tried adding `permissions` to the job as shown in https://github.com/stefanzweifel/git-auto-commit-action/#usage

I’d hoped just providing the token when checking out the repo (see #1834) would be sufficient, but it wasn‘t, so trying this.