### PR TITLE
fix: introduce dedicated spaces where absent

### DIFF
--- a/src/pages/_components/landing-page/Islands.astro
+++ b/src/pages/_components/landing-page/Islands.astro
@@ -35,12 +35,12 @@ import IslandGraphic from './IslandGraphic.astro';
 			>
 				View the full dataset</a
 			>
-			&middot; Based on real-world performance data from
+			&middot; Based on real-world performance data from{" "}
 			<a
 				class="text-astro-gray-100 underline underline-offset-2 decoration-astro-gray-300 hover:decoration-white transition-colors durartion-500 ease-out"
 				href="https://httparchive.org/"
 				target="_blank">HTTP Archive</a
-			> and the
+			> and the{" "}
 			<a
 				class="text-astro-gray-100 underline underline-offset-2 decoration-astro-gray-300 hover:decoration-white transition-colors durartion-500 ease-out"
 				href="https://developer.chrome.com/docs/crux"

--- a/src/pages/press/index.astro
+++ b/src/pages/press/index.astro
@@ -265,7 +265,7 @@ const socialLinks = [
 								welcoming atmosphere that reinforces the Astro brand.
 							</p>
 							<p>
-								While we love Houston dearly,
+								While we love Houston dearly,{" "}
 								<strong class="text-white font-medium">
 									they must not be used in your own materials.
 								</strong>


### PR DESCRIPTION
## Description

This PR adds dedicated spaces `{" "}` in places where they were absent because of changes to whitespaces in https://github.com/withastro/astro/pull/16965.

This includes all occurrences noticed by Lloyd and Armand. I also searched for more occurrences with some custom regexes, but couln't find any 👍 

## Browser Test Checklist


I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

