### PR TITLE
Fix sponsor logo display on Safari

### DIFF
--- a/src/pages/_components/landing-page/Sponsors.astro
+++ b/src/pages/_components/landing-page/Sponsors.astro
@@ -150,7 +150,7 @@ const largeSponsorRows = [...rows(exclusiveSponsors), ...rows(mainSponsors)];
 						>
 							<StripWidth>
 								<Icon
-									class="lg:mx-auto max-w-full"
+									class="w-full"
 									name={sponsor.src}
 									height={sponsor.height}
 									aria-hidden="true"
@@ -177,7 +177,7 @@ const largeSponsorRows = [...rows(exclusiveSponsors), ...rows(mainSponsors)];
 								name={sponsor.src}
 								height={sponsor.height}
 								aria-hidden="true"
-								class="max-w-full"
+								class="w-full"
 							/>
 						</StripWidth>
 						<span class="sr-only">{sponsor.label}</span>
@@ -195,7 +195,7 @@ const largeSponsorRows = [...rows(exclusiveSponsors), ...rows(mainSponsors)];
 					width="24"
 					height="24"
 					aria-hidden="true"
-					class="max-w-full text-astro-red"
+					class="w-full text-astro-red"
 				/>
 				<span class="text-astro-gray-200 text-center leading-snug">Sponsor Astro</span>
 			</a>

--- a/src/pages/_components/landing-page/Sponsors.astro
+++ b/src/pages/_components/landing-page/Sponsors.astro
@@ -170,7 +170,7 @@ const largeSponsorRows = [...rows(exclusiveSponsors), ...rows(mainSponsors)];
 						href={sponsor.href}
 						rel="sponsored"
 						target="_blank"
-						class="h-32 lg:h-44 grow shrink basis-1/2 p-4 lg:basis-1/4 flex flex-col items-center justify-center gap-2 sm:gap-4 first:border-t first:border-astro-dark-100/20 odd:border-r odd:border-astro-dark-100/20 lg:[&:nth-child(2)]:border-r lg:[&:nth-child(6)]:border-r lg:[&:nth-child]:border-astro-dark-100/20 hover:bg-astro-gray-100/5 bg-clip-padding transition-colors  duration-400 last:odd:col-span-2 last:odd:border-r-0 -outline-offset-2"
+						class="h-32 lg:h-44 grow shrink basis-1/2 p-4 lg:basis-1/4 flex flex-col items-center justify-center gap-2 sm:gap-4 first:border-t first:border-astro-dark-100/20 odd:border-r odd:border-astro-dark-100/20 lg:[&:nth-child(2)]:border-r lg:[&:nth-child(6)]:border-r lg:border-astro-dark-100/20 hover:bg-astro-gray-100/5 bg-clip-padding transition-colors  duration-400 last:odd:col-span-2 last:odd:border-r-0 -outline-offset-2"
 					>
 						<StripWidth>
 							<Icon
@@ -188,7 +188,7 @@ const largeSponsorRows = [...rows(exclusiveSponsors), ...rows(mainSponsors)];
 				href="https://opencollective.com/astrodotbuild"
 				rel="sponsored"
 				target="_blank"
-				class="h-32 lg:h-44 grow shrink basis-1/2 p-4 lg:basis-1/4 flex flex-col items-center justify-center gap-2 first:border-t first:border-astro-dark-100/20 odd:border-r odd:border-astro-dark-100/20 lg:[&:nth-child(2)]:border-r lg:[&:nth-child(6)]:border-r lg:[&:nth-child]:border-astro-dark-100/20 hover:bg-astro-gray-100/5 bg-clip-padding transition-colors duration-400 last:odd:col-span-2 last:odd:border-r-0 -outline-offset-2"
+				class="h-32 lg:h-44 grow shrink basis-1/2 p-4 lg:basis-1/4 flex flex-col items-center justify-center gap-2 first:border-t first:border-astro-dark-100/20 odd:border-r odd:border-astro-dark-100/20 lg:[&:nth-child(2)]:border-r lg:[&:nth-child(6)]:border-r lg:border-astro-dark-100/20 hover:bg-astro-gray-100/5 bg-clip-padding transition-colors duration-400 last:odd:col-span-2 last:odd:border-r-0 -outline-offset-2"
 			>
 				<Icon
 					name="heart"


### PR DESCRIPTION
- Closes #2489
- Some difference in SVG rendering in Safari (perhaps specific to `<use>`?) caused logos to have zero width where they worked in Chromium and Firefox
- This PR fixes that and also cleans up some incorrect CSS syntax in the same component, which @trueberryless [noticed](https://github.com/withastro/astro.build/pull/2477#pullrequestreview-4547936153) now triggers warnings after the switch to lightningcss in Astro 7

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [x] Safari
- [ ] iOS Safari

