### PR TITLE
Fix RSS/site URL using preview domain in production

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,10 +9,16 @@ import astroExpressiveCode from 'astro-expressive-code';
 import icon from 'astro-icon';
 import houston from './houston.theme.json';
 
-/* On Cloudflare Workers Builds, WORKERS_CI_BRANCH is set to the branch name for non-production deploys */
-const PREVIEW_SITE = process.env.WORKERS_CI_BRANCH
-	? `https://${process.env.WORKERS_CI_BRANCH}.previews.astro.build`
-	: undefined;
+/*
+ * On Cloudflare Workers Builds, WORKERS_CI_BRANCH is set to the branch name for every build,
+ * including production. Only use the branch preview URL for non-production branches, otherwise
+ * production would resolve to https://main.previews.astro.build (see issue #2542).
+ */
+const PRODUCTION_BRANCH = 'main';
+const PREVIEW_SITE =
+	process.env.WORKERS_CI_BRANCH && process.env.WORKERS_CI_BRANCH !== PRODUCTION_BRANCH
+		? `https://${process.env.WORKERS_CI_BRANCH}.previews.astro.build`
+		: undefined;
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
`WORKERS_CI_BRANCH` is set on all Cloudflare Workers builds, including production. This meant the production `main` build resolved `site` to `https://main.previews.astro.build`, breaking RSS item links (and sitemap/canonical URLs).

This skips the preview URL for the production branch (`main`).

Fixes #2542