### PR TITLE
Fix author profile broken image

### DIFF
--- a/src/pages/themes/_components/ThemeAuthorProfile.astro
+++ b/src/pages/themes/_components/ThemeAuthorProfile.astro
@@ -19,13 +19,19 @@ const { author } = Astro.props;
 	<span class="pr-2">Back to all themes</span>
 </a>
 <div class="flex lg:flex-col flex-wrap items-center gap-4">
-	<Image
-		src={author.avatar ?? ''}
-		height={300}
-		width={300}
-		class="lg:w-full h-fit size-12"
-		alt=""
-	/>
+	{author.avatar ? (
+		<img
+			src={author.avatar}
+			height={300}
+			width={300}
+			class="lg:w-full h-fit size-12"
+			alt=""
+		/>
+	) : (
+		<span class="grid place-content-center w-12 lg:w-full aspect-square bg-[#23262e] font-heading text-lg lg:text-8xl">
+			{author.name[0]}
+		</span>
+	)}
 	<h1 class="lg:hidden border-astro-gray-500 heading-3">{author.name}</h1>
 	<div class="flex flex-col gap-4 pt-2 lg:pt-8 w-full">
 		<div class="flex justify-between items-baseline">


### PR DESCRIPTION
The Astro `<Image />` component is replaced with a standard HTML `<img>` tag.
(like [Avatar.astro](https://github.com/platoltheme/astro.build/blob/ada51708bf52a317978ec688adfcefc2367f8ca1/src/pages/themes/_components/Avatar.astro)) which is already loads the author image at every [ThemeCard.astro](https://github.com/platoltheme/astro.build/blob/ada51708bf52a317978ec688adfcefc2367f8ca1/src/pages/themes/_components/ThemeCard.astro#L43)

Additionally, adds a fallback avatar for theme authors who do not have a profile image. When an avatar URL is missing, a styled placeholder displaying the first initial of the author's name is rendered instead.

Fixes https://github.com/withastro/astro.build/issues/2610

## Browser Test Checklist

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [x] Safari
- [ ] iOS Safari

