### PR TITLE
Include MDX files in `pages` collection

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -143,7 +143,7 @@ export const collections = {
 		}),
 	},
 	pages: defineCollection({
-		loader: glob({ base: './src/content/pages', pattern: '**/*.md' }),
+		loader: glob({ base: './src/content/pages', pattern: '**/*.{md,mdx}' }),
 		schema: ({ image }) =>
 			z.discriminatedUnion('pageLayout', [
 				z.object({


### PR DESCRIPTION
Fixes #1971.

When updating content collections to use loaders, I’d missed that there was a collection with mixed `.md` and `.mdx` files and was only globbing the `.md` files causing a couple of our pages to be missing.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

