### PR TITLE
Add astro-chat-widget.svg for integrations

### DIFF
--- a/public/assets/integrations/astro-chat-widget.svg
+++ b/public/assets/integrations/astro-chat-widget.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <!-- Brand mark (catalog avatar, demo favicon): speech bubble + spark.
+       v3: symmetric thick-armed spark, blunt rounded tail — survives 16px.
+       Submitted to astro.build's integrations library (public/assets/integrations/). -->
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6b83ff"/>
+      <stop offset="1" stop-color="#4257e0"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="url(#g)"/>
+  <path d="M64 25c-24 0-43.5 16-43.5 35.7 0 11 6.1 20.9 15.6 27.4.2 5.6-1.6 11.6-5 16.5-1.1 1.6.2 3.7 2.1 3.4 9.2-1.4 17.2-5.3 22.8-9.9 2.6.4 5.3.6 8 .6 24 0 43.5-16 43.5-35.7S88 25 64 25z" fill="#fff"/>
+  <g fill="url(#g)" transform="translate(41 37.7) scale(1.92)">
+    <path d="M12 0c1.1 6.8 5.2 10.9 12 12-6.8 1.1-10.9 5.2-12 12-1.1-6.8-5.2-10.9-12-12C6.8 10.9 10.9 6.8 12 0z"/>
+  </g>
+</svg>

--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -293,8 +293,8 @@
 			"image": "/assets/integrations/astro-cloudflare-pages-headers.png"
 		},
 		"astro-chat-widget": {
-                      "image": "/assets/integrations/astro-chat-widget.svg"
-		},	
+            "image": "/assets/integrations/astro-chat-widget.svg"
+		},
 		"astro-navbar": {
 			"description": "A fully accessible responsive headless navigation bar for Astro. It supports mobile responsive toggle and dropdowns."
 		},

--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -293,7 +293,7 @@
 			"image": "/assets/integrations/astro-cloudflare-pages-headers.png"
 		},
 		"astro-chat-widget": {
-            "image": "/assets/integrations/astro-chat-widget.svg"
+			"image": "/assets/integrations/astro-chat-widget.svg"
 		},
 		"astro-navbar": {
 			"description": "A fully accessible responsive headless navigation bar for Astro. It supports mobile responsive toggle and dropdowns."

--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -292,6 +292,9 @@
 		"astro-cloudflare-pages-headers": {
 			"image": "/assets/integrations/astro-cloudflare-pages-headers.png"
 		},
+		"astro-chat-widget": {
+                      "image": "/assets/integrations/astro-chat-widget.svg"
+		},	
 		"astro-navbar": {
 			"description": "A fully accessible responsive headless navigation bar for Astro. It supports mobile responsive toggle and dropdowns."
 		},


### PR DESCRIPTION
Added SVG Avatar for the `astro-chat-widget` package

<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

