### PR TITLE
Update State of JS stats for 2025

### DIFF
--- a/src/components/StatsFeature.astro
+++ b/src/components/StatsFeature.astro
@@ -27,20 +27,20 @@ const stats = [
 	{
 		amount: '🏆 #1',
 		text: 'in developer retention',
-		source: 'State of JS 2024',
-		url: 'https://2024.stateofjs.com/en-US/libraries/meta-frameworks/',
+		source: 'State of JS 2023–2025',
+		url: 'https://2025.stateofjs.com/en-US/libraries/meta-frameworks/',
 	},
 	{
 		amount: '💜 #1',
 		text: 'in developer interest',
-		source: 'State of JS 2024',
-		url: 'https://2024.stateofjs.com/en-US/libraries/meta-frameworks/',
+		source: 'State of JS 2022–2025',
+		url: 'https://2025.stateofjs.com/en-US/libraries/meta-frameworks/',
 	},
 	{
-		amount: '📈 3x',
-		text: 'growth in usage',
-		source: 'State of JS 2024',
-		url: 'https://2024.stateofjs.com/en-US/libraries/meta-frameworks/',
+		amount: '📈 #2',
+		text: 'in usage',
+		source: 'State of JS 2024–2025',
+		url: 'https://2025.stateofjs.com/en-US/libraries/meta-frameworks/',
 	},
 ];
 ---


### PR DESCRIPTION
This PR updates our stats component to reflect stats from State of JS 2025

Example usage: https://deploy-preview-2151--astro-www-2.netlify.app/agencies/join/

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

