### PR TITLE
Add step to stats update workflow to fetch Twitter followers

### DIFF
--- a/scripts/update-stats.mjs
+++ b/scripts/update-stats.mjs
@@ -47,6 +47,25 @@ data.stars = github.stargazers_count;
 data.followers.mastodon = mastodon.followers_count;
 data.followers.bluesky = bluesky.followersCount;
 
+// Fetch the latest Astro Twitter followers count from the Twitter API.
+// Conditional because it’s the one API that needs authorization.
+if (process.env.TWITTER_BEARER_TOKEN) {
+	const twitter = z
+		.object({
+			data: z.object({
+				public_metrics: z.object({ followers_count: z.number() }),
+			}),
+		})
+		.parse(
+			await fetch(
+				'https://api.x.com/2/users/by/username/astrodotbuild?user.fields=public_metrics',
+				{ headers: { Authorization: `Bearer ${process.env.TWITTER_BEARER_TOKEN}` } },
+			).then((res) => res.json()),
+		);
+	console.log(`✔︎ Twitter followers: ${twitter.data.public_metrics.followers_count}`);
+	data.followers.twitter = twitter.data.public_metrics.followers_count;
+}
+
 // Write updated stats back to src/data/stats.json.
 console.log('‣ Writing updated stats to src/data/stats.json...');
 await writeFile('src/data/stats.json', JSON.stringify(data, null, '\t'));


### PR DESCRIPTION
This PR updates the `update-stats` script to include a step for pulling Twitter follower count from the API. Uses the [`api.x.com/2/users/by/username/`](https://docs.x.com/x-api/users/get-user-by-username) endpoint.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

