### PR TITLE
Update landing page chart

### DIFF
--- a/src/pages/_components/landing-page/Islands.astro
+++ b/src/pages/_components/landing-page/Islands.astro
@@ -21,11 +21,11 @@ import IslandGraphic from './IslandGraphic.astro';
 		<p class="text-astro-gray-300">% of real-world sites with good Core Web Vitals</p>
 
 		<div class="mt-8 mb-5">
-			<IslandGraphic label="Astro" score="63" size="size-[22px]" icon="logos/astro" glow />
-			<IslandGraphic label="WordPress" score="44" icon="logos/wordpress" />
-			<IslandGraphic label="Gatsby" score="42" size="size-[19px]" icon="logos/gatsby" />
-			<IslandGraphic label="Next.js" score="27" icon="logos/next-js" />
-			<IslandGraphic label="Nuxt" score="24" size="size-6" icon="logos/nuxt" />
+			<IslandGraphic label="Astro" score="62" size="size-[22px]" icon="logos/astro" glow />
+			<IslandGraphic label="WordPress" score="46" icon="logos/wordpress" />
+			<IslandGraphic label="Gatsby" score="45" size="size-[19px]" icon="logos/gatsby" />
+			<IslandGraphic label="Next.js" score="29" icon="logos/next-js" />
+			<IslandGraphic label="Nuxt" score="25" size="size-6" icon="logos/nuxt" />
 		</div>
 
 		<p class="text-astro-gray-300 text-balance">


### PR DESCRIPTION
This PR makes two small changes to the Core Web Vitals chart on the homepage:

- Updates the link to the dataset to use the new HTTP Archive report (the lookerstudio UI is deprecated but this is the same data)
- Updates the values to the the latest data (November 2025, December hasn’t been published yet)

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

