### PR TITLE
fix: exclude main branch from preview site URL

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,10 +9,10 @@ import astroExpressiveCode from 'astro-expressive-code';
 import icon from 'astro-icon';
 import houston from './houston.theme.json';
 
-/* On Cloudflare Workers Builds, WORKERS_CI_BRANCH is set to the branch name for non-production deploys */
-const PREVIEW_SITE = process.env.WORKERS_CI_BRANCH
-	? `https://${process.env.WORKERS_CI_BRANCH}.previews.astro.build`
-	: undefined;
+/* On Cloudflare Workers Builds, WORKERS_CI_BRANCH is set to the branch name */
+const branch = process.env.WORKERS_CI_BRANCH;
+const PREVIEW_SITE =
+	branch && branch !== 'main' ? `https://${branch}.previews.astro.build` : undefined;
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
On Cloudflare Workers Builds, `WORKERS_CI_BRANCH` is set to the branch name even on `main`, which caused the site URL to be overridden to `main.previews.astro.build` instead of `astro.build`.

This adds a check to exclude `main` from preview site URL generation so production deploys use the correct site URL.

Fixes the issue noted in https://github.com/withastro/astro.build/pull/2432#discussion_r2143312089