### PR TITLE
docs(telemetry): note the CLI sends which AI agent invoked it, not just whether

### DIFF
--- a/src/content/pages/telemetry.md
+++ b/src/content/pages/telemetry.md
@@ -2,7 +2,7 @@
 seo:
   title: Telemetry
   description: Astro collects anonymous telemetry data about general usage to help inform our roadmap. Participation is optional and you may opt-out at any time.
-updated_date: 2026-05-28
+updated_date: 2026-07-13
 ---
 
 The `astro` CLI collects **anonymous telemetry data** about general usage. Participation is optional, and you may opt-out at any time.
@@ -18,7 +18,7 @@ We track general usage information about Astro and different configuration optio
 - Command invoked (`astro build`, `astro dev`, `astro preview`, etc.)
 - Astro version
 - General machine information (e.g. number of CPUs, macOS/Windows/Linux, CI environment, etc.)
-- Development environment (e.g. whether the CLI was invoked by an AI coding agent)
+- Development environment (e.g. whether — and which — AI coding agent invoked the CLI)
 - General configuration information (Integrations, adapters, markdown options, etc.)
 - Sanitized error information
 - Toolbar usage (e.g. built-in apps being used)

--- a/src/content/pages/telemetry.md
+++ b/src/content/pages/telemetry.md
@@ -18,7 +18,7 @@ We track general usage information about Astro and different configuration optio
 - Command invoked (`astro build`, `astro dev`, `astro preview`, etc.)
 - Astro version
 - General machine information (e.g. number of CPUs, macOS/Windows/Linux, CI environment, etc.)
-- Development environment (e.g. whether — and which — AI coding agent invoked the CLI)
+- Development environment (e.g. which AI coding agent invoked the CLI, if any)
 - General configuration information (Integrations, adapters, markdown options, etc.)
 - Sanitized error information
 - Toolbar usage (e.g. built-in apps being used)


### PR DESCRIPTION
The telemetry page lists what the CLI collects, including:

> Development environment (e.g. whether the CLI was invoked by an AI coding agent)

Since the agent-detection feature landed (withastro/astro#16610), the CLI actually sends a bit more than *whether* — it includes *which* agent. `packages/astro/src/events/session.ts` populates `EventPayload` with `agentId` (e.g. `"claude-code"`), `agentName`, and `agentType` (lines 15–21, 153–157), across the dev/build/preview/sync/add commands.

This is a one-line wording update so the disclosure matches what's sent — "whether **— and which —** AI coding agent invoked the CLI" — plus a bump of `updated_date`. Docs-only, no code.

Happy to reword if you'd phrase it differently; I just wanted the page to reflect the agent identity now being included.

<sub>AI-assisted; the `session.ts` fields I verified myself against `astro` `main`.</sub>
