### PR TITLE
fix: oxvg link

### DIFF
--- a/src/content/blog/astro-620.mdx
+++ b/src/content/blog/astro-620.mdx
@@ -43,7 +43,7 @@ yarn upgrade astro --latest
 
 ## SVG optimizer
 
-Astro's experimental SVG optimization has been redesigned with a new `svgOptimizer` option that replaces the previous `svgo` flag. Instead of being tied directly to SVGO, the new API introduces an `SvgOptimizer` interface that any optimization library can implement. Astro ships with a built-in `svgoOptimizer()` based on [SVGO](https://svgo.dev/), but you can now swap in alternatives like [OxVG](https://github.com/nicolo-ribaudo/oxvg).
+Astro's experimental SVG optimization has been redesigned with a new `svgOptimizer` option that replaces the previous `svgo` flag. Instead of being tied directly to SVGO, the new API introduces an `SvgOptimizer` interface that any optimization library can implement. Astro ships with a built-in `svgoOptimizer()` based on [SVGO](https://svgo.dev/), but you can now swap in alternatives like [OxVG](https://github.com/noahbald/oxvg).
 
 ```js title="astro.config.mjs"
 import { defineConfig, svgoOptimizer } from "astro/config";


### PR DESCRIPTION
Fixes the OXVG link at https://astro.build/blog/astro-620/ - it was previously pointing to the wrong repo.

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

