### PR TITLE
Update landing page CWV metrics with latest data

### DIFF
--- a/src/pages/_components/landing-page/Islands.astro
+++ b/src/pages/_components/landing-page/Islands.astro
@@ -21,10 +21,10 @@ import IslandGraphic from './IslandGraphic.astro';
 		<p class="text-astro-gray-300">% of real-world sites with good Core Web Vitals</p>
 
 		<div class="mt-8 mb-5">
-			<IslandGraphic label="Astro" score="66" size="size-[22px]" icon="logos/astro" glow />
+			<IslandGraphic label="Astro" score="71" size="size-[22px]" icon="logos/astro" glow />
 			<IslandGraphic label="WordPress" score="48" icon="logos/wordpress" />
-			<IslandGraphic label="Gatsby" score="47" size="size-[19px]" icon="logos/gatsby" />
-			<IslandGraphic label="Next.js" score="30" icon="logos/next-js" />
+			<IslandGraphic label="Gatsby" score="45" size="size-[19px]" icon="logos/gatsby" />
+			<IslandGraphic label="Next.js" score="35" icon="logos/next-js" />
 			<IslandGraphic label="Nuxt" score="28" size="size-6" icon="logos/nuxt" />
 		</div>
 

--- a/src/pages/_components/landing-page/Islands.astro
+++ b/src/pages/_components/landing-page/Islands.astro
@@ -35,7 +35,7 @@ import IslandGraphic from './IslandGraphic.astro';
 			>
 				View the full dataset</a
 			>
-			&middot; Based on real-world performance data from{' '}
+			{' '}&middot; Based on real-world performance data from{' '}
 			<a
 				class="text-astro-gray-100 underline underline-offset-2 decoration-astro-gray-300 hover:decoration-white transition-colors durartion-500 ease-out"
 				href="https://httparchive.org/"


### PR DESCRIPTION
Tiny PR updating HTTP Archive stats on the landing page to the latest August 2026 figures.

It also fixes a whitespace bug:
| Before | After |
|--------|--------|
| <img width="324" height="33" alt="image" src="https://github.com/user-attachments/assets/731aa9f2-3164-47d9-bc14-f0b77f3a79a0" /> | <img width="327" height="40" alt="image" src="https://github.com/user-attachments/assets/80fa8a9d-e3e9-4753-bc05-489efa150391" /> |


## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [x] Chrome / Chromium
- [x] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

