### PR TITLE
Fix `update:showcase` script

### DIFF
--- a/scripts/update-showcase.mjs
+++ b/scripts/update-showcase.mjs
@@ -1,5 +1,5 @@
 import fs from 'node:fs/promises';
-import ghActions from '@actions/core';
+import * as ghActions from '@actions/core';
 import octokit from '@octokit/graphql';
 import { parseHTML } from 'linkedom';
 import puppeteer from 'puppeteer';


### PR DESCRIPTION
<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

This PR fixes the way we import `@actions/core` in the showcase update script following the [`3.0.0` release](https://github.com/actions/toolkit/blob/main/packages/core/RELEASES.md#300) of the package.

## Test Checklist

I tested locally, before the fix we get:

```
import ghActions from '@actions/core';
       ^^^^^^^^^
SyntaxError: The requested module '@actions/core' does not provide an export named 'default'
```

After the fix, the script no longer error and starts downloading Chrome (note that I did not let it run entirely locally).

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

