### PR TITLE
Expose API token when running stats script

### DIFF
--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -95,6 +95,8 @@ jobs:
 
       - name: Run update:stats script
         run: pnpm run update:stats
+        env:
+          TWITTER_BEARER_TOKEN: ${{ secrets.TWITTER_BEARER_TOKEN }}
 
       - name: Create Pull Request
         id: createpr


### PR DESCRIPTION
Missed this when adding Twitter API support to the stats script in #1952. The secret is set on the repo but not passed into the action when it runs, which this PR fixes.
