### PR TITLE
Fix 'seperate' -> 'separate' typos in showcase code comment and hybrid-rendering blog post

### DIFF
--- a/src/content/blog/hybrid-rendering.mdx
+++ b/src/content/blog/hybrid-rendering.mdx
@@ -48,7 +48,7 @@ Unfortunately, this setup was quite rigid and didn't allow mixing static and dyn
 
 In Astro 2.0, we've revamped the `astro build` pipeline to handle hybrid rendering.
 During the initial bundling process, a new static analysis step determines which pages should be prerendered.
-This allows us to split your routes into seperate chunks, depending on _when_ they should be rendered.
+This allows us to split your routes into separate chunks, depending on _when_ they should be rendered.
 
 Much like the original `static` process, the prerendered chunk is executed and the output is written to `.html` files. The chunk is then discarded.
 

--- a/src/pages/showcase/[...page].astro
+++ b/src/pages/showcase/[...page].astro
@@ -15,7 +15,7 @@ export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
 		(a, b) => getWeight(a) - getWeight(b),
 	);
 
-	// seperate out sites that display with a larger thumbnail
+	// separate out sites that display with a larger thumbnail
 	const highlighted = sortedShowcase.filter((site) => site.data.highlight);
 
 	// build final showcase array by interleaving 1 highlighted item for every 4 non-highlighted items


### PR DESCRIPTION
Two unrelated `seperate` typos in the astro.build site:

- `src/pages/showcase/[...page].astro:18` — internal code comment explaining the highlighted-thumbnail interleaving step.
- `src/content/blog/hybrid-rendering.mdx:51` — body text of the Astro 2.0 hybrid rendering blog post (user-visible to anyone reading the post on astro.build).

Source verified against current `main` before commit.