### PR TITLE
Update workspace VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,10 +21,20 @@
 	},
 
 	// prefer .js extension on imports
-	"javascript.preferences.importModuleSpecifierEnding": "js",
-	"typescript.preferences.importModuleSpecifierEnding": "js",
+	"js/ts.preferences.importModuleSpecifierEnding": "js",
 
 	// use local typescript version
-	"typescript.tsdk": "node_modules/typescript/lib",
-	"astro.content-intellisense": true
+	"js/ts.tsdk.path": "node_modules/typescript/lib",
+	"astro.content-intellisense": true,
+
+	"json.schemas": [
+		{
+			"fileMatch": ["src/content/integrations.json"],
+			"url": "./.astro/collections/integrations.schema.json"
+		}
+	],
+
+	"yaml.schemas": {
+		"./.astro/collections/showcase.schema.json": "src/content/showcase/*.yml"
+	}
 }


### PR DESCRIPTION
This PR updates the VS Code workspace config that’s bundled with this repo:

1. Updates a couple of settings that were using deprecated APIs to use the modern equivalent

2. Configure use of Astro’s generated JSON Schema files for showcase and integration data files. For example, this provides intellisense in the YAML files for showcase entries based on the content collection schema.