### PR TITLE
Require dependencies to be ≥3 days old

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,7 @@
 	],
 	"rangeStrategy": "bump",
 	"ignorePaths": ["**/node_modules/**"],
+	"minimumReleaseAge": "3 days",
 	"packageRules": [
 		{
 			"groupName": "github-actions",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,6 @@ allowBuilds:
   esbuild: false
   puppeteer: false
   sharp: false
+
+# Require dependencies to be at least 3 days old before allowing them to be installed.
+minimumReleaseAge: 4320


### PR DESCRIPTION
Updates pnpm and Renovate configurations to prevent brand new packages from being installed.