### PR TITLE
Fix missing whitespace on case study pages

### DIFF
--- a/src/pages/case-studies/[slug].astro
+++ b/src/pages/case-studies/[slug].astro
@@ -62,7 +62,7 @@ const authors = await Promise.all(data.authors.map((author) => getEntry('authors
 	>
 		<header class="mx-auto w-full max-w-4xl text-center">
 			<p class="code text-astro-gray-200">
-				Case Study &bull;
+				Case Study &bull;{' '}
 				<time datetime={data.publishDate.toISOString()}>
 					{format(data.publishDate, 'MMMM yyyy')}
 				</time>


### PR DESCRIPTION
Fixes some missing whitespace between text nodes that got lost when Astro changed its whitespace handling

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

