### PR TITLE
Fix link to Vite 8 blog post

### DIFF
--- a/src/content/blog/astro-620.mdx
+++ b/src/content/blog/astro-620.mdx
@@ -190,7 +190,7 @@ Work on the next major version of Astro has begun. The first Astro 7 alpha inclu
 
 ### Vite 8 support
 
-Astro 7 upgrades to [Vite 8](https://vite.dev/blog/announcing-vite-8), the latest major version of the build tool that powers Astro. This is a breaking change for Astro integrations and plugins that depend on Vite internals, but most Astro users should be able to upgrade without any changes to their project code.
+Astro 7 upgrades to [Vite 8](https://vite.dev/blog/announcing-vite8), the latest major version of the build tool that powers Astro. This is a breaking change for Astro integrations and plugins that depend on Vite internals, but most Astro users should be able to upgrade without any changes to their project code.
 
 ### Stable Rust compiler
 


### PR DESCRIPTION
The [recent blog post on Astro 6.2](https://astro.build/blog/astro-620/) contains a broken link to the Vite 8 blog post.

Checked formatting and build are OK.