### PR TITLE
feat: add playground links

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -30,6 +30,7 @@ const groups: LinkGroup[] = [
 			},
 			{ label: 'Themes', href: '/themes/' },
 			{ label: 'Integrations', href: '/integrations/' },
+			{ label: 'Playground', href: 'https://play.astro.build/' },
 			{ label: 'Site showcase', href: '/showcase/' },
 			{ label: 'Starter templates', href: 'https://astro.new/' },
 		],

--- a/src/components/HeaderDrawerContent.astro
+++ b/src/components/HeaderDrawerContent.astro
@@ -11,6 +11,7 @@ const nav: Nav = [
 			{ href: '/themes/', label: 'Themes', icon: 'palette', prefetch: true },
 			{ href: '/integrations/', label: 'Integrations', icon: 'layers', prefetch: true },
 			{ href: '/showcase/', label: 'Site showcase', icon: 'browser-windows', prefetch: true },
+			{ href: 'https://play.astro.build', label: 'Playground', icon: 'plug' },
 			{
 				href: 'https://docs.astro.build/en/tutorial/0-introduction/',
 				label: 'Tutorials',

--- a/src/components/HeaderNav.astro
+++ b/src/components/HeaderNav.astro
@@ -22,6 +22,7 @@ const socialLinks = siteInfo.socialLinks.filter((link) => link.showInHeader);
 				{ href: '/themes/', label: 'Themes', icon: 'palette', prefetch: true },
 				{ href: '/integrations/', label: 'Integrations', icon: 'layers', prefetch: true },
 				{ href: '/showcase/', label: 'Site showcase', icon: 'browser-windows', prefetch: true },
+				{ href: 'https://play.astro.build', label: 'Playground', icon: 'plug' },
 				{
 					href: 'https://docs.astro.build/en/tutorial/0-introduction/',
 					label: 'Tutorials',


### PR DESCRIPTION
<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

This PR adds a new link to the header and the footer. The link to the playground

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

