### PR TITLE
Simplify Sätteri comparison table for mobile

### DIFF
--- a/src/content/blog/astro-7.mdx
+++ b/src/content/blog/astro-7.mdx
@@ -118,14 +118,14 @@ Under the hood, Sätteri uses [pulldown-cmark](https://github.com/pulldown-cmark
 
 | Feature | unified | Sätteri |
 | -- | -- | -- |
-| GFM (tables, footnotes, strikethrough, task lists) | `remark-gfm` plugin | Built-in, on by default |
-| Smart punctuation (curly quotes, em dashes) | `remark-smartypants` plugin | Built-in |
-| Heading IDs | `remark-heading-id` or similar plugin | Built-in |
-| Container directives (`:::note`) | `remark-directive` plugin | Built-in |
-| Math (`$x^2$`, `$$\sum$$`) | `remark-math` plugin | Built-in |
-| Frontmatter (YAML, TOML) | `remark-frontmatter` plugin | Built-in |
-| Superscript / subscript | `remark-supersub` or similar plugin | Built-in |
-| Wikilinks (`[[Page]]`) | `remark-wiki-link` plugin | Built-in |
+| GFM (tables, footnotes, strikethrough, task lists) | remark-gfm plugin | Built-in, on by default |
+| Smart punctuation (curly quotes, em dashes) | remark-smartypants plugin | Built-in |
+| Heading IDs | remark-heading-id or similar plugin | Built-in |
+| Container directives | remark-directive plugin | Built-in |
+| Math | remark-math plugin | Built-in |
+| Frontmatter (YAML, TOML) | remark-frontmatter plugin | Built-in |
+| Superscript / subscript | remark-supersub or similar plugin | Built-in |
+| Wikilinks | remark-wiki-link plugin | Built-in |
 
 Non-default features are enabled through the `features` option:
 


### PR DESCRIPTION
Removes backtick formatting from plugin names and inline code examples from the Feature column in the unified/Sätteri comparison table. This reduces the table width on mobile so it doesn't squeeze as badly.