### PR TITLE
Return 404 when the font proxy can't reach the CDN

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -11,11 +11,19 @@ export default {
 		// failures on preview deployments).
 		if (url.pathname.startsWith('/fonts/')) {
 			const fontsUrl = `https://fonts-cdn.astro.build${url.pathname.replace('/fonts/', '/')}${url.search}`;
-			return fetch(fontsUrl, {
-				headers: {
-					Origin: 'https://astro.build',
-				},
-			});
+			try {
+				return await fetch(fontsUrl, {
+					headers: {
+						Origin: 'https://astro.build',
+					},
+				});
+			} catch (error) {
+				// The font CDN can be unreachable (e.g. in local dev the origin-locked
+				// host isn't resolvable). Degrade to a 404 so a failed font request
+				// doesn't surface as a 500 that breaks the whole page.
+				console.error(`[fonts] failed to proxy ${fontsUrl}:`, error);
+				return new Response('Font not found', { status: 404 });
+			}
 		}
 
 		const state = new FetchState(request);


### PR DESCRIPTION
## Changes

- The `/fonts/*` proxy in `src/fetch.ts` now catches failures from the upstream `fonts-cdn.astro.build` request and returns a `404` instead of letting the rejection propagate. Previously any failure surfaced as a `500 "Network connection lost"` that broke the whole page.
- Note that fixing fonts-cdn should make this unnecessary, but local dev should never be broken.
