### PR TITLE
fix: prerender conflict flag for astro-5140 post

### DIFF
--- a/src/content/blog/astro-5140.mdx
+++ b/src/content/blog/astro-5140.mdx
@@ -50,13 +50,13 @@ Previously, when two dynamic routes such as `/blog/[slug]` and `/blog/[...all]` 
 
 Now, when this happens, a warning will be displayed explaining which routes collided and on which path.
 
-Additionally, a new experimental flag `failOnPrerenderCollision` can be used to fail the build with a helpful error when such a collision occurs. Set the following flag in your Astro config for "Houston's helping hand" to force you to explicitly address any routing conflicts:
+Additionally, a new experimental flag `failOnPrerenderConflict` can be used to fail the build with a helpful error when such a collision occurs. Set the following flag in your Astro config for "Houston's helping hand" to force you to explicitly address any routing conflicts:
 
 ```js
 // astro.config.mjs
 export default defineConfig({
 	experimental: {
-		failOnPrerenderCollision: true,
+		failOnPrerenderConflict: true,
 	},
 });
 ```


### PR DESCRIPTION
The Astro 5.14 blog post uses `failOnPrerenderCollision` instead of `failOnPrerenderConflict` experimental flag. The latter is part of the official documentation and the correct flag. This PR fixes the issue.

Blog post: https://astro.build/blog/astro-5140/#prerendered-route-collision-warnings
Docs: https://docs.astro.build/en/reference/experimental-flags/fail-on-prerender-conflict/

<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

