### PR TITLE
Update prism integration's url

### DIFF
--- a/src/content/integrations.json
+++ b/src/content/integrations.json
@@ -1408,7 +1408,7 @@
 		],
 		"npmUrl": "https://www.npmjs.com/package/@astrojs/prism",
 		"repoUrl": "https://github.com/withastro/astro",
-		"homepageUrl": "https://docs.astro.build/en/reference/api-reference/#prism-",
+		"homepageUrl": "https://docs.astro.build/en/guides/syntax-highlighting/#prism-",
 		"official": true,
 		"downloads": 15969476,
 		"created": "2021-06-07T20:53:12.802Z"


### PR DESCRIPTION
old link was dead link, this link should link to the correct prism page from the documentation

