### PR TITLE
refactor(seo): simplify metadata generation and optimize head ordering

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -35,8 +35,6 @@ const resolvedImage = {
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title set:html={smartypants(title, 1)} />
-<meta name="generator" content={Astro.generator} />
-<meta name="theme-color" content="#8D46E7" />
 
 <!-- Fathom - beautiful, simple website analytics -->
 <script is:inline src="https://cdn.usefathom.com/script.js" data-site="EZBHTSIG" defer></script>
@@ -51,6 +49,8 @@ const resolvedImage = {
 <link rel="sitemap" href="/sitemap-index.xml" />
 <link rel="alternate" type="application/rss+xml" href="/rss.xml" title="RSS" />
 
+<meta name="generator" content={Astro.generator} />
+<meta name="theme-color" content="#8D46E7" />
 <SEO
 	name={siteInfo.name}
 	title={title}

--- a/src/components/Favicon.astro
+++ b/src/components/Favicon.astro
@@ -1,5 +1,3 @@
-<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-
 <script>
 	const favicon = document.querySelector('link[rel="icon"]')!;
 	document.addEventListener('visibilitychange', () => {
@@ -7,3 +5,5 @@
 		favicon.setAttribute('href', `/favicon${hidden ? '-hidden' : ''}.svg`);
 	});
 </script>
+
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -11,10 +11,10 @@ export type SEOMetadata = {
 	canonicalURL?: URL | string | null;
 	locale?: string;
 };
-export type OpenGraph = Partial<SEOMetadata> & {
+export type OpenGraph = {
 	type?: string;
 };
-export type Twitter = Partial<SEOMetadata> & {
+export type Twitter = {
 	handle?: string;
 	card?: 'summary' | 'summary_large_image';
 };
@@ -29,42 +29,29 @@ const {
 	image,
 	locale = 'en',
 	canonicalURL = new URL(Astro.url.pathname, Astro.site),
+	og: ogProps = {},
+	twitter: twitterProps = {},
 } = Astro.props;
 
 const og = {
-	name,
-	title,
-	description,
-	canonicalURL,
-	image,
-	locale,
 	type: 'website',
-	...Astro.props.og,
+	...ogProps,
 } satisfies OpenGraph;
 
 const twitter = {
-	name,
-	title,
-	description,
-	canonicalURL,
-	image,
-	locale,
 	card: 'summary_large_image',
-	...Astro.props.twitter,
+	...twitterProps,
 } satisfies Twitter;
 
 /**
  * Enforce some standard canonical URL formatting across the site.
  */
 function formatCanonicalURL(url: string | URL) {
-	const path = url.toString();
-	const hasQueryParams = path.includes('?');
-	// If there are query params, make sure the URL has no trailing slash
-	if (hasQueryParams) {
-		path.replace(/\/?$/, '');
-	}
-	// otherwise, canonical URL always has a trailing slash
-	return path.replace(/\/?$/, hasQueryParams ? '' : '/');
+  const value = url.toString();
+
+  return value.includes('?')
+    ? value.replace(/\/?$/, '')
+    : value.replace(/\/?$/, '/');
 }
 ---
 
@@ -73,22 +60,18 @@ function formatCanonicalURL(url: string | URL) {
 <meta name="description" content={description} />
 
 {/* OpenGraph Tags */}
-<meta property="og:title" content={og.title} />
+<meta property="og:title" content={title} />
 <meta property="og:type" content={og.type} />
-{og.canonicalURL && <meta property="og:url" content={formatCanonicalURL(og.canonicalURL)} />}
-<meta property="og:locale" content={og.locale} />
-<meta property="og:description" content={og.description} />
-<meta property="og:site_name" content={og.name} />
-{og.image && <meta property="og:image" content={og.image.src} />}
-{og.image && <meta property="og:image:alt" content={og.image.alt} />}
+{canonicalURL && <meta property="og:url" content={formatCanonicalURL(canonicalURL)} />}
+<meta property="og:locale" content={locale} />
+<meta property="og:description" content={description} />
+<meta property="og:site_name" content={name} />
+{image && <meta property="og:image" content={image.src} />}
+{image && <meta property="og:image:alt" content={image.alt} />}
 
 {/* Twitter Tags */}
 {twitter.card && <meta name="twitter:card" content={twitter.card} />}
 {twitter.handle && <meta name="twitter:site" content={twitter.handle} />}
-<meta name="twitter:title" content={twitter.title} />
-<meta name="twitter:description" content={twitter.description} />
-{twitter.image && <meta name="twitter:image" content={twitter.image.src} />}
-{twitter.image && <meta name="twitter:image:alt" content={twitter.image.alt} />}
 
 {
 	/*


### PR DESCRIPTION
## Changes

* Simplified the SEO metadata model by making the page metadata (`title`, `description`, `image`, `canonicalURL`, `locale`) the single source of truth.

* Removed duplicated metadata from the `OpenGraph` and `Twitter` types. `OpenGraph` now only exposes Open Graph-specific configuration (`type`), while `Twitter` only exposes Twitter-specific configuration (`card` and `handle`).

* Removed generation of the following Twitter tags, which are already supported through Open Graph fallbacks:

  * `twitter:title`
  * `twitter:description`
  * `twitter:image`
  * `twitter:image:alt`

* Kept the Twitter-specific tags that cannot be inferred from Open Graph:

  * `twitter:card`
  * `twitter:site`

* Removed the duplicated `canonicalURL` property from `OpenGraph`. The page-level `canonicalURL` is now used directly for both:

  * `<link rel="canonical">`
  * `<meta property="og:url">`

* Fixed the canonical URL formatter to correctly normalize trailing slashes.

* Reordered metadata in `BaseHead.astro` to better follow the ordering recommended by Capo.js for `<head>` elements, improving consistency with modern head optimization guidance. ([[Rviscomi](https://rviscomi.github.io/capo.js/)][1])

* Reordered the favicon component so the generated `<head>` better aligns with the expected ordering after all head elements are assembled. ([[Rviscomi](https://rviscomi.github.io/capo.js/)][1])

## Testing

* Verified the generated HTML no longer emits the removed Twitter metadata.

* Confirmed Open Graph metadata continues to render correctly.

* Verified `twitter:card` and `twitter:site` continue to be emitted as expected.

* Verified both `<link rel="canonical">` and `og:url` use the same canonical URL.

* Ran the project locally and confirmed there are no TypeScript or build regressions.

## Resources

Twitter Cards support using several Open Graph properties as fallbacks, making duplicated Twitter metadata unnecessary in most cases.

Although the current documentation has been removed from the X Developer site, it is available through the Internet Archive:

* Twitter Cards Markup (archived):
  [https://web.archive.org/web/20240613190853/https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup](https://web.archive.org/web/20240613190853/https://developer.x.com/en/docs/twitter-for-websites/cards/overview/markup)

* Getting Started with Twitter Cards (archived):
  [https://web.archive.org/web/20240616101429/https://developer.x.com/en/docs/twitter-for-websites/cards/guides/getting-started](https://web.archive.org/web/20240616101429/https://developer.x.com/en/docs/twitter-for-websites/cards/guides/getting-started)

The documentation notes:

> If an `og:type`, `og:title`, and `og:description` exist in the markup but `twitter:card` is absent, then a Summary Card may be rendered.

Since Astro intentionally emits `summary_large_image`, only `twitter:card` (and optionally `twitter:site`/`twitter:creator`) need to be generated separately, while the remaining metadata can be provided via Open Graph.

The `<head>` reordering is based on the recommendations from Capo.js, which validates and recommends an optimal ordering of head elements to improve browser parsing and perceived performance. ([[Rviscomi](https://rviscomi.github.io/capo.js/)][1])

[1]: https://rviscomi.github.io/capo.js/ "capo.js: get your ﹤𝚑𝚎𝚊𝚍﹥ in order | capo.js"