### PR TITLE
fix: showcase title for Tally

### DIFF
--- a/src/content/showcase/tally.johng.io.yml
+++ b/src/content/showcase/tally.johng.io.yml
@@ -1,4 +1,4 @@
-title: Loading | Tally - Word Counter
+title: Tally - Word Counter
 image: ./tally.johng.io.webp
 url: https://tally.johng.io
 dateAdded: 2025-12-08T12:12:38.156Z


### PR DESCRIPTION
Hey @delucis, thanks for fixing the screenshot of my site in https://github.com/withastro/astro.build/pull/2029/commits/da089e39bb72f605e8b510e60a211d2c1bde2166. This PR fixes the title to match.

For context, https://tally.johng.io redirects to a page like https://tally.johng.io/en based on the user's locale. Puppeteer was too fast in the update showcase workflow and took a screenshot of the former instead of the latter.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [x] Android Firefox
- [ ] Safari
- [ ] iOS Safari

